### PR TITLE
Median filter for TemperatureControl

### DIFF
--- a/src/libs/Median.h
+++ b/src/libs/Median.h
@@ -1,0 +1,37 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+template <typename T>
+void split(T data[], unsigned int n, T x, unsigned int& i, unsigned int& j)
+{
+  do {
+    while (data[i] < x) i++;
+    while (x < data[j]) j--;
+
+    if (i <= j) {
+      T ii = data[i];
+      data[i] = data[j];
+      data[j] = ii;
+      i++; j--;
+    }
+  } while (i <= j);
+}
+
+// C.A.R. Hoare's Quick Median
+template <typename T>
+unsigned int quick_median(T data[], unsigned int n)
+{
+  unsigned int l = 0, r = n-1, k = n/2;
+  while (l < r) {
+    T x = data[k];
+    unsigned int i = l, j = r;
+    split(data, n, x, i, j);
+    if (j < k) l = i;
+    if (k < i) r = j;
+  }
+  return k;
+}

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -41,6 +41,8 @@
 
 #define i_max_checksum                      4112
 
+#define QUEUE_LEN 8
+
 class TemperatureControlPool;
 
 class TemperatureControl : public Module {
@@ -90,7 +92,8 @@ class TemperatureControl : public Module {
         double acceleration_factor;
         double readings_per_second;
 
-        RingBuffer<uint16_t,8> queue;  // Queue of readings
+        RingBuffer<uint16_t,QUEUE_LEN> queue;  // Queue of readings
+        uint16_t median_buffer[QUEUE_LEN];
         int running_total;
 
         uint16_t name_checksum;


### PR DESCRIPTION
This greatly improves the stability of temperature control on my machine which was previously nearly unusable due to glitches from the LPCXpresso's ADC, as mentioned in Issue #80.
