### PR TITLE
Fixed SerialConsole and get_arguments tolerance to CR+LF.

### DIFF
--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -134,6 +134,7 @@ ConfigValue* Config::value(uint16_t check_sums[]){
             continue;
         }
         result = this->config_cache[i];
+        result->found = true;
         break;
     }
     

--- a/src/libs/Config.h
+++ b/src/libs/Config.h
@@ -47,7 +47,7 @@ class Config : public Module {
 
         ConfigCache config_cache;             // A cache in which ConfigValues are kept
         vector<ConfigSource*> config_sources; // A list of all possible coniguration sources
-        bool   config_cache_loaded;           // Whether or not the cache is currently popluated
+        bool   config_cache_loaded;           // Whether or not the cache is currently populated
 };
 
 #endif

--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -107,8 +107,15 @@ string shift_parameter( string &parameters ){
 // Separate command from arguments
 string get_arguments( string possible_command ){
     size_t beginning = possible_command.find_first_of(" ");
-    if( beginning == string::npos ){ return ""; }
-    return possible_command.substr( beginning + 1, possible_command.size() - beginning + 1);
+    size_t newline = possible_command.find_first_of("\r\n");
+
+    if( beginning == string::npos ){ 
+        return ""; 
+    } else if( newline == string::npos ){ 
+        return possible_command.substr(beginning + 1, possible_command.size() - beginning + 1);
+    } else {
+        return possible_command.substr(beginning + 1, newline - (beginning + 1)); 
+    }
 }
 
 // Returns true if the file exists

--- a/src/modules/utils/configurator/Configurator.cpp
+++ b/src/modules/utils/configurator/Configurator.cpp
@@ -61,7 +61,7 @@ void Configurator::config_get_command( string parameters, StreamOutput* stream )
         setting = source;
         source = "";
         uint16_t setting_checksums[3];
-        get_checksums(setting_checksums, setting );
+        get_checksums(setting_checksums, setting);
         ConfigValue* cv = this->kernel->config->value(setting_checksums);
         string value = "";
         if(cv->found){ value = cv->as_string(); }


### PR DESCRIPTION
The console wasn't really handling commands with parameters well (or at all) when using CR+LF instead of just LF, because it was leaving stray trailing \r's and other things.

I've refactored the handling of serial console command lines a bit (instead of grabbing the line char by char until \n, it now stops filling the buffer at \n and then grabs the whole line based on buffer length - at least it should be) and added additional \r\n stripping in get_arguments.

Debugging this was a bit of a pain, so it might be entirely possible i've screwed something up in the process. Also, i've been coding in loosely typed languages for years now and am a bit rusty with C/C++, so please excuse any glaring screwups.

From what i can see, both CR+LF and LF modes work fine now.
