### PR TITLE
Ensure that C++11 checksum is evaluated at compile-time

### DIFF
--- a/src/libs/checksumm.h
+++ b/src/libs/checksumm.h
@@ -33,7 +33,11 @@
 */
 #ifdef CHECKSUM_USE_CPP
 
-/* Cool C++11 approach contributed by bgamari on smoothieware IRC channel. */
+#include <type_traits>
+
+/* Cool C++11 approach contributed by bgamari on #smoothieware IRC channel.
+ * Unfortunately this will have to wait until after we switch to GCC 4.7.
+ */
 constexpr uint16_t checksum(const char* s, size_t n, size_t i, uint16_t sum1, uint16_t sum2) {
   return (i <= n) ? checksum(s, n, i+1, (sum1 + s[i]) % 255, (sum2 + sum1) % 255) : ((sum2 << 8) | sum1);
 }
@@ -42,7 +46,7 @@ constexpr uint16_t operator "" _checksum(const char* s, size_t n) {
   return checksum(s, n, 0, 0, 0);
 }
 
-#define CHECKSUM(X) X##_checksum
+#define CHECKSUM(X) std::integral_constant<uint16_t, X##_checksum>::value
 
 #else /* !CHECKSUM_USE_CPP */
 


### PR DESCRIPTION
Wrapping the expression in an std::integral_constant<> seems to do the
right thing, even with no optimization.

Unfortunately, it seems that gcc 4.6 doesn't support user-defined string
literals, so we'll need to wait until we start building with 4.7 before
enabling this.
