### PR TITLE
move digipot to CurrentCOntrol Module

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -11,7 +11,6 @@
 #include "libs/nuts_bolts.h"
 #include "libs/SlowTicker.h"
 #include "libs/Adc.h"
-#include "libs/Digipot.h"
 #include "libs/Pauser.h"
 #include "libs/StreamOutputPool.h"
 #include <mri.h>
@@ -63,7 +62,6 @@ Kernel::Kernel(){
     add_module( this->slow_ticker          = new SlowTicker());
     this->step_ticker          = new StepTicker();
     this->adc                  = new Adc();
-    this->digipot              = new Digipot();
 
     // LPC17xx-specific
     NVIC_SetPriorityGrouping(0);

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -13,7 +13,6 @@
 #include "libs/StreamOutputPool.h"
 #include "libs/StepTicker.h"
 #include "libs/Adc.h"
-#include "libs/Digipot.h"
 #include "libs/Pauser.h"
 #include "modules/communication/SerialConsole.h"
 #include "modules/communication/GcodeDispatch.h"
@@ -50,7 +49,6 @@ class Kernel {
         SlowTicker*       slow_ticker;
         StepTicker*       step_ticker;
         Adc*              adc;
-        Digipot*          digipot;
 
     private:
         std::array<std::vector<Module*>, NUMBER_OF_DEFINED_EVENTS> hooks; // When a module asks to be called for a specific event ( a hook ), this is where that request is remembered

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -16,7 +16,11 @@ Laser::Laser(){
 }
 
 void Laser::on_module_loaded() {
-    if( !this->kernel->config->value( laser_module_enable_checksum )->by_default(false)->as_bool() ){ return; }
+	if( !this->kernel->config->value( laser_module_enable_checksum )->by_default(false)->as_bool() ){
+		// as not needed free up resource
+		delete this;
+		return;
+	}
 
     this->laser_pin = new mbed::PwmOut(p21);
     this->laser_pin->period_us(20);

--- a/src/modules/utils/currentcontrol/CurrentControl.cpp
+++ b/src/modules/utils/currentcontrol/CurrentControl.cpp
@@ -8,10 +8,20 @@
 #include <string>
 using namespace std;
 
-CurrentControl::CurrentControl(){}
+CurrentControl::CurrentControl(){
+	digipot= NULL;
+}
 
 void CurrentControl::on_module_loaded(){
-    if( !this->kernel->config->value( currentcontrol_module_enable_checksum )->by_default(false)->as_bool() ){ return; }
+	if( !this->kernel->config->value( currentcontrol_module_enable_checksum )->by_default(false)->as_bool() ){
+		// as this module is not needed free up the resource
+		delete this;
+		return;
+	}
+
+	// allocate digipot, if already allocated delete it first
+	delete digipot;
+	digipot = new Digipot();
 
     // Get configuration
     this->alpha_current =           this->kernel->config->value(alpha_current_checksum  )->by_default(0.8)->as_number();
@@ -19,10 +29,10 @@ void CurrentControl::on_module_loaded(){
     this->gamma_current =           this->kernel->config->value(gamma_current_checksum  )->by_default(0.8)->as_number();
     this->delta_current =           this->kernel->config->value(delta_current_checksum  )->by_default(0.8)->as_number();
 
-    this->kernel->digipot->set_current(0, this->alpha_current);
-    this->kernel->digipot->set_current(1, this->beta_current );
-    this->kernel->digipot->set_current(2, this->gamma_current);
-    this->kernel->digipot->set_current(3, this->delta_current);
+    this->digipot->set_current(0, this->alpha_current);
+    this->digipot->set_current(1, this->beta_current );
+    this->digipot->set_current(2, this->gamma_current);
+    this->digipot->set_current(3, this->delta_current);
 
     this->register_for_event(ON_GCODE_RECEIVED);
 }
@@ -40,8 +50,8 @@ void CurrentControl::on_gcode_received(void *argument)
             for (i = 0; i < 4; i++)
             {
                 if (gcode->has_letter(alpha[i]))
-                    this->kernel->digipot->set_current(i, gcode->get_value(alpha[i]));
-                gcode->stream->printf("%c:%3.1fA%c", alpha[i], this->kernel->digipot->get_current(i), (i == 3)?'\n':' ');
+                    this->digipot->set_current(i, gcode->get_value(alpha[i]));
+                gcode->stream->printf("%c:%3.1fA%c", alpha[i], this->digipot->get_current(i), (i == 3)?'\n':' ');
             }
         }
     }

--- a/src/modules/utils/currentcontrol/CurrentControl.h
+++ b/src/modules/utils/currentcontrol/CurrentControl.h
@@ -5,6 +5,7 @@
 #include "libs/nuts_bolts.h"
 #include "libs/utils.h"
 #include "libs/Pin.h"
+#include "libs/Digipot.h"
 
 #define alpha_current_checksum                  CHECKSUM("alpha_current")
 #define beta_current_checksum                   CHECKSUM("beta_current")
@@ -22,7 +23,9 @@ class CurrentControl : public Module {
         double alpha_current;
         double beta_current;
         double gamma_current;
-        double delta_current;
+		double delta_current;
+
+		Digipot* digipot;
 };
 
 


### PR DESCRIPTION
For those of us not using smoothie board it would be nice if the smoothie board only options were encapsulated in the loadable modules.

Case in point Digipot() is instantiated in Kernel  line 66, but is only ever used in CurrentControl. I would suggest moving it to CurentControl so if CurrentControl is not enabled it never gets created.

Additionally, to save memory, if a module is set to false in the configuration it should delete itself in the on_module_load() otherwise modules like laser and currentcontrol take up valuable heap space.

Thanks.
