### PR TITLE
Gcode: Again ensure no allocations occur

### DIFF
--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -48,7 +48,7 @@ bool Gcode::has_letter( char letter ){
 double Gcode::get_value( char letter ){
     //__disable_irq();
     for (size_t i=0; i <= this->command.length()-1; i++){
-         const char c = this->command[i];
+         const char& c = this->command.at(i);
          if( letter == c ){
             size_t beginning = i+1;
             char buffer[20];


### PR DESCRIPTION
For some reason `const char std::string::operator[]` still assumes that
things might be mutated. `const char& operator[]`, on the other hand,
appears to do the right thing. I'll admit that this is evidence that
`std::string` is just too subtle here. Perhaps a homebrew string type is
in order.
