### PR TITLE
Player: Reduce block queue depth to 16

### DIFF
--- a/src/modules/robot/Player.h
+++ b/src/modules/robot/Player.h
@@ -25,7 +25,7 @@ class Player : public Module {
         void pop_and_process_new_block(int debug);
         void wait_for_queue(int free_blocks);
 
-        RingBuffer<Block,32> queue;  // Queue of Blocks
+        RingBuffer<Block,16> queue;  // Queue of Blocks
         Block* current_block;
         bool looking_for_new_block;
 


### PR DESCRIPTION
It seems we don't have enough memory to keep this many blocks around;
the heap collides with the stack on LPC1769.
