### PR TITLE
Gcode: Ensure queued is initialized

### DIFF
--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -16,7 +16,8 @@ using std::string;
 
 
 Gcode::Gcode(const string& command, StreamOutput* stream) :
-  command(command), m(0), g(0), add_nl(false), stream(stream)
+  command(command), m(0), g(0), add_nl(false),
+  queued(0), stream(stream)
 {
     prepare_cached_values();
 }


### PR DESCRIPTION
This was a silly and obvious oversight from
6a3328dfe514e66a98c0cf5adc7252d333567e83. Thanks to wolfmanjm for
spotting it.
