### PR TITLE
added new simpleshell commands progress, abort and help

### DIFF
--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -47,6 +47,12 @@ void SimpleShell::on_console_line_received( void* argument ){
         this->reset_command(get_arguments(possible_command),new_message.stream );
     else if (check_sum == dfu_command_checksum)
         this->reset_command(get_arguments(possible_command),new_message.stream );
+	else if (check_sum == help_command_checksum)
+		this->help_command(get_arguments(possible_command),new_message.stream );
+	else if (check_sum == progress_command_checksum)
+		this->progress_command(get_arguments(possible_command),new_message.stream );
+	else if (check_sum == abort_command_checksum)
+		this->abort_command(get_arguments(possible_command),new_message.stream );
 }
 
 // Convert a path indication ( absolute or relative ) into a path ( absolute )
@@ -148,13 +154,66 @@ void SimpleShell::play_command( string parameters, StreamOutput* stream ){
         this->current_stream = stream;
     }else{
         this->current_stream = kernel->streams;
-    }
+	}
+
+	// get size of file
+	int result = fseek(this->current_file_handler, 0, SEEK_END);
+	if (0 != result){
+		stream->printf("WARNING - Could not get file size\r\n");
+		file_size= -1;
+	}else{
+		file_size= ftell(this->current_file_handler);
+		fseek(this->current_file_handler, 0, SEEK_SET);
+		stream->printf("  File size %ld\r\n", file_size);
+	}
+	played_cnt= 0;
+}
+
+void SimpleShell::progress_command( string parameters, StreamOutput* stream ){
+	if(!playing_file) {
+		stream->printf("Not currently playing\r\n");
+		return;
+	}
+
+	if(file_size > 0) {
+		int pcnt= (file_size - (file_size - played_cnt)) * 100 / file_size;
+		stream->printf("%d %% complete\r\n", pcnt);
+	}else{
+		stream->printf("File size is unknown\r\n");
+	}		
+}
+
+void SimpleShell::abort_command( string parameters, StreamOutput* stream ){
+	if(!playing_file) {
+		stream->printf("Not currently playing\r\n");
+		return;
+	}
+	playing_file = false;
+	played_cnt= 0;
+	file_size= 0;
+	fclose(current_file_handler);
+	stream->printf("Aborted playing file\r\n");
 }
 
 // Reset the system
 void SimpleShell::reset_command( string parameters, StreamOutput* stream){
     stream->printf("Smoothie out. Peace.\r\n");
     system_reset();
+}
+
+void SimpleShell::help_command( string parameters, StreamOutput* stream ){
+	stream->printf("Commands:\r\n");
+	stream->printf("ls [folder]\r\n");
+	stream->printf("cd folder\r\n");
+	stream->printf("pwd\r\n");	
+	stream->printf("cat file [limit]\r\n");
+	stream->printf("play file [-q]\r\n");
+	stream->printf("progress\r\n");
+	stream->printf("abort\r\n");
+	stream->printf("reset\r\n");			
+	stream->printf("config-get [<configuration_source>] <configuration_setting>\r\n");
+	stream->printf("config-set [<configuration_source>] <configuration_setting> <value>\r\n");
+	stream->printf("config-load [<file_name>]\r\n");
 }
 
 void SimpleShell::on_main_loop(void* argument){
@@ -172,15 +231,17 @@ void SimpleShell::on_main_loop(void* argument){
                 message.stream = this->current_stream;
                 // wait for the queue to have enough room that a serial message could still be received before sending
                 this->kernel->player->wait_for_queue(2);
-                this->kernel->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+				this->kernel->call_event(ON_CONSOLE_LINE_RECEIVED, &message);
+				played_cnt += buffer.size();
                 buffer.clear();
                 return;
             }else{
                 buffer += c;
             }
         };
-
+		this->playing_file = false;
+		played_cnt= 0;
+		file_size= 0;
         fclose(this->current_file_handler);
-        this->playing_file = false;
     }
 }

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -15,13 +15,16 @@
 #include "libs/StreamOutput.h"
 
 
-#define ls_command_checksum      CHECKSUM("ls")
-#define cd_command_checksum      CHECKSUM("cd")
-#define pwd_command_checksum     CHECKSUM("pwd")
-#define cat_command_checksum     CHECKSUM("cat")
-#define play_command_checksum    CHECKSUM("play")
-#define reset_command_checksum   CHECKSUM("reset")
-#define dfu_command_checksum     CHECKSUM("dfu")
+#define ls_command_checksum       CHECKSUM("ls")
+#define cd_command_checksum       CHECKSUM("cd")
+#define pwd_command_checksum      CHECKSUM("pwd")
+#define cat_command_checksum      CHECKSUM("cat")
+#define play_command_checksum     CHECKSUM("play")
+#define progress_command_checksum CHECKSUM("progress")
+#define abort_command_checksum    CHECKSUM("abort")
+#define reset_command_checksum    CHECKSUM("reset")
+#define dfu_command_checksum      CHECKSUM("dfu")
+#define help_command_checksum     CHECKSUM("help")
 
 class SimpleShell : public Module {
     public:
@@ -36,12 +39,18 @@ class SimpleShell : public Module {
         void pwd_command(  string parameters, StreamOutput* stream );
         void cat_command(  string parameters, StreamOutput* stream );
         void play_command( string parameters, StreamOutput* stream );
-        void reset_command(string parameters, StreamOutput* stream );
-
+        void progress_command( string parameters, StreamOutput* stream );
+        void abort_command( string parameters, StreamOutput* stream );
+		void reset_command(string parameters, StreamOutput* stream );
+		void help_command(string parameters, StreamOutput* stream );
+		
+	private:
         string current_path;
-        bool playing_file;
+		bool playing_file;
+		
         StreamOutput* current_stream;
-        FILE* current_file_handler;
+		FILE* current_file_handler;
+		long file_size, played_cnt;
 };
 
 


### PR DESCRIPTION
AFter playing with locally large files it became apparent a command to see the progress would be nice and a way to abort the currently playing file.

This patch adds a progress command which shows the current progress (approximately) and abort which stops the play and closes the file.

It also adds a help command which just shows the current list of accepted commands.
