### PR TITLE
Change default homing direction in example config for delta/rostock

### DIFF
--- a/ConfigSamples/Smoothieboard.Rostock/config
+++ b/ConfigSamples/Smoothieboard.Rostock/config
@@ -102,17 +102,17 @@ switch.spindle.enable                        false            #
 # Endstops
 alpha_min_endstop                            1.24             #
 alpha_max_endstop                            1.25             #
-alpha_homing_direction                       1                #
+alpha_homing_direction                       0                # Home up
 alpha_min                                    0                #
 alpha_max                                    0                #
 beta_min_endstop                             1.26             #
 beta_max_endstop                             1.27             #
-beta_homing_direction                        1                #
+beta_homing_direction                        0                #
 beta_min                                     0                #
 beta_max                                     0                #
 gamma_min_endstop                            1.28             #
 gamma_max_endstop                            1.29             #
-gamma_homing_direction                       1                #
+gamma_homing_direction                       0                #
 gamma_min                                    0                #
 gamma_max                                    300              #
 


### PR DESCRIPTION
Most people find that homing direction 0 goes up and 1 goes down. and when set to 0 it loads the homing_max and when set to 1 it loads the homing_min.
This sets the default homing direction for deltas to be up/max
