### PR TITLE
add GCode::txt_after_ok so test can be appended to the ok message to conf...

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -104,7 +104,10 @@ void GcodeDispatch::on_console_line_received(void * line){
 
                 if ( return_error_on_unhandled_gcode == true && gcode->accepted_by_module == false)
                     new_message.stream->printf("ok (command unclaimed)\r\n");
-                else
+                else if(!gcode->txt_after_ok.empty()) {
+                    new_message.stream->printf("ok %s\r\n", gcode->txt_after_ok.c_str());
+                    gcode->txt_after_ok.clear();
+                }else
                     new_message.stream->printf("ok\r\n");
 
                 delete gcode;

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -32,6 +32,7 @@ Gcode::Gcode(const Gcode& to_copy){
     this->add_nl                = to_copy.add_nl;
     this->stream                = to_copy.stream;
     this->accepted_by_module=false;
+    this->txt_after_ok.assign( to_copy.txt_after_ok );
 }
 
 Gcode& Gcode::operator= (const Gcode& to_copy){
@@ -44,6 +45,7 @@ Gcode& Gcode::operator= (const Gcode& to_copy){
         this->g                     = to_copy.g;
         this->add_nl                = to_copy.add_nl;
         this->stream                = to_copy.stream;
+        this->txt_after_ok.assign( to_copy.txt_after_ok );
     }
     this->accepted_by_module=false;
     return *this;

--- a/src/modules/communication/utils/Gcode.h
+++ b/src/modules/communication/utils/Gcode.h
@@ -42,6 +42,7 @@ class Gcode {
         bool add_nl;
         StreamOutput* stream;
 
+        string txt_after_ok;
         bool accepted_by_module;
 
 };

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -123,8 +123,9 @@ void TemperatureControl::on_gcode_received(void* argument){
     {
         // Get temperature
         if( gcode->m == this->get_m_code ){
-            gcode->stream->printf("%s:%3.1f /%3.1f @%d ", this->designator.c_str(), this->get_temperature(), ((target_temperature == UNDEFINED)?0.0:target_temperature), this->o);
-            gcode->add_nl = true;
+            char buf[32]; // should be big enough for any status
+            int n= snprintf(buf, sizeof(buf), "%s:%3.1f /%3.1f @%d ", this->designator.c_str(), this->get_temperature(), ((target_temperature == UNDEFINED)?0.0:target_temperature), this->o);
+            gcode->txt_after_ok.append(buf, n);
         }
         if (gcode->m == 301)
         {


### PR DESCRIPTION
...orm with pronterface standards

Use this in M105 so temperatures are displayed in pronterface
