### PR TITLE
Fix makefile so src/version.cpp is copied if on win32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ debug
 /mac_install.log
 /win_install.log
 /linux_install.log
+/src/version.cpp

--- a/makefile
+++ b/makefile
@@ -6,6 +6,8 @@ DIRSCLEAN = $(addsuffix .clean,$(DIRS))
 all:
 ifneq "$(OS)" "Windows_NT"
 	@./generate-version.sh
+else
+	@xcopy /C /I /Y src/version.cpp.placeholder src/version.cpp
 endif
 	@echo Building mbed SDK
 	@ $(MAKE) -C mbed

--- a/src/version.cpp.placeholder
+++ b/src/version.cpp.placeholder
@@ -1,6 +1,6 @@
 #include "version.h"
 const char *Version::get_build(void) const {
-    return "edge-8028708";
+    return "placeholder";
 }
 const char *Version::get_build_date(void) const {
     return __DATE__ " " __TIME__;


### PR DESCRIPTION
Add src/version.cpp to .gitignore so it doesn't get checked in
