### PR TITLE
Fix encoder resolution

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -130,6 +130,8 @@ panel.enable                                 false             # set to true to 
 panel.lcd                                    viki_lcd          # set type of panel also i2c_lcd is a generic i2c panel
 panel.encoder_a_pin                          0.15!^            # encoder pin if used
 panel.encoder_b_pin                          0.17!^            # encoder pin if used
+panel.menu_offset                            0                 # some panels will need 1 here
+
 #panel.button_pause_pin                      0.18^             # pin used for pause button on VikiLcd
 #panel.up_button_pin                         0.1!              # up button if used
 #panel.down_button_pin                       0.0!              # down button if used

--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -25,7 +25,6 @@ Panel::Panel(){
     this->click_changed = false;
     this->refresh_flag = false;
     this->enter_menu_mode();
-    this->menu_offset = 1;
     this->lcd= NULL;
     this->do_buttons = false;
     this->idle_time= 0;
@@ -65,6 +64,10 @@ void Panel::on_module_loaded(){
 
     // some panels may need access to this global info
     this->lcd->setPanel(this);
+
+    // some encoders may need more clicks to move menu, this is a divisor and is in config as it is
+    // an end user usability issue
+    this->menu_offset = this->kernel->config->value( panel_checksum, menu_offset_checksum )->by_default(0)->as_number();
 
     // load jogging feedrates in mm/min
     jogging_speed_mm_min[0]= this->kernel->config->value( panel_checksum, jog_x_feedrate_checksum )->by_default(3000.0)->as_number();
@@ -175,9 +178,6 @@ void Panel::on_idle(void* argument){
         this->down_button.check_signal(but&BUTTON_DOWN);
         this->back_button.check_signal(but&BUTTON_LEFT);
         this->click_button.check_signal(but&BUTTON_SELECT);
-
-        // FIXME test
-//        if(but&BUTTON_AUX1) lcd->buzz(10, 500);
     }
     
     // If we are in menu mode and the position has changed
@@ -302,7 +302,7 @@ void Panel::set_control_value(double value){
 }
 
 double Panel::get_control_value(){
-    return this->control_base_value + (this->control_normal_counter*this->normal_increment/this->encoder_click_resolution);
+    return this->control_base_value + (this->control_normal_counter*this->normal_increment);
 }
 
 bool Panel::is_playing() const {

--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -24,6 +24,7 @@
 #define viki_lcd_checksum          CHECKSUM("viki_lcd")
 #define smoothiepanel_checksum     CHECKSUM("smoothiepanel")
 
+#define menu_offset_checksum       CHECKSUM("menu_offset")
 #define jog_x_feedrate_checksum    CHECKSUM("alpha_jog_feedrate")
 #define jog_y_feedrate_checksum    CHECKSUM("beta_jog_feedrate")
 #define jog_z_feedrate_checksum    CHECKSUM("gamma_jog_feedrate")

--- a/src/modules/utils/panel/panels/Smoothiepanel.h
+++ b/src/modules/utils/panel/panels/Smoothiepanel.h
@@ -60,7 +60,7 @@ class Smoothiepanel : public LcdBase {
 
         uint8_t readButtons();
         int readEncoderDelta();
-        int getEncoderResolution() { return 2; }
+        int getEncoderResolution() { return 4; }
 
         void buzz(long,uint16_t);
 

--- a/src/modules/utils/panel/panels/VikiLCD.h
+++ b/src/modules/utils/panel/panels/VikiLCD.h
@@ -80,6 +80,8 @@ class VikiLCD : public LcdBase {
 
         uint8_t readButtons();
         int readEncoderDelta();
+        
+        // this is the number of clicks per detent
         int getEncoderResolution() { return 2; }
 
         void buzz(long,uint16_t);


### PR DESCRIPTION
add config option to set menu_offset

This should fix the menu and jogging value changes for viki and smoothie panel.
If the menu moves too many times per detent then change panel.menu_offset to 1 in config.
Some people may want to do this anyway for better menu control.
