### PR TITLE
Use ahbmalloc() to dynamically allocate usb ram for the frame buffer

### DIFF
--- a/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.h
+++ b/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.h
@@ -57,7 +57,7 @@ private:
     void renderChar(uint8_t *fb, char c, int ox, int oy);
     void displayChar(int row, int column,char inpChr);
 
-    static uint8_t fb[1024];
+    uint8_t *fb;
     bool inited;
     bool dirty;
 };


### PR DESCRIPTION
This is the best solution so far, doesn't use any memory of glcd panel is not enabled.
uses USB_RAM for the frame buffer.
