### PR TITLE
Feature/m27more

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -180,7 +180,7 @@ void Player::progress_command( string parameters, StreamOutput* stream ){
             }
             stream->printf("\r\n");
         }else{
-            stream->printf("SD printing byte %ld/%ld", played_cnt, file_size);
+            stream->printf("SD printing byte %ld/%ld\r\n", played_cnt, file_size);
         }
 
     }else{


### PR DESCRIPTION
This makes M27 or "progress -b" report bytes, like the other firmwares. I haven't tested this quite yet, so don't merge until I either test it, or you double-check my work. Hopefully this will get Smoothie and OctoPrint closer to working in harmony.
