### PR TITLE
Feature/cleanup clock init

### DIFF
--- a/mbed/src/vendor/NXP/cmsis/LPC1768/system_LPC17xx.c
+++ b/mbed/src/vendor/NXP/cmsis/LPC1768/system_LPC17xx.c
@@ -554,7 +554,7 @@ void SystemInit (void)
    *
    * |   Fcpu |--|   Fin |  M | N |   PLL0 | D | PLL0CFG | CCLKCFG |
    *    96MHz :2*  12MHz * 12 / 1 = 288MHz / 3   0x0000B       0x2
-   *   100MHz :2*  12MHz * 50 / 4 = 300MHz / 3   0x30031       0x2
+   *   100MHz :2*  12MHz * 25 / 2 = 300MHz / 3   0x10018       0x2
    *   120MHz :2*  12MHz * 15 / 1 = 360MHz / 3   0x0000E       0x2
    *
    */
@@ -569,7 +569,7 @@ void SystemInit (void)
     LPC_SC->PLL0FEED  = 0x55;
   } else {
 //     LPC_SC->PLL0CFG   = 0x0000000B;  // 96MHz
-    LPC_SC->PLL0CFG   = 0x00030031;     // 100MHz
+    LPC_SC->PLL0CFG   = 0x00010018;     // 100MHz
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
   }


### PR DESCRIPTION
PLEASE TEST THOROUGHLY BEFORE MERGING

After discussion with wolfmanjim and seeing his excellent auto-detection patch, I decided to clean up SystemInit() to be more readable and better documented.

Since we're now officially using PLL1, I also changed it to run 1768s at 100MHz instead of 96MHz

The only reason we were using 96MHz in the first place is that for some reason, mbed divided the usb clock from the main clock instead of using PLL1, which is provided for this exact purpose.

All my boards are buried deep in storage, please test this for me!
