### PR TITLE
allow _ for panel custom menu comamnds that need spaces (like G0 X100 Y1...

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -164,7 +164,8 @@ panel.gamma_jog_feedrate                     200               # z jogging feedr
 panel.hotend_temperature                     185               # temp to set hotend when preheat is selected
 panel.bed_temperature                        60                # temp to set bed when preheat is selected
 
-# Example of a custom menu entry, which will show up in the Custom entry. NOTE _ gets converted to space in the menu
+# Example of a custom menu entry, which will show up in the Custom entry. 
+# NOTE _ gets converted to space in the menu and commands, | is used to separate multiple commands
 custom_menu.power_on.enable                true              #
 custom_menu.power_on.name                  Power_on          #
 custom_menu.power_on.command               M80               #

--- a/src/modules/utils/panel/PanelScreen.h
+++ b/src/modules/utils/panel/PanelScreen.h
@@ -25,7 +25,8 @@ public:
     void refresh_menu(bool clear);
     void refresh_menu(void) { refresh_menu(true); };
     virtual void display_menu_line(uint16_t line) = 0;
-
+    // default idle timeout for a screen, each screen can override this
+    virtual int idle_timeout_secs(){ return 10; }
     Panel *panel;
     PanelScreen *parent;
 

--- a/src/modules/utils/panel/screens/CustomScreen.cpp
+++ b/src/modules/utils/panel/screens/CustomScreen.cpp
@@ -27,10 +27,13 @@ CustomScreen::CustomScreen()
         if (THEKERNEL->config->value(custom_menu_checksum, modules[i], enable_checksum )->as_bool()) {
             // Get Menu entry name
             string name = THEKERNEL->config->value(custom_menu_checksum, modules[i], name_checksum )->as_string();
-            std::replace( name.begin(), name.end(), '_', ' ');
+            std::replace( name.begin(), name.end(), '_', ' '); // replace _ with space
 
             // Get Command
             string command = THEKERNEL->config->value(custom_menu_checksum, modules[i], command_checksum )->as_string();
+            std::replace( command.begin(), command.end(), '_', ' '); // replace _ with space
+            std::replace( command.begin(), command.end(), '|', '\n'); // replace | with \n for multiple commands
+
             // put in menu item list
             menu_items.push_back(make_tuple(strdup(name.c_str()), strdup(command.c_str())));
             //printf("added menu %s, command %s\n", name.c_str(), command.c_str());

--- a/src/modules/utils/panel/screens/CustomScreen.h
+++ b/src/modules/utils/panel/screens/CustomScreen.h
@@ -24,6 +24,7 @@ public:
     void on_main_loop();
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
+    int idle_timeout_secs() { return 60; }
 
 private:
     std::string command;

--- a/src/modules/utils/panel/screens/PrepareScreen.h
+++ b/src/modules/utils/panel/screens/PrepareScreen.h
@@ -26,6 +26,7 @@ public:
     void on_main_loop();
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
+    int idle_timeout_secs() { return 30; }
 
 private:
     PanelScreen *extruder_screen;


### PR DESCRIPTION
...00 would be G1_X100_Y100)

allow | to separate commands to allow for multiple commands in custom menu
Allow each screen to determine its timeout value before returnign to watch screen
make custom menu and prepare timeouts much longer
allow button press in startup panel screen to go to main menu
