### PR TITLE
Make minimum planner speed configurable

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -15,6 +15,7 @@ acceleration                                 3000             # Acceleration in 
 acceleration_ticks_per_second                1000             # Number of times per second the speed is updated
 junction_deviation                           0.05             # Similar to the old "max_jerk", in millimeters, see : https://github.com/grbl/grbl/blob/master/planner.c#L409
                                                               # and https://github.com/grbl/grbl/wiki/Configuring-Grbl-v0.8 . Lower values mean being more careful, higher values means being faster and have more jerk
+#minimum_planner_speed                       0.0              # sets the minimum planner speed in mm/sec
 
 # Stepper module configuration
 microseconds_per_step_pulse                  1                # Duration of step pulses to stepper drivers, in microseconds

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -54,7 +54,7 @@ void Block::clear()
 
 void Block::debug()
 {
-    THEKERNEL->streams->printf("%p: steps:%4d|%4d|%4d(max:%4d) nominal:r%10d/s%6.1f mm:%9.6f rdelta:%8f acc:%5d dec:%5d rates:%10d>%10d  entry: %10.4f taken:%d ready:%d \r\n", this, this->steps[0], this->steps[1], this->steps[2], this->steps_event_count, this->nominal_rate, this->nominal_speed, this->millimeters, this->rate_delta, this->accelerate_until, this->decelerate_after, this->initial_rate, this->final_rate, this->entry_speed, this->times_taken, this->is_ready );
+    THEKERNEL->streams->printf("%p: steps:%4d|%4d|%4d(max:%4d) nominal:r%10d/s%6.1f mm:%9.6f rdelta:%8f acc:%5d dec:%5d rates:%10d>%10d  entry/max: %10.4f/%10.4f taken:%d ready:%d \r\n", this, this->steps[0], this->steps[1], this->steps[2], this->steps_event_count, this->nominal_rate, this->nominal_speed, this->millimeters, this->rate_delta, this->accelerate_until, this->decelerate_after, this->initial_rate, this->final_rate, this->entry_speed, this->max_entry_speed, this->times_taken, this->is_ready );
 }
 
 

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -32,7 +32,7 @@ void Conveyor::on_module_loaded(){
 
 // Delete blocks here, because they can't be deleted in interrupt context ( see Block.cpp:release )
 void Conveyor::on_idle(void* argument){
-    if (flush_blocks){
+    while (flush_blocks > 0){
         // Cleanly delete block
         Block* block = queue.get_tail_ref();
         block->gcodes.clear();

--- a/src/modules/robot/Planner.h
+++ b/src/modules/robot/Planner.h
@@ -13,14 +13,7 @@
 #include "../communication/utils/Gcode.h"
 #include "Block.h"
 
-#define acceleration_checksum       CHECKSUM("acceleration")
-#define max_jerk_checksum           CHECKSUM("max_jerk")
-#define junction_deviation_checksum CHECKSUM("junction_deviation")
-
-// TODO: Get from config
-#define MINIMUM_PLANNER_SPEED 0.0F
 using namespace std;
-
 
 class Planner : public Module {
     public:
@@ -42,7 +35,7 @@ class Planner : public Module {
 
         float acceleration;          // Setting
         float junction_deviation;    // Setting
-
+        float minimum_planner_speed; // Setting
 };
 
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -248,15 +248,23 @@ void Robot::on_gcode_received(void * argument){
                 }
                 break;
 
-            case 205: // M205 Xnnn - set junction deviation
+            case 205: // M205 Xnnn - set junction deviation Snnn - Set minimum planner speed
                 gcode->mark_as_taken();
                 if (gcode->has_letter('X'))
                 {
                     float jd= gcode->get_value('X');
                     // enforce minimum
-                    if (jd < 0.0)
-                        jd = 0.0;
+                    if (jd < 0.0F)
+                        jd = 0.0F;
                     THEKERNEL->planner->junction_deviation= jd;
+                }
+                if (gcode->has_letter('S'))
+                {
+                    float mps= gcode->get_value('S');
+                    // enforce minimum
+                    if (mps < 0.0F)
+                        mps = 0.0F;
+                    THEKERNEL->planner->minimum_planner_speed= mps;
                 }
                 break;
 
@@ -282,7 +290,7 @@ void Robot::on_gcode_received(void * argument){
                 this->arm_solution->get_steps_per_millimeter(steps);
                 gcode->stream->printf(";Steps per unit:\nM92 X%1.5f Y%1.5f Z%1.5f\n", steps[0], steps[1], steps[2]);
                 gcode->stream->printf(";Acceleration mm/sec^2:\nM204 S%1.5f\n", THEKERNEL->planner->acceleration/3600);
-                gcode->stream->printf(";Junction Deviation:\nM205 X%1.5f\n", THEKERNEL->planner->junction_deviation);
+                gcode->stream->printf(";X- Junction Deviation, S - Minimum Planner speed:\nM205 X%1.5f S%1.5f\n", THEKERNEL->planner->junction_deviation, THEKERNEL->planner->minimum_planner_speed);
                 gcode->mark_as_taken();
                 break;
 


### PR DESCRIPTION
pop all flushable blocks for queue in one on_idle
Add M205 Sxxx to set minimum planner speed from console and save with M500
