### PR TITLE
Add Makefile magic to exclude specified modules

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -77,6 +77,7 @@ OUTDIR=../$(DEVICE)
 
 # List of sources to be compiled/assembled
 CSRCS1 = $(wildcard $(SRC)/*.c $(SRC)/*/*.c $(SRC)/*/*/*.c $(SRC)/*/*/*/*.c $(SRC)/*/*/*/*/*.c $(SRC)/*/*/*/*/*/*.c)
+# Totally exclude network if NONETWORK is defined
 ifeq "$(NONETWORK)" "1"
 CSRCS = $(filter-out $(SRC)/libs/Network/%,$(CSRCS1))
 DEFINES += -DNONETWORK
@@ -90,10 +91,17 @@ ASRCS +=  $(wildcard $(SRC)/*.s $(SRC)/*/*.s $(SRC)/*/*/*.s $(SRC)/*/*/*/*.s $(S
 endif
 CPPSRCS1 = $(wildcard $(SRC)/*.cpp $(SRC)/*/*.cpp $(SRC)/*/*/*.cpp $(SRC)/*/*/*/*.cpp $(SRC)/*/*/*/*/*.cpp $(SRC)/*/*/*/*/*/*.cpp)
 ifeq "$(NONETWORK)" "1"
-CPPSRCS = $(filter-out $(SRC)/libs/Network/%,$(CPPSRCS1))
+CPPSRCS2 = $(filter-out $(SRC)/libs/Network/%,$(CPPSRCS1))
 else
-CPPSRCS = $(CPPSRCS1)
+CPPSRCS2 = $(CPPSRCS1)
 endif
+
+# Totally exclude any modules listed in EXCLUDE_MODULES
+# uppercase function
+uc = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$1))))))))))))))))))))))))))
+EXL = $(patsubst %,$(SRC)/modules/%/%,$(EXCLUDED_MODULES))
+CPPSRCS = $(filter-out $(EXL),$(CPPSRCS2))
+DEFINES += $(call uc, $(subst /,_,$(patsubst %,-DNO_%,$(EXCLUDED_MODULES))))
 
 # List of the objects files to be compiled/assembled
 OBJECTS = $(patsubst %.c,$(OUTDIR)/%.o,$(CSRCS)) $(patsubst %.s,$(OUTDIR)/%.o,$(patsubst %.S,$(OUTDIR)/%.o,$(ASRCS))) $(patsubst %.cpp,$(OUTDIR)/%.o,$(CPPSRCS))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,22 +95,34 @@ int main() {
     bool sdok= (sd.disk_initialize() == 0);
 
     // Create and add main modules
-    kernel->add_module( new Laser() );
-    kernel->add_module( new ExtruderMaker() );
     kernel->add_module( new SimpleShell() );
     kernel->add_module( new Configurator() );
     kernel->add_module( new CurrentControl() );
-    kernel->add_module( new TemperatureControlPool() );
     kernel->add_module( new SwitchPool() );
     kernel->add_module( new PauseButton() );
     kernel->add_module( new PlayLed() );
     kernel->add_module( new Endstops() );
     kernel->add_module( new Player() );
+
+    // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
+    #ifndef NO_TOOLS_TEMPERATURECONTROL
+    kernel->add_module( new TemperatureControlPool() );
+    #endif
+    #ifndef NO_TOOLS_EXTRUDER
+    kernel->add_module( new ExtruderMaker() );
+    #endif
+    #ifndef NO_TOOLS_LASER
+    kernel->add_module( new Laser() );
+    #endif
+    #ifndef NO_UTILS_PANEL
     kernel->add_module( new Panel() );
+    #endif
+    #ifndef NO_TOOLS_TOUCHPROBE
     kernel->add_module( new Touchprobe() );
-#ifndef NONETWORK
+    #endif
+    #ifndef NONETWORK
     kernel->add_module( new Network() );
-#endif
+    #endif
 
     // Create and initialize USB stuff
     u.init();

--- a/src/makefile
+++ b/src/makefile
@@ -46,6 +46,14 @@ else
 DEFINES += -D__GITVERSIONSTRING__=\"placeholder\"
 endif
 
+# add any modules that you do not want included in the build
+export EXCLUDED_MODULES = tools/touchprobe
+# e.g for a CNC machine
+#export EXCLUDED_MODULES = tools/touchprobe tools/laser tools/temperaturecontrol tools/extruder
+
+# set to not compile in any network support
+#export NONETWORK = 1
+
 include $(BUILD_DIR)/build.mk
 
 CONSOLE?=/dev/arduino


### PR DESCRIPTION
Allow modules in tools and utils to be completely eliminated from the build.

Add the partial path of the module to eliminate to src/makefile in the EXCLUDE_MODULES variable
for instance tools/touchprobe utils/panel

In main.cpp modules that can be removed need to be bracketed with a define like so...
# ifndef NO_TOOLS_TOUCHPROBE

```
 kernel->add_module( new Touchprobe() );
```
# endif

The define is automatically created by the makefile system as shown.
