### PR TITLE
attempt to fix pwm switch putput pins

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -103,6 +103,7 @@ switch.fan.input_on_command                  M106             #
 switch.fan.input_off_command                 M107             #
 switch.fan.output_pin                        2.6              #
 switch.fan.pwm_output                        true             # pwm output settable with S parameter in the input_on_comand
+#switch.fan.max_pwm                           255              # set max pwm for the pin default is 255
 
 #switch.misc.enable                           true             #
 #switch.misc.input_on_command                 M42              #


### PR DESCRIPTION
added max_pwm config setting for the output pin
Turning pin on without an S parameter sets it to full on (max_pwm) rather than last setting, same as Marlin
