### PR TITLE
Fix get_checksums() to not need a terminating space

### DIFF
--- a/src/libs/ConfigSource.cpp
+++ b/src/libs/ConfigSource.cpp
@@ -29,7 +29,7 @@ ConfigValue* ConfigSource::process_line(const string &buffer)
         return NULL;
     }
 
-    string key= buffer.substr(begin_key,  end_key - begin_key).append(" ");
+    string key= buffer.substr(begin_key,  end_key - begin_key);
     uint16_t check_sums[3];
     get_checksums(check_sums, key);
 

--- a/src/libs/ConfigSource.h
+++ b/src/libs/ConfigSource.h
@@ -22,7 +22,7 @@ class ConfigSource {
         // Read each value, and append it as a ConfigValue to the config_cache we were passed
         virtual void transfer_values_to_cache( ConfigCache* ) = 0;
         virtual bool is_named( uint16_t check_sum ) = 0;
-        virtual void write( string setting, string value ) = 0;
+        virtual bool write( string setting, string value ) = 0;
         virtual string read( uint16_t check_sums[3] ) = 0;
 
     protected:

--- a/src/libs/ConfigSources/FileConfigSource.h
+++ b/src/libs/ConfigSources/FileConfigSource.h
@@ -22,7 +22,7 @@ public:
     FileConfigSource(string config_file, const char *name);
     void transfer_values_to_cache( ConfigCache *cache );
     bool is_named( uint16_t check_sum );
-    void write( string setting, string value );
+    bool write( string setting, string value );
     string read( uint16_t check_sums[3] );
     bool has_config_file();
     void try_config_file(string candidate);

--- a/src/libs/ConfigSources/FirmConfigSource.cpp
+++ b/src/libs/ConfigSources/FirmConfigSource.cpp
@@ -49,8 +49,9 @@ bool FirmConfigSource::is_named( uint16_t check_sum ){
 }
 
 // Write a config setting to the file *** FirmConfigSource is read only ***
-void FirmConfigSource::write( string setting, string value ){
+bool FirmConfigSource::write( string setting, string value ){
     //THEKERNEL->streams->printf("ERROR: FirmConfigSource is read only\r\n");
+    return false;
 }
 
 // Return the value for a specific checksum

--- a/src/libs/ConfigSources/FirmConfigSource.h
+++ b/src/libs/ConfigSources/FirmConfigSource.h
@@ -21,7 +21,7 @@ class FirmConfigSource : public ConfigSource {
         FirmConfigSource(const char* name);
         void transfer_values_to_cache( ConfigCache* cache );
         bool is_named( uint16_t check_sum );
-        void write( string setting, string value );
+        bool write( string setting, string value );
         string read( uint16_t check_sums[3] );
 
 };

--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -35,17 +35,23 @@ uint16_t get_checksum(const char* to_check){
    return (sum2 << 8) | sum1;
 }
 
-void get_checksums(uint16_t check_sums[], const string key){
-    const string k = key+" ";
+void get_checksums(uint16_t check_sums[], const string& key){
     check_sums[0] = 0x0000;
     check_sums[1] = 0x0000;
     check_sums[2] = 0x0000;
     size_t begin_key = 0;
     unsigned int counter = 0;
-    while( begin_key < key.size()-1 && counter < 3 ){
-        const size_t end_key =  k.find_first_of(" .", begin_key);
-        const string key_node = k.substr(begin_key, end_key - begin_key);
+    while( begin_key < key.size() && counter < 3 ){
+        size_t end_key =  key.find_first_of(".", begin_key);
+        string key_node;
+        if(end_key == string::npos) {
+            key_node= key.substr(begin_key);
+        }else{
+            key_node= key.substr(begin_key, end_key-begin_key);
+        }
+
         check_sums[counter] = get_checksum(key_node);
+        if(end_key == string::npos) break;
         begin_key = end_key + 1;
         counter++;
     }

--- a/src/libs/utils.h
+++ b/src/libs/utils.h
@@ -22,7 +22,7 @@ string remove_non_number( string str );
 uint16_t get_checksum(const string& to_check);
 uint16_t get_checksum(const char* to_check);
 
-void get_checksums(uint16_t check_sums[], const string key);
+void get_checksums(uint16_t check_sums[], const string& key);
 
 string shift_parameter( string &parameters );
 


### PR DESCRIPTION
remove the append(" ") to checksum generation
fix config-set and allow it to append new key/vlaues to config file
