### PR TITLE
Only report long lines in config if not truncating a comment

### DIFF
--- a/src/libs/ConfigSources/FileConfigSource.h
+++ b/src/libs/ConfigSources/FileConfigSource.h
@@ -29,7 +29,7 @@ public:
     string get_config_file();
 
 private:
-    bool readLine(string& line, FILE *fp);
+    bool readLine(string& line, int lineno, FILE *fp);
     string config_file;         // Path to the config file
     bool   config_file_found;   // Wether or not the config file's location is known
 };

--- a/src/makefile
+++ b/src/makefile
@@ -27,6 +27,10 @@ STACK_SIZE=3072
 # 0 if you don't want to break into GDB at startup.
 ENABLE_DEBUG_MONITOR?=0
 
+# this is the default UART baud rate used if it is not set in config
+# it is also the baud rate used to report any errors found while parsing the config file
+DEFAULT_SERIAL_BAUD_RATE?=9600
+
 ifeq "$(ENABLE_DEBUG_MONITOR)" "1"
 # Can add MRI_UART_BAUD=115200 to next line if GDB fails to connect to MRI.
 # Tends to happen on some Linux distros but not Windows and OS X.
@@ -46,8 +50,8 @@ else
 DEFINES += -D__GITVERSIONSTRING__=\"placeholder\"
 endif
 
-# use c++11 features for the checksums
-DEFINES += -DCHECKSUM_USE_CPP
+# use c++11 features for the checksums and set default baud rate for serial uart
+DEFINES += -DCHECKSUM_USE_CPP -DDEFAULT_SERIAL_BAUD_RATE=$(DEFAULT_SERIAL_BAUD_RATE)
 
 # add any modules that you do not want included in the build
 export EXCLUDED_MODULES = tools/touchprobe


### PR DESCRIPTION
report the line number the long line is on
Add a DEFAULT_SERIAL_BAUD_RATE define to src/makefile to set the default baud rate used when config has not yet been loaded
