### PR TITLE
Workaround driver sending 3 bytes more than packet size by adding 4 byte...

### DIFF
--- a/src/libs/Network/uip/Network.cpp
+++ b/src/libs/Network/uip/Network.cpp
@@ -203,7 +203,7 @@ void Network::on_idle(void *argument)
 {
     if (!ethernet->isUp()) return;
 
-    int len;
+    int len= sizeof(uip_buf); // set maximum size
     if (ethernet->_receive_frame(uip_buf, &len)) {
         uip_len = len;
         this->handlePacket();

--- a/src/libs/Network/uip/uip/uip.c
+++ b/src/libs/Network/uip/uip/uip.c
@@ -152,7 +152,7 @@ struct uip_eth_addr uip_ethaddr = {{0, 0, 0, 0, 0, 0}};
 #endif
 
 #ifndef UIP_CONF_EXTERNAL_BUFFER
-u8_t uip_buf[UIP_BUFSIZE + 2] __attribute__ ((section ("AHBSRAM1")));   /* The packet buffer that contains
+u8_t uip_buf[UIP_BUFSIZE + 4] __attribute__ ((section ("AHBSRAM1")));   /* The packet buffer that contains
                     incoming packets. */
 #endif /* UIP_CONF_EXTERNAL_BUFFER */
 

--- a/src/libs/Network/uip/uip/uip.h
+++ b/src/libs/Network/uip/uip/uip.h
@@ -428,9 +428,9 @@ void uip_setipid(u16_t id);
  */
 
 #ifdef __cplusplus
-extern "C" u8_t uip_buf[UIP_BUFSIZE+2];
+extern "C" u8_t uip_buf[UIP_BUFSIZE+4];
 #else
-extern u8_t uip_buf[UIP_BUFSIZE+2];
+extern u8_t uip_buf[UIP_BUFSIZE+4];
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
...s to uip buffer size

Discard packets that are too big for uip buffer (UDP broadcasts usually)
