### PR TITLE
flash led1 on gcode received, dimmed loops, led2 init done + main loop, led3 idle loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,8 +161,12 @@ int main() {
     kernel->config->config_cache_clear();
 
     if(kernel->use_leds) {
-        // set some leds to indicate status... led0 init doe, led1 mainloop running, led2 idle loop running, led3 sdcard ok
-        leds[0]= 1; // indicate we are done with init
+        // set some leds to indicate status...
+        //   led1 (flash) gcode received
+        //   led2 (on) init done (dimmed) mainloop running
+        //   led3 (dimmed) idle loop running
+        //   led4 (on) sdcard ok
+        leds[1]= 1; // indicate we are done with init
         leds[3]= sdok?1:0; // 4th led inidicates sdcard is available (TODO maye should indicate config was found)
     }
 
@@ -188,8 +192,7 @@ int main() {
     // Main loop
     while(1){
         if(kernel->use_leds) {
-            // flash led 2 to show we are alive
-            leds[1]= (cnt++ & 0x1000) ? 1 : 0;
+            leds[1]= (cnt++ & 0x03F0) ? 0 : 1;
         }
         kernel->call_event(ON_MAIN_LOOP);
         kernel->call_event(ON_IDLE);


### PR DESCRIPTION
trying to make more use of leds:
- led1 flashes when receiving gcodes (I mainly wanted _this_)
- led2+led3 are dimmed, they were too distracting for only showing idle action
- led3 flickers when actions are going on
- led2 used for end of init phase (on) and main idle loop (dimmed)
- led3 used for slow ticker idle loop

this could be implemented more generally (e.g. using a class Led), but I think this wouldn't be of much value until more uses come up.

--HG--
extra : source : 51a0b52e50ab596ad39f75d65ec742eb03bec58e
