### PR TITLE
move led toggling in main and SlowTicker to IdleLeds module

### DIFF
--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -121,16 +121,8 @@ bool SlowTicker::flag_1s(){
     return false;
 }
 
-#include "gpio.h"
-extern GPIO leds[];
 void SlowTicker::on_idle(void*)
 {
-    static uint16_t ledcnt= 0;
-    if(THEKERNEL->use_leds) {
-        // flash led 3 to show we are alive
-        leds[2]= (ledcnt++ & 0x1000) ? 1 : 0;
-    }
-
     // if interrupt has set the 1 second flag
     if (flag_1s())
         // fire the on_second_tick event

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "modules/utils/pausebutton/PauseButton.h"
 #include "modules/utils/PlayLed/PlayLed.h"
 #include "modules/utils/panel/Panel.h"
+#include "modules/utils/idleleds/IdleLeds.h"
 #include "libs/Network/uip/Network.h"
 #include "Config.h"
 #include "checksumm.h"
@@ -107,6 +108,9 @@ int main() {
     // Create and add main modules
     kernel->add_module( new SimpleShell() );
     kernel->add_module( new Configurator() );
+    if(kernel->use_leds)
+      kernel->add_module( new IdleLeds() );     // must be added early
+
     kernel->add_module( new CurrentControl() );
     kernel->add_module( new SwitchPool() );
     kernel->add_module( new PauseButton() );
@@ -184,13 +188,8 @@ int main() {
         }
     }
 
-    uint16_t cnt= 0;
     // Main loop
     while(1){
-        if(kernel->use_leds) {
-            // flash led 2 to show we are alive
-            leds[1]= (cnt++ & 0x1000) ? 1 : 0;
-        }
         kernel->call_event(ON_MAIN_LOOP);
         kernel->call_event(ON_IDLE);
     }

--- a/src/modules/utils/idleleds/IdleLeds.cpp
+++ b/src/modules/utils/idleleds/IdleLeds.cpp
@@ -1,0 +1,49 @@
+#include "IdleLeds.h"
+
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "libs/gpio.h"
+
+#define idleleds_checksum CHECKSUM("idleleds")
+#define enable_checksum   CHECKSUM("enable")
+#define led_main_checksum CHECKSUM("led_main")
+#define led_idle_checksum CHECKSUM("led_idle")
+
+extern GPIO leds[];
+
+IdleLeds::IdleLeds(){}
+
+void IdleLeds::on_module_loaded()
+{
+    // Exit if this module is not enabled
+    if ( !THEKERNEL->config->value( idleleds_checksum, enable_checksum )->by_default(true)->as_bool() ) {
+        delete this;
+        return;
+    }
+
+    register_for_event(ON_CONFIG_RELOAD);
+    register_for_event(ON_IDLE);
+    register_for_event(ON_MAIN_LOOP);
+
+    on_config_reload(this);
+}
+
+void IdleLeds::on_config_reload(void* argument)
+{
+    led_main = THEKERNEL->config->value( idleleds_checksum, led_main_checksum )->by_default(2)->as_int() - 1;
+    led_idle = THEKERNEL->config->value( idleleds_checksum, led_idle_checksum )->by_default(3)->as_int() - 1;
+
+    counter_main = 0;
+    counter_idle = 0;
+}
+
+void IdleLeds::on_main_loop(void* argument)
+{
+    if(led_main >= 0) leds[led_main]= (counter_main++ & 0x1000) ? 1 : 0;
+}
+
+void IdleLeds::on_idle(void* argument)
+{
+    if(led_idle >= 0) leds[led_idle]= (counter_idle++ & 0x1000) ? 1 : 0;
+}

--- a/src/modules/utils/idleleds/IdleLeds.h
+++ b/src/modules/utils/idleleds/IdleLeds.h
@@ -1,0 +1,23 @@
+#ifndef _IdleLeds_H
+#define _IdleLeds_H
+
+#include "libs/Kernel.h"
+#include "libs/Pin.h"
+
+class IdleLeds : public Module {
+public:
+    IdleLeds();
+
+    void on_module_loaded(void);
+    void on_config_reload(void*);
+    void on_main_loop(void*);
+    void on_idle(void*);
+
+    int8_t      led_main;
+    int16_t     counter_main;
+
+    int8_t      led_idle;
+    int16_t     counter_idle;
+};
+
+#endif /* _IdleLeds_H */


### PR DESCRIPTION
move fixed led toggling from main loop and SlowTicker::on_idle to a module.
This allows using these leds for different purposes by disabling this module.
Both leds are configurable separately (index starting by 1).
They can be disabled individually by assigning 0.

Default config:

```
idleleds.enable    true
idleleds.led_main  2
idleleds.led_idle  3
```
