### PR TITLE
Add a check that the zprobe is not already triggered before moving the motors

### DIFF
--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -183,23 +183,6 @@ bool ZProbe::return_probe(int steps)
     return true;
 }
 
-// check if the probe is currently triggered
-bool ZProbe::check_probe()
-{
-    // if the zprobe pin is set more than half the time during the
-    // debounce window, we'll call it triggered.
-    unsigned int debounce = 0;
-    unsigned int triggered = 0;
-
-    do {
-        THEKERNEL->call_event(ON_IDLE);
-        if( this->pin.get() ) {
-            triggered++;
-        } 
-    } while (debounce++ < debounce_count);
-    return triggered > debounce / 2;
-}
-
 // calculate the X and Y positions for the three towers given the radius from the center
 static std::tuple<float, float, float, float, float, float> getCoordinates(float radius)
 {
@@ -447,7 +430,7 @@ void ZProbe::on_gcode_received(void *argument)
             THEKERNEL->conveyor->wait_for_empty_queue();
 
             // make sure the probe is not already triggered before moving motors
-            if(check_probe()) {
+            if(this->pin.get()) {
                 gcode->stream->printf("ZProbe triggered before move, aborting command.\n");
                 return;
             }
@@ -472,7 +455,7 @@ void ZProbe::on_gcode_received(void *argument)
             gcode->mark_as_taken();
 
             // make sure the probe is not already triggered before moving motors
-            if(check_probe()) {
+            if(this->pin.get()) {
                 gcode->stream->printf("ZProbe triggered before move, aborting command.\n");
                 return;
             } 

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -31,7 +31,6 @@ private:
     bool run_probe(int& steps, bool fast= false);
     bool probe_delta_tower(int& steps, float x, float y);
     bool return_probe(int steps);
-    bool check_probe();
     bool calibrate_delta_endstops(Gcode *gcode);
     bool calibrate_delta_radius(Gcode *gcode);
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);


### PR DESCRIPTION
I need to manually deploy my zprobe and more than once I've run G30 or G32 without doing the deployment and the printer does bad things and I have kill the power.

This change adds a check that the zprobe is not triggered before starting the G30 or G32 routine. Seems like a generally useful safety feature.  
