### PR TITLE
add delimiters to shift_parameter

### DIFF
--- a/src/libs/utils.cpp
+++ b/src/libs/utils.cpp
@@ -111,8 +111,8 @@ string remove_non_number( string str ){
 }
 
 // Get the first parameter, and remove it from the original string
-string shift_parameter( string &parameters ){
-    size_t beginning = parameters.find_first_of(" ");
+string shift_parameter( string &parameters, string delimiters ){
+    size_t beginning = parameters.find_first_of(delimiters);
     if( beginning == string::npos ){ string temp = parameters; parameters = ""; return temp; }
     string temp = parameters.substr( 0, beginning );
     parameters = parameters.substr(beginning+1, parameters.size());

--- a/src/libs/utils.h
+++ b/src/libs/utils.h
@@ -24,7 +24,7 @@ uint16_t get_checksum(const char* to_check);
 
 void get_checksums(uint16_t check_sums[], const string& key);
 
-string shift_parameter( string &parameters );
+string shift_parameter( string &parameters, string delimiters = " " );
 
 string get_arguments( string possible_command );
 


### PR DESCRIPTION
extend shift_parameter(parameters) to shift_parameter(parameters, delimiters = " ")

delimiters is a set of characters

e.g. shift_parameter(str, ":=") returns all characters up to ':' or '='
