### PR TITLE
Feature/set output pin

### DIFF
--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -1,9 +1,9 @@
 /*
-      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
-      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
-*/
+ This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+ Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 using namespace std;
 #include <vector>
@@ -26,10 +26,10 @@ using namespace std;
 Config::Config()
 {
     this->config_cache = NULL;
-
+    
     // Config source for firm config found in src/config.default
     this->config_sources.push_back( new FirmConfigSource("firm") );
-
+    
     // Config source for */config files
     FileConfigSource *fcs = NULL;
     if( file_exists("/local/config") )
@@ -58,12 +58,17 @@ void Config::get_module_list(vector<uint16_t> *list, uint16_t family)
     this->config_cache->collect(family, CHECKSUM("enable"), list);
 }
 
+void Config::get_checksums(vector<uint16_t>* list, uint16_t family)
+{
+    this->config_cache->collect(family, 0, list);
+}
+
 // Command to load config cache into buffer for multiple reads during init
 void Config::config_cache_load(bool parse)
 {
     // First clear the cache
     this->config_cache_clear();
-
+    
     this->config_cache= new ConfigCache;
     if(parse) {
         // For each ConfigSource in our stack
@@ -102,9 +107,9 @@ ConfigValue *Config::value(uint16_t check_sums[])
         // note this will cause whatever called it to blow up!
         return NULL;
     }
-
+    
     ConfigValue *result = this->config_cache->lookup(check_sums);
-
+    
     if(result == NULL) {
         // create a dummy value for this to play with, each call requires it's own value not a shared one
         // result= new ConfigValue(check_sums);
@@ -112,7 +117,7 @@ ConfigValue *Config::value(uint16_t check_sums[])
         dummyValue.clear();
         result = &dummyValue;
     }
-
+    
     return result;
 }
 

--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -1,9 +1,9 @@
 /*
- This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
- Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
- */
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 using namespace std;
 #include <vector>
@@ -26,10 +26,10 @@ using namespace std;
 Config::Config()
 {
     this->config_cache = NULL;
-    
+
     // Config source for firm config found in src/config.default
     this->config_sources.push_back( new FirmConfigSource("firm") );
-    
+
     // Config source for */config files
     FileConfigSource *fcs = NULL;
     if( file_exists("/local/config") )
@@ -68,7 +68,7 @@ void Config::config_cache_load(bool parse)
 {
     // First clear the cache
     this->config_cache_clear();
-    
+
     this->config_cache= new ConfigCache;
     if(parse) {
         // For each ConfigSource in our stack
@@ -107,9 +107,9 @@ ConfigValue *Config::value(uint16_t check_sums[])
         // note this will cause whatever called it to blow up!
         return NULL;
     }
-    
+
     ConfigValue *result = this->config_cache->lookup(check_sums);
-    
+
     if(result == NULL) {
         // create a dummy value for this to play with, each call requires it's own value not a shared one
         // result= new ConfigValue(check_sums);
@@ -117,7 +117,7 @@ ConfigValue *Config::value(uint16_t check_sums[])
         dummyValue.clear();
         result = &dummyValue;
     }
-    
+
     return result;
 }
 

--- a/src/libs/Config.h
+++ b/src/libs/Config.h
@@ -1,9 +1,9 @@
 /*
-      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
-      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
-*/
+ This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+ Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef CONFIG_H
 #define CONFIG_H
@@ -18,28 +18,29 @@ class ConfigSource;
 class ConfigCache;
 
 class Config : public Module {
-    public:
-        Config();
-
-        void on_module_loaded();
-        void on_console_line_received( void* argument );
-        void config_cache_load(bool parse= true);
-        void config_cache_clear();
-        void set_string( string setting , string value);
-
-        ConfigValue* value(uint16_t check_sum_a, uint16_t check_sum_b= 0, uint16_t check_sum_c= 0 );
-        ConfigValue* value(uint16_t check_sums[3] );
-
-        void get_module_list(vector<uint16_t>* list, uint16_t family);
-        bool is_config_cache_loaded() { return config_cache != NULL; };    // Whether or not the cache is currently popluated
-
-        friend class  Configurator;
-
-    private:
-        bool   has_characters(uint16_t check_sum, string str );
-
-        ConfigCache* config_cache;            // A cache in which ConfigValues are kept
-        vector<ConfigSource*> config_sources; // A list of all possible coniguration sources
+public:
+    Config();
+    
+    void on_module_loaded();
+    void on_console_line_received( void* argument );
+    void config_cache_load(bool parse= true);
+    void config_cache_clear();
+    void set_string( string setting , string value);
+    
+    ConfigValue* value(uint16_t check_sum_a, uint16_t check_sum_b= 0, uint16_t check_sum_c= 0 );
+    ConfigValue* value(uint16_t check_sums[3] );
+    
+    void get_module_list(vector<uint16_t>* list, uint16_t family);
+    void get_checksums(vector<uint16_t>* list, uint16_t family);
+    bool is_config_cache_loaded() { return config_cache != NULL; };    // Whether or not the cache is currently popluated
+    
+    friend class  Configurator;
+    
+private:
+    bool   has_characters(uint16_t check_sum, string str );
+    
+    ConfigCache* config_cache;            // A cache in which ConfigValues are kept
+    vector<ConfigSource*> config_sources; // A list of all possible coniguration sources
 };
 
 #endif

--- a/src/libs/Config.h
+++ b/src/libs/Config.h
@@ -1,9 +1,9 @@
 /*
- This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
- Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
- Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
- */
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef CONFIG_H
 #define CONFIG_H
@@ -18,29 +18,29 @@ class ConfigSource;
 class ConfigCache;
 
 class Config : public Module {
-public:
-    Config();
-    
-    void on_module_loaded();
-    void on_console_line_received( void* argument );
-    void config_cache_load(bool parse= true);
-    void config_cache_clear();
-    void set_string( string setting , string value);
-    
-    ConfigValue* value(uint16_t check_sum_a, uint16_t check_sum_b= 0, uint16_t check_sum_c= 0 );
-    ConfigValue* value(uint16_t check_sums[3] );
-    
-    void get_module_list(vector<uint16_t>* list, uint16_t family);
-    void get_checksums(vector<uint16_t>* list, uint16_t family);
-    bool is_config_cache_loaded() { return config_cache != NULL; };    // Whether or not the cache is currently popluated
-    
-    friend class  Configurator;
-    
-private:
-    bool   has_characters(uint16_t check_sum, string str );
-    
-    ConfigCache* config_cache;            // A cache in which ConfigValues are kept
-    vector<ConfigSource*> config_sources; // A list of all possible coniguration sources
+    public:
+        Config();
+
+        void on_module_loaded();
+        void on_console_line_received( void* argument );
+        void config_cache_load(bool parse= true);
+        void config_cache_clear();
+        void set_string( string setting , string value);
+
+        ConfigValue* value(uint16_t check_sum_a, uint16_t check_sum_b= 0, uint16_t check_sum_c= 0 );
+        ConfigValue* value(uint16_t check_sums[3] );
+
+        void get_module_list(vector<uint16_t>* list, uint16_t family);
+        void get_checksums(vector<uint16_t>* list, uint16_t family);
+        bool is_config_cache_loaded() { return config_cache != NULL; };    // Whether or not the cache is currently popluated
+
+        friend class  Configurator;
+
+    private:
+        bool   has_characters(uint16_t check_sum, string str );
+
+        ConfigCache* config_cache;            // A cache in which ConfigValues are kept
+        vector<ConfigSource*> config_sources; // A list of all possible coniguration sources
 };
 
 #endif

--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -39,7 +39,7 @@ void ConfigCache::replace_or_push_back(ConfigValue *new_value)
             return;
         }
     }
-    
+
     // Value does not already exists, add to the list
     store.push_back(new_value);
 }
@@ -50,7 +50,7 @@ ConfigValue *ConfigCache::lookup(const uint16_t *check_sums) const
         if(memcmp(check_sums, cv->check_sums, sizeof(cv->check_sums)) == 0)
             return cv;
     }
-    
+
     return NULL;
 }
 

--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -39,7 +39,7 @@ void ConfigCache::replace_or_push_back(ConfigValue *new_value)
             return;
         }
     }
-
+    
     // Value does not already exists, add to the list
     store.push_back(new_value);
 }
@@ -50,14 +50,14 @@ ConfigValue *ConfigCache::lookup(const uint16_t *check_sums) const
         if(memcmp(check_sums, cv->check_sums, sizeof(cv->check_sums)) == 0)
             return cv;
     }
-
+    
     return NULL;
 }
 
 void ConfigCache::collect(uint16_t family, uint16_t cs, vector<uint16_t> *list)
 {
     for( auto &kv : store ) {
-        if( kv->check_sums[2] == cs && kv->check_sums[0] == family ) {
+        if( (!cs || (kv->check_sums[2] == cs)) && (kv->check_sums[0] == family) ) {
             // We found a module enable for this family, add it's number
             list->push_back(kv->check_sums[1]);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@
 
 #include "mbed.h"
 
+#include "set_output_pin.h"
+
 #define second_usb_serial_enable_checksum  CHECKSUM("second_usb_serial_enable")
 #define disable_msd_checksum  CHECKSUM("msd_disable")
 #define disable_leds_checksum  CHECKSUM("leds_disable")
@@ -103,6 +105,10 @@ void init() {
     // }
 
     bool sdok= (sd.disk_initialize() == 0);
+
+    // Set default pin values.
+    
+    set_output_pin::set_output_pins();
 
     // Create and add main modules
     kernel->add_module( new SimpleShell() );

--- a/src/modules/utils/set_output_pin/set_output_pin.cpp
+++ b/src/modules/utils/set_output_pin/set_output_pin.cpp
@@ -1,0 +1,33 @@
+//
+//  set_output_pin.cpp
+//
+//  Created by Ron Aldrich on 6/20/14.
+//
+
+#include "set_output_pin.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+#include "checksumm.h"
+#include "Pin.h"
+#include "Kernel.h"
+#include "ConfigValue.h"
+#include "Config.h"
+
+static uint16_t default_checksum = CHECKSUM("set_output_pin");
+
+void set_output_pin::set_output_pins()
+{
+    std::vector <uint16_t> thePins;
+    
+    THEKERNEL->config->get_checksums(&thePins, default_checksum);
+ 
+    for( auto i : thePins )
+    {
+        Pin thePin;
+        thePin.from_string(THEKERNEL->config->value(default_checksum, i)->as_string())->as_output()->set(0);
+    }
+}

--- a/src/modules/utils/set_output_pin/set_output_pin.h
+++ b/src/modules/utils/set_output_pin/set_output_pin.h
@@ -1,0 +1,18 @@
+//
+//  set_output_pin.h
+//
+//  Created by Ron Aldrich on 6/20/14.
+//
+//  A simple method for configuring default pin values for pins that need to be set at startup, but don't need to be modified.
+//
+
+#ifndef __set_output_pin__
+#define __set_output_pin__
+
+class set_output_pin
+{
+public:
+    static void set_output_pins();
+};
+
+#endif /* defined(__set_output_pin__) */


### PR DESCRIPTION
A simple method for configuring default pin values for pins that need to be set at startup, but don't need to be modified thereafter.

Example configuration:

set_output_pin.alpha_ms1_pin           10.29!
set_output_pin.alpha_ms2_pin           10.30
set_output_pin.alpha_ms3_pin           10.31!

Would set the stepper motor mode pins for the alpha axis to 0b101 (32 micro-steps).