### PR TITLE
Squashed commit from branch fix/menu_mem_savings

### DIFF
--- a/src/modules/utils/panel/screens/ControlScreen.h
+++ b/src/modules/utils/panel/screens/ControlScreen.h
@@ -30,8 +30,8 @@ private:
     void set_current_pos(char axis, float p);
     char control_mode;
     char controlled_axis;
-    float pos[3];
     bool pos_changed;
+    float pos[3];
     float jog_increment;
 };
 

--- a/src/modules/utils/panel/screens/CustomScreen.cpp
+++ b/src/modules/utils/panel/screens/CustomScreen.cpp
@@ -25,6 +25,8 @@ using namespace std;
 
 CustomScreen::CustomScreen()
 {
+    this->command = nullptr;
+
     //printf("Setting up CustomScreen\n");
     vector<uint16_t> modules;
     THEKERNEL->config->get_module_list( &modules, custom_menu_checksum );
@@ -87,7 +89,7 @@ void CustomScreen::clicked_menu_entry(uint16_t line)
 void CustomScreen::on_main_loop()
 {
     // issue command
-    if (this->command.empty()) return;
-    send_command(this->command.c_str());
-    this->command.clear();
+    if (this->command == nullptr) return;
+    send_command(this->command);
+    this->command = nullptr;
 }

--- a/src/modules/utils/panel/screens/CustomScreen.h
+++ b/src/modules/utils/panel/screens/CustomScreen.h
@@ -10,7 +10,6 @@
 
 #include "PanelScreen.h"
 
-#include <string>
 #include <vector>
 #include <tuple>
 
@@ -27,7 +26,7 @@ public:
     int idle_timeout_secs() { return 60; }
 
 private:
-    std::string command;
+    const char *command;
     std::vector<std::tuple<const char*,const char*> > menu_items;
 };
 

--- a/src/modules/utils/panel/screens/PrepareScreen.cpp
+++ b/src/modules/utils/panel/screens/PrepareScreen.cpp
@@ -23,6 +23,8 @@ using namespace std;
 
 PrepareScreen::PrepareScreen()
 {
+    this->command = nullptr;
+
     // Children screens
     this->extruder_screen = (new ExtruderScreen()  )->set_parent(this);
     THEPANEL->temperature_screen->set_parent(this);
@@ -94,8 +96,8 @@ void PrepareScreen::cooldown()
 void PrepareScreen::on_main_loop()
 {
     // change actual axis value
-    if (this->command.empty()) return;
-    send_command(this->command.c_str());
-    this->command.clear();
+    if (this->command == nullptr) return;
+    send_command(this->command);
+    this->command = nullptr;
 }
 

--- a/src/modules/utils/panel/screens/PrepareScreen.h
+++ b/src/modules/utils/panel/screens/PrepareScreen.h
@@ -34,7 +34,7 @@ private:
     void preheat();
     void cooldown();
     void setup_temperature_screen();
-    string command;
+    const char *command;
 };
 
 #endif


### PR DESCRIPTION
commit 4eabd88eb9c53dbf45bb43b965be6c7e2d90a980
Author: stth1998 stth1998@web.de
Date:   Mon Aug 11 23:06:18 2014 +0200

```
addition to commit bfdf666

changed:
src/modules/utils/panel/screens/PrepareScreen.cpp

added initialization
```

commit ed824b1ad8f8532fadeace04824097a27045a473
Author: stth1998 stth1998@web.de
Date:   Mon Aug 11 23:01:52 2014 +0200

```
addition to commit 9e0f582

changed:
src/modules/utils/panel/screens/CustomScreen.cpp

initialization added
```

commit 9e04fe38da0fecbf8ef5373e28e179cab9e0f582
Author: stth1998 stth1998@web.de
Date:   Mon Aug 11 20:55:26 2014 +0200

```
avoiding multiple string creation #2

changed:
src/modules/utils/panel/screens/CustomScreen.cpp
src/modules/utils/panel/screens/CustomScreen.h

std::string is 8 Bytes + heap allocations if set <-> const char * is 4 bytes + reused c string
in line 83 in CustomScreen.cpp there is always a const char * string pointer assigend
They do not need to be put into a string if the string's c_str() (const char*) is passed to send_command.
the assigned ptr is sufficient, too.

saves 4 bytes RAM (heap) (all the time) + strlen+1+padding bytes RAM (heap) (temporarily)
also saves time for allocation and deallocation
```

commit bfdf666dc0b94e61f19e511284ba9dbba64ea7c3
Author: stth1998 stth1998@web.de
Date:   Mon Aug 11 20:50:54 2014 +0200

```
avoiding multiple string creation #1

changed:
src/modules/utils/panel/screens/PrepareScreen.cpp
src/modules/utils/panel/screens/PrepareScreen.h

std::string is 8 Bytes + heap allocations if set <-> const char * is 4 bytes + reuse of c string literal
command is only assigned in line 67 to 73 in PrepareScreen.cpp there are const char [] string literals assigend only.

They do not need to be put into a string, if the string's c_str() (const char*) is passed to send_command.
the assigned literal is sufficient, too.

saves 4 bytes of RAM (heap) (all the time) + strlen+1+padding bytes RAM (heap) (temporarily)
also saves time for allocation and deallocation when a command is executed
```

commit ba02d5f9c9b162e6dc58c7dae8983f1ec03769b2
Author: stth1998 stth1998@web.de
Date:   Mon Aug 11 19:19:29 2014 +0200

```
respect memory alignment in class ControlScreen

changed:
src/modules/utils/panel/screens/ControlScreen.h

putting the bool in one block with the two chars saves 4 bytes of RAM per instance due to memory alignment
```
