### PR TITLE
Change win32 git branch extraction to use same approach as generate-version.sh

### DIFF
--- a/src/generate-version.bat
+++ b/src/generate-version.bat
@@ -1,5 +1,6 @@
 @for /f "delims=" %%a in ('git symbolic-ref HEAD') do @set myvar=%%a
 @for /f "delims=" %%b in ('git log "--pretty=format:%%h" -1') do @set myvar2=%%b
+@REM the 11 is derived from generate-version.sh "cut -b 12" by subtracting 1 
 @echo %myvar:~11%-%myvar2%
 @copy /b  version.cpp+,, >NUL:
 


### PR DESCRIPTION
Sorry for just adding a change to my previous pull request a few minutes later but I think this is better now since it uses the exactly the same approach as the shell script.
