### PR TITLE
Config sample thermistor lookup fix

### DIFF
--- a/ConfigSamples/AzteegX5Mini.delta/config
+++ b/ConfigSamples/AzteegX5Mini.delta/config
@@ -76,7 +76,7 @@ laser_module_enable                          false            # Whether to activ
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all. All configuration is ignored if false.
 temperature_control.hotend.thermistor_pin    0.24             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.5              # Pin that controls the heater
-temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64 for a list of valid thermistor names
+temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h for a list of valid thermistor names
 temperature_control.hotend.set_m_code        104              #
 temperature_control.hotend.set_and_wait_m_code 109            #
 temperature_control.hotend.designator        T                #

--- a/ConfigSamples/AzteegX5Mini/config
+++ b/ConfigSamples/AzteegX5Mini/config
@@ -68,7 +68,7 @@ laser_module_enable                          false            # Whether to activ
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all. All configuration is ignored if false.
 temperature_control.hotend.thermistor_pin    0.24             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.5              # Pin that controls the heater
-temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64 for a list of valid thermistor names
+temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h for a list of valid thermistor names
 temperature_control.hotend.set_m_code        104              #
 temperature_control.hotend.set_and_wait_m_code 109            #
 temperature_control.hotend.designator        T                #
@@ -80,7 +80,7 @@ temperature_control.hotend.d_factor          24               #
 temperature_control.bed.enable               false            #
 temperature_control.bed.thermistor_pin       0.23             #
 temperature_control.bed.heater_pin           2.7              #
-temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64 for a list of valid thermistor names
+temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/predefined_thermistors.h for a list of valid thermistor names
 temperature_control.bed.set_m_code           140              #
 temperature_control.bed.set_and_wait_m_code  190              #
 temperature_control.bed.designator           B                #

--- a/ConfigSamples/Smoothieboard.delta/config
+++ b/ConfigSamples/Smoothieboard.delta/config
@@ -125,7 +125,7 @@ temperature_control.hotend.enable            true             # Whether to activ
                                                               # All configuration is ignored if false.
 temperature_control.hotend.thermistor_pin    0.23             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.7              # Pin that controls the heater
-temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 temperature_control.hotend.set_m_code        104              #
 temperature_control.hotend.set_and_wait_m_code 109            #
@@ -143,7 +143,7 @@ temperature_control.hotend.designator        T                #
 
 #temperature_control.hotend2.thermistor_pin    0.25             # Pin for the thermistor to read
 #temperature_control.hotend2.heater_pin        1.23              # Pin that controls the heater
-#temperature_control.hotend2.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+#temperature_control.hotend2.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 #temperature_control.hotend2.set_m_code        884              #
 #temperature_control.hotend2.set_and_wait_m_code 889            #
@@ -158,7 +158,7 @@ temperature_control.hotend.designator        T                #
 temperature_control.bed.enable               true             #
 temperature_control.bed.thermistor_pin       0.24             #
 temperature_control.bed.heater_pin           2.5              #
-temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 temperature_control.bed.set_m_code           140              #
 temperature_control.bed.set_and_wait_m_code  190              #

--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -120,7 +120,7 @@ temperature_control.hotend.enable            true             # Whether to activ
                                                               # All configuration is ignored if false.
 temperature_control.hotend.thermistor_pin    0.23             # Pin for the thermistor to read
 temperature_control.hotend.heater_pin        2.7              # Pin that controls the heater, set to nc if a readonly thermistor is being defined
-temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+temperature_control.hotend.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 temperature_control.hotend.set_m_code        104              #
 temperature_control.hotend.set_and_wait_m_code 109            #
@@ -138,7 +138,7 @@ temperature_control.hotend.designator        T                #
 
 #temperature_control.hotend2.thermistor_pin    0.25             # Pin for the thermistor to read
 #temperature_control.hotend2.heater_pin        1.23              # Pin that controls the heater
-#temperature_control.hotend2.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+#temperature_control.hotend2.thermistor        EPCOS100K        # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 #temperature_control.hotend2.set_m_code        884              #
 #temperature_control.hotend2.set_and_wait_m_code 889            #
@@ -153,7 +153,7 @@ temperature_control.hotend.designator        T                #
 temperature_control.bed.enable               true             #
 temperature_control.bed.thermistor_pin       0.24             #
 temperature_control.bed.heater_pin           2.5              #
-temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/TemperatureControl.cpp:64
+temperature_control.bed.thermistor           Honeywell100K    # see src/modules/tools/temperaturecontrol/predefined_thermistors.h
                                                               # for a list of valid thermistor names
 temperature_control.bed.set_m_code           140              #
 temperature_control.bed.set_and_wait_m_code  190              #


### PR DESCRIPTION
The thermistor lookup table looks to have moved. Updated the sample
configs to point to the new location
