### PR TITLE
Added automatic end-stop offset calbration to M206:

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -629,9 +629,19 @@ void Endstops::on_gcode_received(void *argument)
             break;
 
             case 206: // M206 - set homing offset
-                if (gcode->has_letter('X')) home_offset[0] = gcode->get_value('X');
-                if (gcode->has_letter('Y')) home_offset[1] = gcode->get_value('Y');
-                if (gcode->has_letter('Z')) home_offset[2] = gcode->get_value('Z');
+                if (gcode->has_letter('P')){
+                    float cartesian[3];
+
+                    THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
+
+                    if (gcode->has_letter('X')) home_offset[0] -= cartesian[X_AXIS];
+                    if (gcode->has_letter('Y')) home_offset[1] -= cartesian[Y_AXIS];
+                    if (gcode->has_letter('Z')) home_offset[2] -= cartesian[Z_AXIS];
+                } else {
+                    if (gcode->has_letter('X')) home_offset[0] = gcode->get_value('X');
+                    if (gcode->has_letter('Y')) home_offset[1] = gcode->get_value('Y');
+                    if (gcode->has_letter('Z')) home_offset[2] = gcode->get_value('Z');
+                }
                 gcode->stream->printf("X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
                 gcode->mark_as_taken();
                 break;


### PR DESCRIPTION
M206 P X Y Z
When P is available in the line, every named axis will be assumed to be zero,
and the calculated offset inserted into memory.

Not only useful for cartesian axis systems, as the kinematics are taken into account at the point of execution 
