### PR TITLE
Integral windup protection

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -51,6 +51,7 @@ class TemperatureControl : public Module {
 
         // PID runtime
         float i_max;
+        float i_windup;
 
         int o;
 


### PR DESCRIPTION
Modify TemperatureControl module to do simple integral windup
protection (ignore the I term of PID when far from setpoint)

Addresses #539.
