### PR TITLE
Modified currentcontrol to print values when given M907

### DIFF
--- a/src/modules/utils/currentcontrol/CurrentControl.cpp
+++ b/src/modules/utils/currentcontrol/CurrentControl.cpp
@@ -88,6 +88,7 @@ void CurrentControl::on_gcode_received(void *argument)
                     float c = gcode->get_value(alpha[i]);
                     this->digipot->set_current(i, c);
                 }
+                gcode->stream->printf("%c:%3.1fA%c", alpha[i], this->digipot->get_current(i), (i == 7)?'\n':' ');
             }
 
         } else if(gcode->m == 500 || gcode->m == 503) {


### PR DESCRIPTION
M907 stopped printing the current values when the code was refactored for memory savings.  Re-added the print line to allow M907 to show the current used
