### PR TITLE
Add option to oversample thermistor ADC values.

### DIFF
--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -27,6 +27,7 @@ class Thermistor : public TempSensor
     private:
         int new_thermistor_reading();
         float adc_value_to_temperature(int adc_value);
+        uint32_t oversample_tick(uint32_t dummy);
 
         // Thermistor computation settings
         float r0;
@@ -36,7 +37,11 @@ class Thermistor : public TempSensor
         float beta;
         float j;
         float k;
-
+        
+        uint16_t oversample_freq;
+        uint16_t oversample_count;
+        int oversample_sum;
+        
         Pin  thermistor_pin;
 
         RingBuffer<uint16_t,QUEUE_LEN> queue;  // Queue of readings


### PR DESCRIPTION
This improves the stability of PID control by reducing the effect of quantization
on the operation of the D term.

Also switched adc_value_to_temperature() to use float math instead of unnecessarily
precise double calculations.

http://koti.kapsi.fi/jpa/stuff/other/therm_test/report.html (current edge / new default is first image, pull request + config is last image)
This feature is off by default, set temperature_control.hotend.oversample_freq to e.g. 1000 Hz to enable it.
By oversampling the ADC value, we get more accurate and less quantized temperature readings.
This in turn makes the PID D-term behave better and improves temperature stability.
The effect is largest at high temperatures (>200 C), where the steps are larger with 100K NTC.