### PR TITLE
Save 64 bytes RAM per thermistor by moving median_buffer to AHB0.

### DIFF
--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -14,6 +14,7 @@
 #include "ConfigValue.h"
 #include "libs/Median.h"
 #include "Thermistor.h"
+#include "libs/platform_memory.h"
 
 // a const list of predefined thermistors
 #include "predefined_thermistors.h"
@@ -32,8 +33,17 @@
 #define r2_checksum                        CHECKSUM("r2")
 #define thermistor_pin_checksum            CHECKSUM("thermistor_pin")
 
+
+// Temporary buffer used only during median computation.
+// Shared between all thermistors.
+static uint16_t *median_buffer = NULL;
+
 Thermistor::Thermistor()
 {
+    if (median_buffer == NULL)
+    {
+        median_buffer = static_cast<uint16_t*>(AHB0.alloc(QUEUE_LEN * sizeof(uint16_t)));
+    }
 }
 
 Thermistor::~Thermistor()

--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -40,8 +40,6 @@ class Thermistor : public TempSensor
         Pin  thermistor_pin;
 
         RingBuffer<uint16_t,QUEUE_LEN> queue;  // Queue of readings
-        uint16_t median_buffer[QUEUE_LEN];
-        
 };
 
 #endif


### PR DESCRIPTION
Also we only need one median_buffer (total), because each thermistor
uses it only when quick_median() is running. Actual data is stored
in the queue. So this patch reuses the same buffer for all thermistors.
