### PR TITLE
Small fixes for the Spindle module.

### DIFF
--- a/src/modules/tools/spindle/Spindle.h
+++ b/src/modules/tools/spindle/Spindle.h
@@ -49,6 +49,7 @@ class Spindle: public Module {
         float control_P_term;
         float control_I_term;
         float control_D_term;
+        float smoothing_decay;
         
         // These fields are updated by the interrupt
         uint32_t last_edge; // Timestamp of last edge


### PR DESCRIPTION
- Now uses us_ticker_read(), leaving systick free for other uses.
- Sets lower priority for the pulse sensor interrupt.
- Added option for smoothing filter on the RPM readings, which
  helps PID if the readings are noisy.
