### PR TITLE
Fix/wait for temp done in gcode received

### DIFF
--- a/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
@@ -14,7 +14,7 @@
 
 
 #define SQ(x) powf(x, 2)
-#define ROUND(x, y) (roundf(x * 1e ## y) / 1e ## y)
+#define ROUND(x, y) (roundf(x * (float)(1e ## y)) / (float)(1e ## y))
 
 LinearDeltaSolution::LinearDeltaSolution(Config* config)
 {

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -21,7 +21,6 @@ class TemperatureControl : public Module {
 
         void on_module_loaded();
         void on_main_loop(void* argument);
-        void on_gcode_execute(void* argument);
         void on_gcode_received(void* argument);
         void on_second_tick(void* argument);
         void on_get_public_data(void* argument);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -17,6 +17,7 @@
 #include "mri.h"
 #include "version.h"
 #include "PublicDataRequest.h"
+#include "AppendFileStream.h"
 #include "FileStream.h"
 #include "checksumm.h"
 #include "PublicData.h"
@@ -445,11 +446,11 @@ void SimpleShell::save_command( string parameters, StreamOutput *stream )
     }
 
     // replace stream with one that writes to config-override file
-    FileStream *gs = new FileStream(filename.c_str());
-    if(!gs->is_open()) {
-        stream->printf("Unable to open File %s for write\n", filename.c_str());
-        return;
-    }
+    AppendFileStream *gs = new AppendFileStream(filename.c_str());
+    // if(!gs->is_open()) {
+    //     stream->printf("Unable to open File %s for write\n", filename.c_str());
+    //     return;
+    // }
 
     // issue a M500 which will store values in the file stream
     Gcode *gcode = new Gcode("M500", gs);


### PR DESCRIPTION
most hosts expect ok to not be returned until temp is reached with M109, this fixes this.
In addition it removes on gcode execute from temperature control, and removes one of the few uses of pauser.