### PR TITLE
add missing include

### DIFF
--- a/src/modules/communication/GcodeDispatch.h
+++ b/src/modules/communication/GcodeDispatch.h
@@ -8,6 +8,7 @@
 #ifndef GCODE_DISPATCH_H
 #define GCODE_DISPATCH_H
 
+#include <stdio.h>
 #include <string>
 using std::string;
 #include "libs/Module.h"


### PR DESCRIPTION
resolves:
modules/communication/GcodeDispatch.h:29:5: error: 'FILE' does not name a type

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>