### PR TITLE
Fixed Makefile to use the correct standard libraries.

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -142,7 +142,7 @@ endif
 
 # Libraries to be linked into final binary
 MBED_LIBS = $(MBED_DIR)/$(DEVICE)/GCC_ARM/libmbed.a
-SYS_LIBS = -specs=nano.specs -lstdc++ -lsupc++ -lm -lgcc -lc -lgcc -lc -lnosys
+SYS_LIBS = -specs=nano.specs -lstdc++ -lsupc++ -lm -lgcc -lc -lnosys
 LIBS = $(LIBS_PREFIX)
 
 ifeq "$(MRI_ENABLE)" "1"

--- a/build/common.mk
+++ b/build/common.mk
@@ -142,7 +142,7 @@ endif
 
 # Libraries to be linked into final binary
 MBED_LIBS = $(MBED_DIR)/$(DEVICE)/GCC_ARM/libmbed.a
-SYS_LIBS = -lstdc++_s -lsupc++_s -lm -lgcc -lc_s -lgcc -lc_s -lnosys
+SYS_LIBS = -specs=nano.specs -lstdc++ -lsupc++ -lm -lgcc -lc -lgcc -lc -lnosys
 LIBS = $(LIBS_PREFIX)
 
 ifeq "$(MRI_ENABLE)" "1"


### PR DESCRIPTION
This PR may need a detailed explanation:
According to my understanding the "_s" postfix is outdated
and not used anymore.
These small versions of the newlib standard libraries have
been renamed. Nowadays the "_nano" prefix should be used (since GCC 4.8).
I assume, that "_s" stands for "small".

But instead of adding a prefix we should use the spec file.

I checked this patch against the latest Debian Jessie arm-none-eabi (GCC
4.8) toolchain as well as against the toolchain installed by
"linux_install".