### PR TITLE
Implemented Servo controlled probe functionality at the ZProbe module

### DIFF
--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -27,6 +27,7 @@
 #include "LevelingStrategy.h"
 #include "StepTicker.h"
 #include "PwmOut.h" // mbed.h lib
+#include "us_ticker_api.h"
 
 // strategies we know about
 #include "DeltaCalibrationStrategy.h"
@@ -420,20 +421,27 @@ void ZProbe::deploy_servo()
 	this->servo_pin->pulsewidth_us(1000 + this->servo_percent * 10);
 
 	if(this->servo_disable) {				//Disable servo to eliminate jitter
-		wait_ms(250);
+		uint32_t start = us_ticker_read();
+		while ((us_ticker_read() - start) < 25000) {
+		   THEKERNEL->call_event(ON_IDLE);
+		}
 		this->servo_pin->pulsewidth_us(0);
 	}
 }
 
 void ZProbe::retract_servo()
 {
+
 	if(this->servo_pin == NULL) return;
 
 	this->servo_pin->period_ms(20);
 	this->servo_pin->pulsewidth_us(1000);
 
 	if(this->servo_disable) {				//Disable servo to eliminate jitter
-		wait_ms(250);
+		uint32_t start = us_ticker_read();
+		while ((us_ticker_read() - start) < 25000) {
+		   THEKERNEL->call_event(ON_IDLE);
+		}
 		this->servo_pin->pulsewidth_us(0);
 	}
 }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -422,7 +422,7 @@ void ZProbe::deploy_servo()
 
 	if(this->servo_disable) {				//Disable servo to eliminate jitter
 		uint32_t start = us_ticker_read();
-		while ((us_ticker_read() - start) < 25000) {
+		while ((us_ticker_read() - start) < 250000) {
 		   THEKERNEL->call_event(ON_IDLE);
 		}
 		this->servo_pin->pulsewidth_us(0);
@@ -439,7 +439,7 @@ void ZProbe::retract_servo()
 
 	if(this->servo_disable) {				//Disable servo to eliminate jitter
 		uint32_t start = us_ticker_read();
-		while ((us_ticker_read() - start) < 25000) {
+		while ((us_ticker_read() - start) < 250000) {
 		   THEKERNEL->call_event(ON_IDLE);
 		}
 		this->servo_pin->pulsewidth_us(0);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -26,6 +26,7 @@
 #include "PublicData.h"
 #include "LevelingStrategy.h"
 #include "StepTicker.h"
+#include "PwmOut.h" // mbed.h lib
 
 // strategies we know about
 #include "DeltaCalibrationStrategy.h"
@@ -39,6 +40,9 @@
 #define fast_feedrate_checksum   CHECKSUM("fast_feedrate")
 #define probe_height_checksum    CHECKSUM("probe_height")
 #define gamma_max_checksum       CHECKSUM("gamma_max")
+#define servo_pin_checksum       CHECKSUM("servo_pin")
+#define servo_percent_checksum   CHECKSUM("servo_percent")
+#define servo_disable_checksum   CHECKSUM("servo_disable")
 
 // from endstop section
 #define delta_homing_checksum    CHECKSUM("delta_homing")
@@ -69,12 +73,22 @@ void ZProbe::on_module_loaded()
     register_for_event(ON_GCODE_RECEIVED);
 
     THEKERNEL->step_ticker->register_acceleration_tick_handler([this](){acceleration_tick(); });
+
 }
 
 void ZProbe::on_config_reload(void *argument)
 {
     this->pin.from_string( THEKERNEL->config->value(zprobe_checksum, probe_pin_checksum)->by_default("nc" )->as_string())->as_input();
     this->debounce_count = THEKERNEL->config->value(zprobe_checksum, debounce_count_checksum)->by_default(0  )->as_number();
+
+    Pin* dummy_pin = new Pin();
+    dummy_pin->from_string(THEKERNEL->config->value(zprobe_checksum, servo_pin_checksum)->by_default("nc")->as_string())->as_output();
+    if(dummy_pin->connected()) {
+    	this->servo_pin = dummy_pin->hardware_pwm();
+        this->servo_percent = THEKERNEL->config->value(zprobe_checksum, servo_percent_checksum)->by_default(100)->as_int();
+        this->servo_disable = THEKERNEL->config->value( zprobe_checksum, servo_disable_checksum )->by_default(false)->as_bool();
+    	retract_servo();
+    }
 
     // get strategies to load
     vector<uint16_t> modules;
@@ -169,6 +183,8 @@ bool ZProbe::wait_for_probe(int& steps)
 // single probe and report amount moved
 bool ZProbe::run_probe(int& steps, bool fast)
 {
+   deploy_servo(); //Deploy Servo
+    
     // not a block move so disable the last tick setting
     for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
         STEPPER[c]->set_moved_last_block(false);
@@ -192,6 +208,7 @@ bool ZProbe::run_probe(int& steps, bool fast)
 
     bool r = wait_for_probe(steps);
     this->running = false;
+    retract_servo();  //Retract probe
     return r;
 }
 
@@ -295,6 +312,10 @@ void ZProbe::on_gcode_received(void *argument)
             gcode->add_nl = true;
             gcode->mark_as_taken();
 
+        } else if(gcode->m == 401) {
+        	deploy_servo();
+        } else if(gcode->m == 402) {
+        	retract_servo();
         }else {
             for(auto s : strategies){
                 if(s->handleGcode(gcode)) {
@@ -389,4 +410,30 @@ void ZProbe::home()
 float ZProbe::zsteps_to_mm(float steps)
 {
     return steps / Z_STEPS_PER_MM;
+}
+
+void ZProbe::deploy_servo()
+{
+	if(this->servo_pin == NULL) return;
+
+	this->servo_pin->period_ms(20);
+	this->servo_pin->pulsewidth_us(1000 + this->servo_percent * 10);
+
+	if(this->servo_disable) {				//Disable servo to eliminate jitter
+		wait_ms(250);
+		this->servo_pin->pulsewidth_us(0);
+	}
+}
+
+void ZProbe::retract_servo()
+{
+	if(this->servo_pin == NULL) return;
+
+	this->servo_pin->period_ms(20);
+	this->servo_pin->pulsewidth_us(1000);
+
+	if(this->servo_disable) {				//Disable servo to eliminate jitter
+		wait_ms(250);
+		this->servo_pin->pulsewidth_us(0);
+	}
 }

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -8,11 +8,9 @@
 #ifndef ZPROBE_H_
 #define ZPROBE_H_
 
+#include <vector>
 #include "Module.h"
 #include "Pin.h"
-#include "wait_api.h"
-
-#include <vector>
 
 namespace mbed {
     class PwmOut;

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -10,8 +10,13 @@
 
 #include "Module.h"
 #include "Pin.h"
+#include "wait_api.h"
 
 #include <vector>
+
+namespace mbed {
+    class PwmOut;
+}
 
 // defined here as they are used in multiple files
 #define zprobe_checksum            CHECKSUM("zprobe")
@@ -39,21 +44,25 @@ public:
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);
     void home();
+    void deploy_servo();
+    void retract_servo();
 
     bool getProbeStatus() { return this->pin.get(); }
     float getSlowFeedrate() { return slow_feedrate; }
     float getFastFeedrate() { return fast_feedrate; }
     float getProbeHeight() { return probe_height; }
     float zsteps_to_mm(float steps);
-
 private:
     void accelerate(int c);
+    mbed::PwmOut *servo_pin;    // PWM output to regulate the laser power
 
     volatile float current_feedrate;
     float slow_feedrate;
     float fast_feedrate;
     float probe_height;
     float max_z;
+    int servo_percent;
+    bool servo_disable;
     volatile struct {
         volatile bool running:1;
         bool is_delta:1;


### PR DESCRIPTION
The following configuration parameters where added:

zprobe.servo_pin 1.24               # Servo PWM pin. Xmin is a good connection as the pin there is PWM
                                                  # and there is also a 5V supply for the servo
                                                  # If Xmax limit is not used, you can switch it with X
min zprobe.servo_percent 85   # Percentage of movement for deployment. Default 100
zprobe.servo_disable true        # Disable servo after a deployment or retract.
                                                 # Use if there is a lot of jittering. Default false

Also two M codes where added (same as Marlin M codes)
M401 For servo deploy
M402 For servo rectract

I did this for my own purpose, but I know that there are a lot of people looking for this functionality. I though it's good to share.