### PR TITLE
Add configurable SCARA limits to MorganSCARASolution

### DIFF
--- a/src/modules/robot/arm_solutions/MorganSCARASolution.h
+++ b/src/modules/robot/arm_solutions/MorganSCARASolution.h
@@ -22,6 +22,8 @@ class MorganSCARASolution : public BaseSolution {
         float arm2_length;
         float morgan_offset_x;
         float morgan_offset_y;
+        float morgan_undefined_min;
+        float morgan_undefined_max;
         float slow_rate;
 };
 


### PR DESCRIPTION
Added config parameters to define regions close to the SCARA tower and the maximum reach in order to prevent arms colliding.
The arms will limit the movement and move around the obstacle if sent to a destination on the other side of such a region.

Making it configurable allows  the user to place system components in those regions without fear of collisions.