### PR TITLE
Add option to oversample thermistor ADC values.

### DIFF
--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -35,6 +35,7 @@ class Thermistor : public TempSensor
         int new_thermistor_reading();
         float adc_value_to_temperature(int adc_value);
         void calc_jk();
+        uint32_t oversample_tick(uint32_t dummy);
 
         // Thermistor computation settings using beta, not used if using Steinhart-Hart
         float r0;
@@ -58,6 +59,10 @@ class Thermistor : public TempSensor
             };
         };
 
+        uint16_t oversample_freq;
+        uint16_t oversample_count;
+        int oversample_sum;
+        
         Pin  thermistor_pin;
 
         RingBuffer<uint16_t,QUEUE_LEN> queue;  // Queue of readings


### PR DESCRIPTION
This improves the stability of PID control by reducing the effect of quantization
on the operation of the D term.

Pull request #564 rebased against newest edge.
See previous pull request for result graphs from both me and @minad, both of which show large improvement in stability.

I see no reason not to include this as an option. It is off by default and only takes 8 bytes ram per thermistor, no other overhead when disabled.