### PR TITLE
Allow Tn as first command on a line, followed by any M or G command

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -118,7 +118,8 @@ try_again:
             }
 
             while(possible_command.size() > 0) {
-                size_t nextcmd = possible_command.find_first_of("GM", 1);
+                // assumes G or M are always the first on the line
+                size_t nextcmd = possible_command.find_first_of("GM", 2);
                 string single_command;
                 if(nextcmd == string::npos) {
                     single_command = possible_command;

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -118,7 +118,7 @@ try_again:
             }
 
             while(possible_command.size() > 0) {
-                size_t nextcmd = possible_command.find_first_of("GM", possible_command.find_first_of("GM") + 1);
+                size_t nextcmd = possible_command.find_first_of("GM", 1);
                 string single_command;
                 if(nextcmd == string::npos) {
                     single_command = possible_command;


### PR DESCRIPTION
Fixed parser bug to allow something like T1 M200 on a single line
As always if Tn appears anywhere on a line it switches the tool first then executes any commands on that line.