### PR TITLE
Switch momentary output

### DIFF
--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -73,7 +73,7 @@ void Switch::on_config_reload(void *argument)
     this->output_off_command =   THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->by_default("")->as_string();
     this->switch_state =         THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->by_default(false)->as_bool();
     string type =                THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("pwm")->as_string();
-    this->output_pulse_duration = (uint32_t) (THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pulse_duration_checksum )->by_default(0.2)->as_number() * 100.0) + 1;
+    this->output_pulse_duration = (uint32_t) (THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pulse_duration_checksum )->by_default(0.2f)->as_number() * 100.0) + 1;
 
     if(type == "pwm") this->output_type= PWM;
     else if(type == "digital") this->output_type= DIGITAL;

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -260,37 +260,37 @@ void Switch::on_main_loop(void *argument)
 // Check the state of the button and act accordingly
 uint32_t Switch::pinpoll_tick(uint32_t dummy)
 {
-	if (output_pin.connected()) {
-		if (this->output_momentary_counter == 1) {
-			this->switch_state = false;
-			this->output_pin.set(false);
-		}
-		if (this->output_momentary_counter > 0) {
-			this->output_momentary_counter--;
-		}
-	}
+    if (output_pin.connected()) {
+        if (this->output_momentary_counter == 1) {
+            this->switch_state = false;
+            this->output_pin.set(false);
+        }
+        if (this->output_momentary_counter > 0) {
+            this->output_momentary_counter--;
+        }
+    }
     if(input_pin.connected()) {
-		// If pin changed
-		bool current_state = this->input_pin.get();
-		if(this->input_pin_state != current_state) {
-			this->input_pin_state = current_state;
-			// If pin high
-			if( this->input_pin_state ) {
-				// if switch is a toggle switch
-				if( this->input_pin_behavior == toggle_checksum ) {
-					this->flip();
-					// else default is momentary
-				} else {
-					this->flip();
-				}
-				// else if button released
-			} else {
-				// if switch is momentary
-				if( this->input_pin_behavior == momentary_checksum ) {
-					this->flip();
-				}
-			}
-		}
+        // If pin changed
+        bool current_state = this->input_pin.get();
+        if(this->input_pin_state != current_state) {
+            this->input_pin_state = current_state;
+            // If pin high
+            if( this->input_pin_state ) {
+                // if switch is a toggle switch
+                if( this->input_pin_behavior == toggle_checksum ) {
+                    this->flip();
+                    // else default is momentary
+                } else {
+                    this->flip();
+                }
+                // else if button released
+            } else {
+                // if switch is momentary
+                if( this->input_pin_behavior == momentary_checksum ) {
+                    this->flip();
+                }
+            }
+        }
     }
     return 0;
 }

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -30,6 +30,7 @@ class Switch : public Module {
         void on_get_public_data(void* argument);
         void on_set_public_data(void* argument);
         uint32_t pinpoll_tick(uint32_t dummy);
+        uint32_t pinpulse_tick(uint32_t dummy);
         enum OUTPUT_TYPE {PWM, DIGITAL};
     private:
         void flip();
@@ -50,8 +51,8 @@ class Switch : public Module {
         uint16_t  input_off_command_code;
         char      input_on_command_letter;
         char      input_off_command_letter;
-        uint32_t  output_momentary_delay;
-        uint32_t  output_momentary_counter;
+        uint32_t  output_pulse_duration;
+        uint32_t  output_pulse_counter;
         struct {
             bool      switch_changed:1;
             bool      input_pin_state:1;

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -31,30 +31,33 @@ class Switch : public Module {
         void on_set_public_data(void* argument);
         uint32_t pinpoll_tick(uint32_t dummy);
         uint32_t pinpulse_tick(uint32_t dummy);
+
     private:
         void flip();
         void send_gcode(string msg, StreamOutput* stream);
         bool match_input_on_gcode(const Gcode* gcode) const;
         bool match_input_off_gcode(const Gcode* gcode) const;
-
+        
+        uint16_t  name_checksum;
         Pin       input_pin;
-        float     switch_value;
         Pwm       output_pin;
+        
+        float     switch_value;
+        
         string    output_on_command;
         string    output_off_command;
-        uint16_t  name_checksum;
+        
         uint16_t  input_on_command_code;
         uint16_t  input_off_command_code;
         char      input_on_command_letter;
         char      input_off_command_letter;
         struct {
-            bool      switch_state:1;
             bool      switch_changed:1;
             bool      input_pin_state:1;
+            bool      switch_state:1;
             bool      is_input_momentary:1;
             bool      is_output_pwm:1;
             bool      is_output_pulse:1;
-            uint8_t   output_pulse_counter:2;
         };
 };
 

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -45,10 +45,13 @@ class Switch : public Module {
         string    output_off_command;
         uint16_t  name_checksum;
         uint16_t  input_pin_behavior;
+        uint16_t  output_pin_behavior;
         uint16_t  input_on_command_code;
         uint16_t  input_off_command_code;
         char      input_on_command_letter;
         char      input_off_command_letter;
+        uint32_t  output_momentary_delay;
+        uint32_t  output_momentary_counter;
         struct {
             bool      switch_changed:1;
             bool      input_pin_state:1;

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -31,7 +31,6 @@ class Switch : public Module {
         void on_set_public_data(void* argument);
         uint32_t pinpoll_tick(uint32_t dummy);
         uint32_t pinpulse_tick(uint32_t dummy);
-        enum OUTPUT_TYPE {PWM, DIGITAL};
     private:
         void flip();
         void send_gcode(string msg, StreamOutput* stream);
@@ -40,23 +39,22 @@ class Switch : public Module {
 
         Pin       input_pin;
         float     switch_value;
-        OUTPUT_TYPE output_type;
         Pwm       output_pin;
         string    output_on_command;
         string    output_off_command;
         uint16_t  name_checksum;
-        uint16_t  input_pin_behavior;
-        uint16_t  output_pin_behavior;
         uint16_t  input_on_command_code;
         uint16_t  input_off_command_code;
         char      input_on_command_letter;
         char      input_off_command_letter;
-        uint32_t  output_pulse_duration;
-        uint32_t  output_pulse_counter;
         struct {
+            bool      switch_state:1;
             bool      switch_changed:1;
             bool      input_pin_state:1;
-            bool      switch_state;
+            bool      is_input_momentary:1;
+            bool      is_output_pwm:1;
+            bool      is_output_pulse:1;
+            uint8_t   output_pulse_counter:2;
         };
 };
 


### PR DESCRIPTION
This is a small addition to the switch module.

A new configuration parameter has been added: output_pin_behavior, which is analogous to input_pin_behavior.

Setting "output_pin_behavior = toggle" preserves existing behavior, and is the default value.
Setting "output_pin_behavior = momentary" will instead output a pulse when the "on" g-code is received.

The pulse duration is configurable using the "output_pulse_duration" parameter and by default is 0.2 seconds.  This feature is useful for performing all sorts of miscellaneous tasks as the pulse duration can be configured to last minutes or even hours.

I have also implemented a change to how Switch.cpp was reading the configuration.  Details here:
https://groups.google.com/d/msg/smoothie-dev/hbjUP5UwMeM/L2SlhbxYPGIJ

I have tested the momentary output feature and fixed configuration, but have not tested the input modes.

This is my first time contributing to an open source project so I have no idea what I'm doing.