### PR TITLE
Fix/invalid iterator

### DIFF
--- a/src/modules/utils/panel/PanelScreen.cpp
+++ b/src/modules/utils/panel/PanelScreen.cpp
@@ -16,12 +16,12 @@
 #include "libs/StreamOutput.h"
 
 #include <string>
-#include <vector>
+#include <deque>
 
 using namespace std;
 
 // static as it is shared by all screens
-std::vector<std::string> PanelScreen::command_queue;
+std::deque<std::string> PanelScreen::command_queue;
 
 PanelScreen::PanelScreen() {}
 PanelScreen::~PanelScreen() {}
@@ -90,12 +90,12 @@ void PanelScreen::send_command(const char *gcstr)
 void PanelScreen::on_main_loop()
 {
     // for each command in queue send it
-    for (auto& cmd : command_queue) {
+    while(command_queue.size() > 0) {
         struct SerialMessage message;
-        message.message = cmd;
+        message.message = command_queue.front();
+        command_queue.pop_front();
         message.stream = &(StreamOutput::NullStream);
         THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
-        cmd.clear();
     }
     command_queue.clear();
 }

--- a/src/modules/utils/panel/PanelScreen.h
+++ b/src/modules/utils/panel/PanelScreen.h
@@ -9,7 +9,7 @@
 #define PANELSCREEN_H
 
 #include <string>
-#include <vector>
+#include <deque>
 
 class Panel;
 
@@ -37,7 +37,7 @@ protected:
     void send_gcode(std::string g);
     void send_gcode(const char *gm_code, char parameter, float value);
     void send_command(const char *gcstr);
-    static std::vector<std::string> command_queue;
+    static std::deque<std::string> command_queue;
     PanelScreen *parent;
 };
 


### PR DESCRIPTION
The command_queue can get modified if commands are added during a long-running command, like G28. This invalidates the iterator and results in a crash. Switched to a deck as agreed with Wolfmanjm