### PR TITLE
zgrid: no homing prior probing

### DIFF
--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -447,9 +447,6 @@ void ZGridStrategy::setZoffset(float zval)
 
 bool ZGridStrategy::doProbing(StreamOutput *stream)  // probed calibration
 {
-    // home first
-    this->homexyz();
-
     // deactivate correction during moves
     this->setAdjustFunction(false);
 
@@ -532,11 +529,6 @@ void ZGridStrategy::normalize_grid()
    this->setZoffset(getZhomeoffset() + norm_offset);
 }
 
-void ZGridStrategy::homexyz()
-{
-    Gcode gc("G28", &(StreamOutput::NullStream));
-    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
-}
 
 void ZGridStrategy::move(float *position, float feed)
 {

--- a/src/modules/tools/zprobe/ZGridStrategy.h
+++ b/src/modules/tools/zprobe/ZGridStrategy.h
@@ -21,8 +21,6 @@ public:
     float getZOffset(float x, float y);
 
 private:
-    void homexyz();
-
     void move(float *position, float feed);
     void next_cal(void);
     float getZhomeoffset();


### PR DESCRIPTION
Redundant and dangerously unexpected
- user can issue G28 manually if required

Related to #649.

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>