### PR TITLE
Probe improvements

### DIFF
--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -123,8 +123,8 @@ void ZProbe::on_config_reload(void *argument)
     }
 
     this->probe_height  = THEKERNEL->config->value(zprobe_checksum, probe_height_checksum)->by_default(5.0F)->as_number();
-    this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(5)->as_number(); // feedrate in mm/sec
-    this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->by_default(100)->as_number(); // feedrate in mm/sec
+    this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(1)->as_number(); // feedrate in mm/sec
+    this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->by_default(2)->as_number(); // feedrate in mm/sec
     this->max_z         = THEKERNEL->config->value(gamma_max_checksum)->by_default(500)->as_number(); // maximum zprobe distance
 }
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -37,6 +37,7 @@
 #define debounce_count_checksum  CHECKSUM("debounce_count")
 #define slow_feedrate_checksum   CHECKSUM("slow_feedrate")
 #define fast_feedrate_checksum   CHECKSUM("fast_feedrate")
+#define return_feedrate_checksum CHECKSUM("return_feedrate")
 #define probe_height_checksum    CHECKSUM("probe_height")
 #define gamma_max_checksum       CHECKSUM("gamma_max")
 
@@ -126,6 +127,7 @@ void ZProbe::on_config_reload(void *argument)
     this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(1)->as_number(); // feedrate in mm/sec
     this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->by_default(2)->as_number(); // feedrate in mm/sec
     this->max_z         = THEKERNEL->config->value(gamma_max_checksum)->by_default(500)->as_number(); // maximum zprobe distance
+    this->return_feedrate = THEKERNEL->config->value(zprobe_checksum, return_feedrate_checksum)->by_default(2)->as_number(); // feedrate in mm/sec
 }
 
 bool ZProbe::wait_for_probe(int& steps)
@@ -197,10 +199,7 @@ bool ZProbe::run_probe(int& steps, bool fast)
 bool ZProbe::return_probe(int steps)
 {
     // move probe back to where it was
-    float fr= this->slow_feedrate*2; // nominally twice slow feedrate
-    if(fr > this->fast_feedrate) fr= this->fast_feedrate; // unless that is greater than fast feedrate
-
-    coordinated_move(NAN, NAN, zsteps_to_mm(steps), fr, true);
+    coordinated_move(NAN, NAN, zsteps_to_mm(steps), this->return_feedrate, true);
     this->running = false;
 
     return true;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -288,19 +288,40 @@ void ZProbe::on_gcode_received(void *argument)
 
     } else if(gcode->has_m) {
         // M code processing here
-        if(gcode->m == 119) {
-            int c = this->pin.get();
-            gcode->stream->printf(" Probe: %d", c);
-            gcode->add_nl = true;
-            gcode->mark_as_taken();
+        int c;
+        switch (gcode->m ) {
+            case 119:
+                c = this->pin.get();
+                gcode->stream->printf(" Probe: %d", c);
+                gcode->add_nl = true;
+                gcode->mark_as_taken();
+                break;
 
-        }else {
-            for(auto s : strategies){
-                if(s->handleGcode(gcode)) {
-                    gcode->mark_as_taken();
-                    return;
+            case 500: // save settings
+            case 503: // print settings
+                gcode->stream->printf(";Probe feedrates slow/fast/return (mm/sec):\nM670 S%1.2f F%1.2f R%1.2f\n",
+                    this->slow_feedrate, this->fast_feedrate, this->return_feedrate);
+                gcode->stream->printf(";Probe max_z (mm):\nM670 Z%1.2f\n", this->max_z);
+                gcode->stream->printf(";Probe height (mm):\nM670 H%1.2f\n", this->probe_height);
+                gcode->mark_as_taken();
+                break;
+
+            case 670:
+                if (gcode->has_letter('S')) this->slow_feedrate = gcode->get_value('S');
+                if (gcode->has_letter('F')) this->fast_feedrate = gcode->get_value('F');
+                if (gcode->has_letter('R')) this->return_feedrate = gcode->get_value('R');
+                if (gcode->has_letter('Z')) this->max_z = gcode->get_value('Z');
+                if (gcode->has_letter('H')) this->probe_height = gcode->get_value('H');
+                gcode->mark_as_taken();
+                break;
+
+            default:
+                for(auto s : strategies){
+                    if(s->handleGcode(gcode)) {
+                        gcode->mark_as_taken();
+                        return;
+                    }
                 }
-            }
         }
     }
 }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -200,22 +200,8 @@ bool ZProbe::return_probe(int steps)
     // move probe back to where it was
     float fr= this->slow_feedrate*2; // nominally twice slow feedrate
     if(fr > this->fast_feedrate) fr= this->fast_feedrate; // unless that is greater than fast feedrate
-    this->current_feedrate = fr * Z_STEPS_PER_MM; // feedrate in steps/sec
-    bool dir= steps < 0;
-    steps= abs(steps);
 
-    STEPPER[Z_AXIS]->move(dir, steps, 0);
-    if(this->is_delta) {
-        STEPPER[X_AXIS]->move(dir, steps, 0);
-        STEPPER[Y_AXIS]->move(dir, steps, 0);
-    }
-
-    this->running = true;
-    while(STEPPER[Z_AXIS]->is_moving() || (is_delta && (STEPPER[X_AXIS]->is_moving() || STEPPER[Y_AXIS]->is_moving())) ) {
-        // wait for it to complete
-        THEKERNEL->call_event(ON_IDLE);
-    }
-
+    coordinated_move(NAN, NAN, zsteps_to_mm(steps), fr, true);
     this->running = false;
 
     return true;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -177,14 +177,13 @@ bool ZProbe::run_probe(int& steps, bool fast)
     // Enable the motors
     THEKERNEL->stepper->turn_enable_pins_on();
     this->current_feedrate = (fast ? this->fast_feedrate : this->slow_feedrate) * Z_STEPS_PER_MM; // steps/sec
-    float maxz= this->max_z*2;
 
     // move Z down
-    STEPPER[Z_AXIS]->move(true, maxz * Z_STEPS_PER_MM, 0); // always probes down, no more than 2*maxz
+    STEPPER[Z_AXIS]->move(true, this->max_z * Z_STEPS_PER_MM, 0); // always probes down, no more than max_z
     if(this->is_delta) {
         // for delta need to move all three actuators
-        STEPPER[X_AXIS]->move(true, maxz * STEPS_PER_MM(X_AXIS), 0);
-        STEPPER[Y_AXIS]->move(true, maxz * STEPS_PER_MM(Y_AXIS), 0);
+        STEPPER[X_AXIS]->move(true, this->max_z * STEPS_PER_MM(X_AXIS), 0);
+        STEPPER[Y_AXIS]->move(true, this->max_z * STEPS_PER_MM(Y_AXIS), 0);
     }
 
     // start acceleration processing

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -52,6 +52,7 @@ private:
     volatile float current_feedrate;
     float slow_feedrate;
     float fast_feedrate;
+    float return_feedrate;
     float probe_height;
     float max_z;
     volatile struct {

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -33,6 +33,7 @@ public:
 
     bool wait_for_probe(int& steps);
     bool run_probe(int& steps, bool fast= false);
+    bool run_probe_feed(int& steps, float feedrate);
     bool return_probe(int steps);
     bool doProbeAt(int &steps, float x, float y);
     float probeDistance(float x, float y);


### PR DESCRIPTION
- G30 Fxyz support (custom probing feedrate)
- M670 support for live probe configuration and config-override saving support
- zprobe.return_feedrate config option
- zprobe.max_z is not divided by two
- safe default feedrates for cartesians

```
    ;Probe feedrates slow/fast/return (mm/sec):
    M670 S0.50 F2.00 R2.50
    ;Probe max_z (mm):
    M670 Z200.00
    ;Probe height (mm):
    M670 H2.00
```

New options/commands are not documented nor included in config samples yet - I'll add them to this pull request & wiki when this is reviewed.