### PR TITLE
Changes to laser module PWM config.

### DIFF
--- a/ConfigSamples/AzteegX5Mini.delta/config
+++ b/ConfigSamples/AzteegX5Mini.delta/config
@@ -66,10 +66,16 @@ extruder_en_pin                              0.4              # Pin for extruder
 delta_current                                0.7              # Extruder stepper motor current
 
 # Laser module configuration
-laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is ignored if false.
-#laser_module_pin                             2.7              # this pin will be PWMed to control the laser
-#laser_module_max_power                       0.8              # this is the maximum duty cycle that will be applied to the laser
-#laser_module_tickle_power                    0.0              # this duty cycle will be used for travel moves to keep the laser active without actually burning
+laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
+                                                              # ignored if false.
+#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
+                                                              # can be used since laser requires hardware PWM
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
+#laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
 # Hotend temperature control configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all. All configuration is ignored if false.
@@ -224,5 +230,3 @@ digipot_max_current                          2.4             # max current
 digipot_factor                               106.0           # factor for converting current to digipot value
 
 return_error_on_unhandled_gcode              false            #
-
-

--- a/ConfigSamples/AzteegX5Mini/config
+++ b/ConfigSamples/AzteegX5Mini/config
@@ -61,10 +61,16 @@ extruder_en_pin                              0.4              # Pin for extruder
 delta_current                                1.0              # Extruder stepper motor current
 
 # Laser module configuration
-laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is ignored if false.
-#laser_module_pin                             2.7              # this pin will be PWMed to control the laser
-#laser_module_max_power                       0.8              # this is the maximum duty cycle that will be applied to the laser
-#laser_module_tickle_power                    0.0              # this duty cycle will be used for travel moves to keep the laser active without actually burning
+laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
+                                                              # ignored if false.
+#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
+                                                              # can be used since laser requires hardware PWM
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
+#laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
 # Hotend temperature control configuration
 temperature_control.hotend.enable            true             # Whether to activate this ( "hotend" ) module at all. All configuration is ignored if false.
@@ -242,5 +248,3 @@ digipot_max_current                          2.4             # max current
 digipot_factor                               106.0           # factor for converting current to digipot value
 
 return_error_on_unhandled_gcode              false            #
-
-

--- a/ConfigSamples/FirePick.delta/config
+++ b/ConfigSamples/FirePick.delta/config
@@ -131,11 +131,13 @@ delta_current                                   1.5              # First extrude
 # Laser module configuration
 laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
                                                               # ignored if false.
-#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5
+#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
                                                               # can be used since laser requires hardware PWM
-#laser_module_max_power                       0.8             # this is the maximum duty cycle that will be applied to the laser
-#laser_module_tickle_power                    0.0             # this duty cycle will be used for travel moves to keep the laser
-                                                              # active without actually burning
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
 #laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
 # Hotend temperature control configuration
@@ -323,4 +325,3 @@ network.ip_address                           auto             # use dhcp to get 
 #network.ip_mask                              255.255.255.0    # the ip mask
 #network.ip_gateway                           192.168.3.1      # the gateway address
 #network.mac_override                         xx.xx.xx.xx.xx.xx  # override the mac address, only do this if you have a conflict
-

--- a/ConfigSamples/Smoothieboard.delta/config
+++ b/ConfigSamples/Smoothieboard.delta/config
@@ -112,11 +112,13 @@ delta_current                                1.5              # First extruder s
 # Laser module configuration
 laser_module_enable                          false            # Whether to activate the laser module at all. All configuration is
                                                               # ignored if false.
-#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5
+#laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
                                                               # can be used since laser requires hardware PWM
-#laser_module_max_power                       0.8             # this is the maximum duty cycle that will be applied to the laser
-#laser_module_tickle_power                    0.0             # this duty cycle will be used for travel moves to keep the laser
-                                                              # active without actually burning
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
 #laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
 # Hotend temperature control configuration
@@ -304,4 +306,3 @@ network.ip_address                           auto             # use dhcp to get 
 #network.ip_mask                              255.255.255.0    # the ip mask
 #network.ip_gateway                           192.168.3.1      # the gateway address
 #network.mac_override                         xx.xx.xx.xx.xx.xx  # override the mac address, only do this if you have a conflict
-

--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -115,9 +115,11 @@ laser_module_enable                          false            # Whether to activ
                                                               # ignored if false.
 #laser_module_pin                             2.5             # this pin will be PWMed to control the laser. Only P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26
                                                               # can be used since laser requires hardware PWM
-#laser_module_max_power                       0.8             # this is the maximum duty cycle that will be applied to the laser
-#laser_module_tickle_power                    0.0             # this duty cycle will be used for travel moves to keep the laser
-                                                              # active without actually burning
+#laser_module_maximum_power                   1.0             # this is the maximum duty cycle that will be applied to the laser
+#laser_module_minimum_power                   0.0             # This is a value just below the minimum duty cycle that keeps the laser
+                                                              # active without actually burning.
+#laser_module_default_power                   0.8             # This is the default laser power that will be used for cuts if a power has not been specified.  The value is a scale between
+                                                              # the maximum and minimum power levels specified above
 #laser_module_pwm_period                      20              # this sets the pwm frequency as the period in microseconds
 
 # Hotend temperature control configuration

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -33,8 +33,8 @@ class Laser : public Module{
             bool laser_on:1;     // Laser status
             bool laser_inverting:1; // stores whether the pwm period should be inverted
         };
-        float            laser_max_power; // maximum allowed laser power to be output on the pwm pin
-        float            laser_min_power; // value used to tickle the laser on moves.  Also minimum value for auto-scaling
+        float            laser_maximum_power; // maximum allowed laser power to be output on the pwm pin
+        float            laser_minimum_power; // value used to tickle the laser on moves.  Also minimum value for auto-scaling
         float            laser_power;     // current laser power
 };
 

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -34,7 +34,8 @@ class Laser : public Module{
             bool laser_inverting:1; // stores whether the pwm period should be inverted
         };
         float            laser_max_power; // maximum allowed laser power to be output on the pwm pin
-        float            laser_tickle_power; // value used to tickle the laser on moves
+        float            laser_min_power; // value used to tickle the laser on moves.  Also minimum value for auto-scaling
+        float            laser_power;     // current laser power
 };
 
 #endif


### PR DESCRIPTION
This changes the config to work as described in issue #685.  It makes
the laser_module_max_power work as expected / documented, introduces
a minimum power setting, and scales the output between the two.

It should be backwards-compatible with existing configs, but I've not been
able to test it on a live machine yet.  Hopefully I'll be able to get it on a scope 
over the next couple of days to confirm operation.