### PR TITLE
Set the ADC clock div to 8 so we actually get 1000 samples/sec on the…

### DIFF
--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -19,7 +19,7 @@ using namespace std;
 // TODO : Having the same name is confusing, should change that
 
 Adc::Adc(){
-    this->adc = new ADC(1000, 1);
+    this->adc = new ADC(1000, 8);
 }
 
 // Enables ADC on a given pin

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -73,7 +73,7 @@ void Switch::on_config_reload(void *argument)
     this->output_on_command =    THEKERNEL->config->value(switch_checksum, this->name_checksum, output_on_command_checksum )->by_default("")->as_string();
     this->output_off_command =   THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->by_default("")->as_string();
     this->switch_state =         THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->by_default(false)->as_bool();
-    string type =                THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("")->as_string();
+    string type =                THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("pwm")->as_string();
 
     if(type == "pwm"){
         this->output_type= SIGMADELTA;


### PR DESCRIPTION
… ADC instead of 6127 samples/sec

Anyone see why not? We were running an ADC rate of around 6127, now it is 1000 as specified.