### PR TITLE
Add adc oversampling and filtering and averaging

### DIFF
--- a/src/libs/ADC/adc.cpp
+++ b/src/libs/ADC/adc.cpp
@@ -40,7 +40,7 @@ ADC::ADC(int sample_rate, int cclk_div)
             LPC_SC->PCLKSEL0 |= 0x3 << 24;
             break;
         default:
-            printf("Warning: ADC CCLK clock divider must be 1, 2, 4 or 8. %u supplied.\n",
+            printf("ADC Warning: ADC CCLK clock divider must be 1, 2, 4 or 8. %u supplied.\n",
                 cclk_div);
             printf("Defaulting to 1.\n");
             LPC_SC->PCLKSEL0 |= 0x1 << 24;
@@ -50,21 +50,20 @@ ADC::ADC(int sample_rate, int cclk_div)
     clock_div=pclk / adc_clk_freq;
 
     if (clock_div > 0xFF) {
-        //printf("Warning: Clock division is %u which is above 255 limit. Re-Setting at limit.\n",
-        //    clock_div);
+        printf("ADC Warning: Clock division is %u which is above 255 limit. Re-Setting at limit.\n", clock_div);
         clock_div=0xFF;
     }
     if (clock_div == 0) {
-        printf("Warning: Clock division is 0. Re-Setting to 1.\n");
+        printf("ADC Warning: Clock division is 0. Re-Setting to 1.\n");
         clock_div=1;
     }
 
     _adc_clk_freq=pclk / clock_div;
     if (_adc_clk_freq > MAX_ADC_CLOCK) {
-        printf("Warning: Actual ADC sample rate of %u which is above %u limit\n",
+        printf("ADC Warning: Actual ADC sample rate of %u which is above %u limit\n",
             _adc_clk_freq / CLKS_PER_SAMPLE, MAX_ADC_CLOCK / CLKS_PER_SAMPLE);
         while ((pclk / max_div) > MAX_ADC_CLOCK) max_div++;
-        printf("Maximum recommended sample rate is %u\n", (pclk / max_div) / CLKS_PER_SAMPLE);
+        printf("ADC Warning: Maximum recommended sample rate is %u\n", (pclk / max_div) / CLKS_PER_SAMPLE);
     }
 
     LPC_ADC->ADCR =
@@ -296,7 +295,7 @@ void ADC::select(PinName pin) {
 void ADC::burst(int state) {
     if ((state & 1) == 1) {
         if (startmode(0) != 0)
-            fprintf(stderr, "Warning. startmode is %u. Must be 0 for burst mode.\n", startmode(0));
+            fprintf(stderr, "ADC Warning. startmode is %u. Must be 0 for burst mode.\n", startmode(0));
         LPC_ADC->ADCR |= (1 << 16);
     }
     else

--- a/src/libs/ADC/adc.cpp
+++ b/src/libs/ADC/adc.cpp
@@ -5,6 +5,7 @@
 #include "mbed.h"
 #include "adc.h"
 
+using namespace mbed;
 
 ADC *ADC::instance;
 
@@ -151,7 +152,7 @@ int ADC::_pin_to_channel(PinName pin) {
 
 PinName ADC::channel_to_pin(int chan) {
     const PinName pin[8]={p15, p16, p17, p18, p19, p20, p15, p15};
-    
+
     if ((chan < 0) || (chan > 5))
         fprintf(stderr, "ADC channel %u is outside range available to MBED pins.\n", chan);
     return(pin[chan & 0x07]);
@@ -160,7 +161,7 @@ PinName ADC::channel_to_pin(int chan) {
 
 int ADC::channel_to_pin_number(int chan) {
     const int pin[8]={15, 16, 17, 18, 19, 20, 0, 0};
-    
+
     if ((chan < 0) || (chan > 5))
         fprintf(stderr, "ADC channel %u is outside range available to MBED pins.\n", chan);
     return(pin[chan & 0x07]);
@@ -275,7 +276,7 @@ void ADC::setup(PinName pin, int state) {
 //Return channel enabled/disabled state
 int ADC::setup(PinName pin) {
     int chan;
-    
+
     chan = _pin_to_channel(pin);
     return((LPC_ADC->ADCR & (1 << chan)) >> chan);
 }
@@ -283,7 +284,7 @@ int ADC::setup(PinName pin) {
 //Select channel already setup
 void ADC::select(PinName pin) {
     int chan;
-    
+
     //Only one channel can be selected at a time if not in burst mode
     if (!burst()) LPC_ADC->ADCR &= ~0xFF;
     //Select channel
@@ -309,7 +310,7 @@ int  ADC::burst(void) {
 //Set startmode and edge
 void ADC::startmode(int mode, int edge) {
     int lpc_adc_temp;
-    
+
     //Reset start mode and edge bit,
     lpc_adc_temp = LPC_ADC->ADCR & ~(0x0F << 24);
     //Write with new values
@@ -337,7 +338,7 @@ void ADC::start(void) {
 //Set interrupt enable/disable for pin to state
 void ADC::interrupt_state(PinName pin, int state) {
     int chan;
-    
+
     chan = _pin_to_channel(pin);
     if (state == 1) {
         LPC_ADC->ADINTEN &= ~0x100;
@@ -355,7 +356,7 @@ void ADC::interrupt_state(PinName pin, int state) {
 //Return enable/disable state of interrupt for pin
 int ADC::interrupt_state(PinName pin) {
     int chan;
-        
+
     chan = _pin_to_channel(pin);
     return((LPC_ADC->ADINTEN >> chan) & 0x01);
 }
@@ -378,7 +379,7 @@ void ADC::detach(void) {
 //Append interrupt handler for pin to function isr
 void ADC::append(PinName pin, void(*fptr)(uint32_t value)) {
     int chan;
-        
+
     chan = _pin_to_channel(pin);
     _adc_isr[chan] = fptr;
 }
@@ -386,7 +387,7 @@ void ADC::append(PinName pin, void(*fptr)(uint32_t value)) {
 //Append interrupt handler for pin to function isr
 void ADC::unappend(PinName pin) {
     int chan;
-        
+
     chan = _pin_to_channel(pin);
     _adc_isr[chan] = NULL;
 }
@@ -402,13 +403,13 @@ void ADC::unappend() {
 }
 
 //Set ADC offset
-void offset(int offset) {
+void ADC::offset(int offset) {
     LPC_ADC->ADTRM &= ~(0x07 << 4);
     LPC_ADC->ADTRM |= (offset & 0x07) << 4;
 }
 
 //Return current ADC offset
-int offset(void) {
+int ADC::offset(void) {
     return((LPC_ADC->ADTRM >> 4) & 0x07);
 }
 

--- a/src/libs/ADC/adc.h
+++ b/src/libs/ADC/adc.h
@@ -5,12 +5,13 @@
 
 #ifndef MBED_ADC_H
 #define MBED_ADC_H
- 
+
 #include "PinNames.h" // mbed.h lib
 #define XTAL_FREQ       12000000
 #define MAX_ADC_CLOCK   13000000
 #define CLKS_PER_SAMPLE 64
 
+namespace mbed {
 class ADC {
 public:
 
@@ -54,16 +55,16 @@ public:
     1 - Falling edge
     */
     void startmode(int mode, int edge);
-    
+
     //Return startmode state according to mode_edge=0: mode and mode_edge=1: edge
     int startmode(int mode_edge);
-    
+
     //Start ADC conversion
     void start(void);
 
     //Set interrupt enable/disable for pin to state
     void interrupt_state(PinName pin, int state);
-    
+
     //Return enable/disable state of interrupt for pin
     int interrupt_state(PinName pin);
 
@@ -87,7 +88,7 @@ public:
 
     //Set ADC offset to a value 0-7
     void offset(int offset);
-    
+
     //Return current ADC offset
     int offset(void);
 
@@ -96,13 +97,13 @@ public:
 
     //Return DONE flag of ADC on pin
     int done(PinName pin);
-    
+
     //Return OVERRUN flag of ADC on pin
     int overrun(PinName pin);
 
     //Return actual ADC clock
     int actual_adc_clock(void);
-    
+
     //Return actual maximum sample rate
     int actual_sample_rate(void);
 
@@ -112,20 +113,21 @@ public:
     //Return pin number of ADC channel
     int channel_to_pin_number(int chan);
 
+    int _pin_to_channel(PinName pin);
 
 private:
-    int _pin_to_channel(PinName pin);
     uint32_t _data_of_pin(PinName pin);
 
     int _adc_clk_freq;
     void adcisr(void);
     static void _adcisr(void);
     static ADC *instance;
-    
+
     uint32_t _adc_data[8];
     void(*_adc_isr[8])(uint32_t value);
     void(*_adc_g_isr)(int chan, uint32_t value);
     void(*_adc_m_isr)(void);
 };
+}
 
 #endif

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -11,45 +11,109 @@
 #include "libs/Pin.h"
 #include "libs/ADC/adc.h"
 #include "libs/Pin.h"
+#include "libs/Median.h"
 
+#include <cstring>
+#include <algorithm>
 
-using namespace std;
-#include <vector>
 // This is an interface to the mbed.org ADC library you can find in libs/ADC/adc.h
 // TODO : Having the same name is confusing, should change that
 
-Adc::Adc(){
-    this->adc = new ADC(1000, 8);
+Adc *Adc::instance;
+
+static void sample_isr(int chan, uint32_t value)
+{
+    Adc::instance->new_sample(chan, value);
 }
+
+Adc::Adc()
+{
+    instance = this;
+    this->adc = new mbed::ADC(1000, 8);
+    this->adc->append(sample_isr);
+}
+
+/*
+LPC176x ADC channels and pins
+
+Adc Channel Port Pin    Pin Functions                       Associated PINSEL Register
+AD0 P0.23   0-GPIO,     1-AD0[0], 2-I2SRX_CLK, 3-CAP3[0]    14,15 bits of PINSEL1
+AD1 P0.24   0-GPIO,     1-AD0[1], 2-I2SRX_WS, 3-CAP3[1]     16,17 bits of PINSEL1
+AD2 P0.25   0-GPIO,     1-AD0[2], 2-I2SRX_SDA, 3-TXD3       18,19 bits of PINSEL1
+AD3 P0.26   0-GPIO,     1-AD0[3], 2-AOUT, 3-RXD3            20,21 bits of PINSEL1
+AD4 P1.30   0-GPIO,     1-VBUS, 2- , 3-AD0[4]               28,29 bits of PINSEL3
+AD5 P1.31   0-GPIO,     1-SCK1, 2- , 3-AD0[5]               30,31 bits of PINSEL3
+AD6 P0.3    0-GPIO,     1-RXD0, 2-AD0[6], 3-                6,7 bits of PINSEL0
+AD7 P0.2    0-GPIO,     1-TXD0, 2-AD0[7], 3-                4,5 bits of PINSEL0
+*/
 
 // Enables ADC on a given pin
-void Adc::enable_pin(Pin* pin){
+void Adc::enable_pin(Pin *pin)
+{
     PinName pin_name = this->_pin_to_pinname(pin);
+    int channel = adc->_pin_to_channel(pin_name);
+    memset(sample_buffers[channel], 0, sizeof(sample_buffers[0]));
+
     this->adc->burst(1);
-    this->adc->setup(pin_name,1);
-    this->adc->interrupt_state(pin_name,1);
+    this->adc->setup(pin_name, 1);
+    this->adc->interrupt_state(pin_name, 1);
 }
 
-// Read the last value ( burst mode ) on a given pin
-unsigned int Adc::read(Pin* pin){
-    return this->adc->read(this->_pin_to_pinname(pin));
+// Keeps the last 8 values for each channel
+// This is called in an ISR, so sample_buffers needs to be accessed atomically
+void Adc::new_sample(int chan, uint32_t value)
+{
+    // Shuffle down and add new value to the end
+    if(chan < num_channels) {
+        memmove(&sample_buffers[chan][0], &sample_buffers[chan][1], sizeof(sample_buffers[0]) - sizeof(sample_buffers[0][0]));
+        sample_buffers[chan][num_samples - 1] = (value >> 4) & 0xFFF; // the 12 bit ADC reading
+    }
+}
+
+//#define USE_MEDIAN_FILTER
+// Read the filtered value ( burst mode ) on a given pin
+unsigned int Adc::read(Pin *pin)
+{
+    PinName p = this->_pin_to_pinname(pin);
+    int channel = adc->_pin_to_channel(p);
+
+    uint16_t median_buffer[num_samples];
+    // needs atomic access TODO maybe be able to use std::atomic here
+    __disable_irq();
+    memcpy(median_buffer, sample_buffers[channel], sizeof(median_buffer));
+    __enable_irq();
+
+#ifdef USE_MEDIAN_FILTER
+    // returns the median value of the last 8 samples
+    return median_buffer[quick_median(median_buffer, num_samples)];
+
+#else
+    // sort the 8 readings and return the average of the middle 4
+    std::sort(median_buffer, median_buffer + num_samples);
+    int sum = 0;
+    for (int i = num_samples / 4; i < (num_samples - (num_samples / 4)); ++i) {
+        sum += median_buffer[i];
+    }
+    return sum / (num_samples / 2);
+#endif
 }
 
 // Convert a smoothie Pin into a mBed Pin
-PinName Adc::_pin_to_pinname(Pin* pin){
-    if( pin->port == LPC_GPIO0 && pin->pin == 23 ){
+PinName Adc::_pin_to_pinname(Pin *pin)
+{
+    if( pin->port == LPC_GPIO0 && pin->pin == 23 ) {
         return p15;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 24 ){
+    } else if( pin->port == LPC_GPIO0 && pin->pin == 24 ) {
         return p16;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 25 ){
+    } else if( pin->port == LPC_GPIO0 && pin->pin == 25 ) {
         return p17;
-    }else if( pin->port == LPC_GPIO0 && pin->pin == 26 ){
+    } else if( pin->port == LPC_GPIO0 && pin->pin == 26 ) {
         return p18;
-    }else if( pin->port == LPC_GPIO1 && pin->pin == 30 ){
+    } else if( pin->port == LPC_GPIO1 && pin->pin == 30 ) {
         return p19;
-    }else if( pin->port == LPC_GPIO1 && pin->pin == 31 ){
+    } else if( pin->port == LPC_GPIO1 && pin->pin == 31 ) {
         return p20;
-    }else{
+    } else {
         //TODO: Error
         return NC;
     }

--- a/src/libs/Adc.cpp
+++ b/src/libs/Adc.cpp
@@ -16,6 +16,8 @@
 #include <cstring>
 #include <algorithm>
 
+#include "mbed.h"
+
 // This is an interface to the mbed.org ADC library you can find in libs/ADC/adc.h
 // TODO : Having the same name is confusing, should change that
 
@@ -78,7 +80,7 @@ unsigned int Adc::read(Pin *pin)
     int channel = adc->_pin_to_channel(p);
 
     uint16_t median_buffer[num_samples];
-    // needs atomic access TODO maybe be able to use std::atomic here
+    // needs atomic access TODO maybe be able to use std::atomic here or some lockless mutex
     __disable_irq();
     memcpy(median_buffer, sample_buffers[channel], sizeof(median_buffer));
     __enable_irq();

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -11,20 +11,31 @@
 #define ADC_H
 
 #include "PinNames.h" // mbed.h lib
-#include "libs/ADC/adc.h"
 
 class Pin;
+namespace mbed {
+    class ADC;
+}
 
-class Adc {
-    public:
-        Adc();
-        void enable_pin(Pin* pin);
-        unsigned int read(Pin* pin);
-        PinName _pin_to_pinname(Pin* pin);
+class Adc
+{
+public:
+    Adc();
+    void enable_pin(Pin *pin);
+    unsigned int read(Pin *pin);
 
-        ADC* adc;
+    static Adc *instance;
+    void new_sample(int chan, uint32_t value);
+
+private:
+    PinName _pin_to_pinname(Pin *pin);
+    mbed::ADC *adc;
+
+
+    static const int num_channels= 6;
+    static const int num_samples= 8;
+    // buffers storing the last num_samples readings for each channel
+    uint16_t sample_buffers[num_channels][num_samples];
 };
-
-
 
 #endif

--- a/src/libs/Adc.h
+++ b/src/libs/Adc.h
@@ -12,10 +12,16 @@
 
 #include "PinNames.h" // mbed.h lib
 
+#include <cmath>
+
 class Pin;
 namespace mbed {
     class ADC;
 }
+
+// define how many bits of extra resolution required
+// 2 bits means the 12bit ADC is 14 bits of resolution
+#define OVERSAMPLE 2
 
 class Adc
 {
@@ -26,14 +32,24 @@ public:
 
     static Adc *instance;
     void new_sample(int chan, uint32_t value);
+    // return the maximum ADC value, base is 12bits 4095.
+#ifdef OVERSAMPLE
+    int get_max_value() const { return 4095 << OVERSAMPLE;}
+#else
+    int get_max_value() const { return 4095;}
+#endif
 
 private:
     PinName _pin_to_pinname(Pin *pin);
     mbed::ADC *adc;
 
-
     static const int num_channels= 6;
+#ifdef OVERSAMPLE
+    // we need 4^n sample to oversample and we get double that to filter out spikes
+    static const int num_samples= powf(4, OVERSAMPLE)*2;
+#else
     static const int num_samples= 8;
+#endif
     // buffers storing the last num_samples readings for each channel
     uint16_t sample_buffers[num_channels][num_samples];
 };

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -243,6 +243,8 @@ float Thermistor::adc_value_to_temperature(int adc_value)
     float r = r2 / ((4095.0F / adc_value) - 1.0F);
     if (r1 > 0.0F) r = (r1 * r) / (r1 - r);
 
+    if(r > this->r0 * 8) return infinityf(); // 800k is probably open circuit
+
     float t;
     if(this->use_steinhart_hart) {
         float l = logf(r);
@@ -257,18 +259,8 @@ float Thermistor::adc_value_to_temperature(int adc_value)
 
 int Thermistor::new_thermistor_reading()
 {
-    int last_raw = THEKERNEL->adc->read(&thermistor_pin);
-    if (queue.size() >= queue.capacity()) {
-        uint16_t l;
-        queue.pop_front(l);
-    }
-    uint16_t r = last_raw;
-    queue.push_back(r);
-    uint16_t median_buffer[queue.size()];
-    for (int i=0; i<queue.size(); i++)
-      median_buffer[i] = *queue.get_ref(i);
-    uint16_t m = median_buffer[quick_median(median_buffer, queue.size())];
-    return m;
+    // filtering now done in ADC
+    return THEKERNEL->adc->read(&thermistor_pin);
 }
 
 bool Thermistor::set_optional(const sensor_options_t& options) {

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -217,8 +217,10 @@ void Thermistor::get_raw()
     }
 
     int adc_value= new_thermistor_reading();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
+
      // resistance of the thermistor in ohms
-    float r = r2 / ((4095.0F / adc_value) - 1.0F);
+    float r = r2 / (((float)max_adc_value / adc_value) - 1.0F);
     if (r1 > 0.0F) r = (r1 * r) / (r1 - r);
 
     THEKERNEL->streams->printf("adc= %d, resistance= %f\n", adc_value, r);
@@ -234,13 +236,14 @@ void Thermistor::get_raw()
     }
 }
 
-float Thermistor::adc_value_to_temperature(int adc_value)
+float Thermistor::adc_value_to_temperature(uint32_t adc_value)
 {
-    if ((adc_value >= 4095) || (adc_value == 0))
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
+    if ((adc_value >= max_adc_value) || (adc_value == 0))
         return infinityf();
 
     // resistance of the thermistor in ohms
-    float r = r2 / ((4095.0F / adc_value) - 1.0F);
+    float r = r2 / (((float)max_adc_value / adc_value) - 1.0F);
     if (r1 > 0.0F) r = (r1 * r) / (r1 - r);
 
     if(r > this->r0 * 8) return infinityf(); // 800k is probably open circuit

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -236,7 +236,7 @@ void Thermistor::get_raw()
 
 float Thermistor::adc_value_to_temperature(int adc_value)
 {
-    if ((adc_value == 4095) || (adc_value == 0))
+    if ((adc_value >= 4095) || (adc_value == 0))
         return infinityf();
 
     // resistance of the thermistor in ohms

--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -33,7 +33,7 @@ class Thermistor : public TempSensor
 
     private:
         int new_thermistor_reading();
-        float adc_value_to_temperature(int adc_value);
+        float adc_value_to_temperature(uint32_t adc_value);
         void calc_jk();
 
         // Thermistor computation settings using beta, not used if using Steinhart-Hart

--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -60,8 +60,6 @@ class Thermistor : public TempSensor
 
         Pin  thermistor_pin;
 
-        RingBuffer<uint16_t,QUEUE_LEN> queue;  // Queue of readings
-
         struct {
             bool bad_config:1;
             bool use_steinhart_hart:1;


### PR DESCRIPTION
Refactored ADC to handle the filtering and averaging etc, removed from Thermistor.
Added better checks in Thermistor for open circuit thermistor, not just max ADC value.
Added oversampling to increase ADC resolution by 2 bits to 14bits.
Added better filtering for raw ADC values before they get oversampled.
Average last 4 oversampled readings when thermistor reads them, this flattens out the rate of change and improves the PID performance.
Removed the race condition on original ADC reads that could cause bad ADC values to randomly appear.

NOTE rerunning PID autotune is recommended after this change.