### PR TITLE
Feature/m305 set predefined thermistor

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -234,7 +234,7 @@ void TemperatureControl::on_gcode_received(void *argument)
                 if(sensor->get_optional(options)) {
                     for(auto &i : options) {
                         // foreach optional value
-                        gcode->stream->printf("%s(S%d): %c%1.18f\n", this->designator.c_str(), this->pool_index, i.first, i.second);
+                        gcode->stream->printf("%s(S%d): %c %1.18f\n", this->designator.c_str(), this->pool_index, i.first, i.second);
                     }
                 }
             }

--- a/src/modules/tools/temperaturecontrol/Thermistor.cpp
+++ b/src/modules/tools/temperaturecontrol/Thermistor.cpp
@@ -321,7 +321,7 @@ bool Thermistor::set_optional(const sensor_options_t& options) {
             case 'I': this->c1= i.second; define_shh++; break;
             case 'J': this->c2= i.second; define_shh++; break;
             case 'K': this->c3= i.second; define_shh++; break;
-            case 'P': predefined= i.second; break;
+            case 'P': predefined= roundf(i.second); break;
         }
     }
 

--- a/src/modules/tools/temperaturecontrol/Thermistor.h
+++ b/src/modules/tools/temperaturecontrol/Thermistor.h
@@ -65,6 +65,7 @@ class Thermistor : public TempSensor
             bool bad_config:1;
             bool use_steinhart_hart:1;
         };
+        uint8_t thermistor_number;
 };
 
 #endif

--- a/src/modules/tools/temperaturecontrol/predefined_thermistors.h
+++ b/src/modules/tools/temperaturecontrol/predefined_thermistors.h
@@ -5,6 +5,8 @@ typedef struct {
         float beta, r0, t0;
 } const thermistor_beta_table_t;
 
+// NOTE the order of these tables must NOT be changed as the index can be used in M305 to set the prefined thermistor to use
+
 static const thermistor_beta_table_t predefined_thermistors_beta[] {
     // name,            r1,  r2,   beta,    r0,        t0
     {"EPCOS100K",       0,   4700, 4066.0F, 100000.0F, 25.0F}, // B57540G0104F000


### PR DESCRIPTION
M305 S0 P1 would set the thermistor to the predefined thermistor 1 which is EPCOS
M305 on its own will show a table of predefined thermistors and index, also a bunch of other useful information
M500 will now save the predefined thermistor being used if M305 S0 Pn has been specified.
M305 S0 by itself will clear that and not save the thermistor values, defaulting to the config on next reset.