### PR TITLE
Generic calibration strategy

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -611,7 +611,7 @@ void Robot::reset_axis_position(float position, int axis)
 {
     this->last_milestone[axis] = position;
     for (int i = 0; i < 3; i++)
-        this->transformed_last_milestone[i] = this->last_milestone[axis];
+        this->transformed_last_milestone[i] = this->last_milestone[i];
 
     // check function pointer and call if set to transform the target to compensate for bed
     if(compensationTransform) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -245,6 +245,7 @@ void Robot::on_config_reload(void *argument)
     // so the first move can be correct if homing is not performed
     float actuator_pos[3];
     arm_solution->cartesian_to_actuator(last_milestone, actuator_pos);
+    // TODO: transformed_milestone???
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 
@@ -593,8 +594,14 @@ void Robot::reset_axis_position(float x, float y, float z)
     this->transformed_last_milestone[Y_AXIS] = y;
     this->transformed_last_milestone[Z_AXIS] = z;
 
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(transformed_last_milestone);
+    }
+
     float actuator_pos[3];
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
@@ -603,10 +610,17 @@ void Robot::reset_axis_position(float x, float y, float z)
 void Robot::reset_axis_position(float position, int axis)
 {
     this->last_milestone[axis] = position;
-    this->transformed_last_milestone[axis] = position;
+    for (int i = 0; i < 3; i++)
+        this->transformed_last_milestone[i] = this->last_milestone[axis];
+
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(transformed_last_milestone);
+    }
 
     float actuator_pos[3];
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
 
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
@@ -616,11 +630,14 @@ void Robot::reset_axis_position(float position, int axis)
 void Robot::reset_position_from_current_actuator_position()
 {
     float actuator_pos[]= {actuators[X_AXIS]->get_current_position(), actuators[Y_AXIS]->get_current_position(), actuators[Z_AXIS]->get_current_position()};
-    arm_solution->actuator_to_cartesian(actuator_pos, this->last_milestone);
-    memcpy(this->transformed_last_milestone, this->last_milestone, sizeof(this->transformed_last_milestone));
+    arm_solution->actuator_to_cartesian(actuator_pos, this->transformed_last_milestone);
+    memcpy(this->last_milestone, this->transformed_last_milestone, sizeof(this->transformed_last_milestone));
+    if (compensationTransformInverse) {
+        compensationTransformInverse(last_milestone);
+    }
 
     // now reset actuator correctly, NOTE this may lose a little precision
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -637,7 +637,7 @@ void Robot::reset_position_from_current_actuator_position()
     }
 
     // now reset actuator correctly, NOTE this may lose a little precision
-    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
+    //arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -47,6 +47,7 @@ class Robot : public Module {
 
         // set by a leveling strategy to transform the target of a move according to the current plan
         std::function<void(float[3])> compensationTransform;
+        std::function<void(float[3])> compensationTransformInverse;
 
         struct {
             bool inch_mode:1;                                 // true for inch mode, false for millimeter mode ( default )

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -659,6 +659,10 @@ void Endstops::on_gcode_received(void *argument)
 
             if(home_all) {
                 // for deltas this may be important rather than setting each individually
+                float actuators_before[3];
+                for (int i = 0; i < 3; i++) {
+                    actuators_before[i] = THEKERNEL->robot->actuators[i]->get_current_position();
+                }
 
                 // Here's where we would have been if the endstops were perfectly trimmed
                 float ideal_position[3] = {
@@ -688,6 +692,15 @@ void Endstops::on_gcode_received(void *argument)
                     // Reset the actuator positions to correspond our real position
                     THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
                 }
+
+                float actuators_after[3];
+                for (int i = 0; i < 3; i++) {
+                    actuators_after[i] = THEKERNEL->robot->actuators[i]->get_current_position();
+                }
+                gcode->stream->printf("Adjusting actuator positions (mm): %.5f %.5f %.5f\n",
+                                      actuators_after[0] - actuators_before[0],
+                                      actuators_after[1] - actuators_before[1],
+                                      actuators_after[2] - actuators_before[2]);
             } else {
                 // Zero the ax(i/e)s position, add in the home offset
                 for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -857,6 +857,9 @@ void Endstops::on_get_public_data(void* argument){
     }else if(pdr->second_element_is(home_offset_checksum)) {
         pdr->set_data_ptr(&this->home_offset);
         pdr->set_taken();
+    }else if(pdr->second_element_is(homing_position_checksum)) {
+        pdr->set_data_ptr(&this->homing_position);
+        pdr->set_taken();
     }
 }
 

--- a/src/modules/tools/endstops/EndstopsPublicAccess.h
+++ b/src/modules/tools/endstops/EndstopsPublicAccess.h
@@ -2,8 +2,9 @@
 #define __ENDSTOPSPUBLICACCESS_H_
 
 // addresses used for public data access
-#define endstops_checksum    CHECKSUM("endstop")
-#define trim_checksum        CHECKSUM("trim")
-#define home_offset_checksum CHECKSUM("home_offset")
+#define endstops_checksum        CHECKSUM("endstop")
+#define trim_checksum            CHECKSUM("trim")
+#define home_offset_checksum     CHECKSUM("home_offset")
+#define homing_position_checksum CHECKSUM("homing_position")
 
 #endif

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -269,7 +269,7 @@ bool CalibrationStrategy::probe_symmetric(int n, int repeats, float actuator_pos
         n--;
     }
     for (int i = 0; i < n; i++) {
-        float angle = M_PI*2*i/n;
+        float angle = M_PI/2 + M_PI*2*i/n;
 
         float x = probe_radius * cos(angle);
         float y = probe_radius * sin(angle);

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -35,11 +35,11 @@ bool CalibrationStrategy::update_parameter(char parameter, float delta) {
 
 void CalibrationStrategy::update_compensation_transformation()
 {
-    if (plane_p == 0 && plane_q == 0 && plane_offset == 0) {
+    if (plane_u == 0 && plane_v == 0 && plane_offset == 0) {
         THEKERNEL->robot->compensationTransform = nullptr;
         inverse_r[0] = 0; inverse_r[1] = 0; inverse_r[2] = 1;
     } else
-        THEKERNEL->robot->compensationTransform = compute_rotation_transform(plane_p, plane_q, plane_offset, inverse_r);
+        THEKERNEL->robot->compensationTransform = compute_rotation_transform(plane_u, plane_v, plane_offset, inverse_r);
 }
 
 bool CalibrationStrategy::handleGcode(Gcode *gcode)
@@ -56,7 +56,7 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
             int repeats = 1;
 
             for (auto &v : args) {
-                if (v.first == 'N')
+                if (v.first == 'P')
                     samples = int(v.second);
                 else if (v.first == 'O')
                     repeats = int(v.second);
@@ -120,11 +120,11 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
         // handle mcodes
         if(gcode->m == 500 || gcode->m == 503) { // M500 save, M503 display
             gcode->stream->printf(";Plane tilt:\n");
-            gcode->stream->printf("M567 P%.5f Q%.5f W%.5f\n", plane_p, plane_q, plane_offset);
+            gcode->stream->printf("M567 U%.5f V%.5f W%.5f\n", plane_u, plane_v, plane_offset);
             return true;
         } else if(gcode->m == 567) {
-            if (gcode->has_letter('P')) plane_p = gcode->get_value('P');
-            if (gcode->has_letter('Q')) plane_q = gcode->get_value('Q');
+            if (gcode->has_letter('U')) plane_u = gcode->get_value('U');
+            if (gcode->has_letter('V')) plane_v = gcode->get_value('V');
             if (gcode->has_letter('W')) plane_offset = gcode->get_value('W');
 
             update_compensation_transformation();
@@ -537,9 +537,9 @@ std::function<void(float[3])> compute_rotation_transform(float p, float q, float
 
 
 bool CalibrationStrategy::set_parameter(char parameter, float value) {
-    if (parameter == 'P' || parameter == 'Q' || parameter == 'W') {
-        if (parameter == 'P') plane_p = value;
-        if (parameter == 'Q') plane_q = value;
+    if (parameter == 'U' || parameter == 'V' || parameter == 'W') {
+        if (parameter == 'U') plane_u = value;
+        if (parameter == 'V') plane_v = value;
         if (parameter == 'W') plane_offset = value;
 
         update_compensation_transformation();
@@ -570,8 +570,8 @@ bool CalibrationStrategy::set_parameter(char parameter, float value) {
 
 
 float CalibrationStrategy::get_parameter(char parameter) {
-    if (parameter == 'P') return plane_p;
-    if (parameter == 'Q') return plane_q;
+    if (parameter == 'U') return plane_u;
+    if (parameter == 'V') return plane_v;
     if (parameter == 'W') return plane_offset;
 
     int endstop = endstop_parameter_index(parameter);

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -431,7 +431,7 @@ again:
         float new_error = compute_model_rms_error(actuator_positions);
         print_state();
         stream->printf("RMS error after iteration %d: %.3f mm", iteration+1, new_error);
-        if (new_error > last_error) {
+        if (!(new_error < last_error)) {
             stream->printf(" -> rolling back\n");
             restore();
             // increase damping

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -587,6 +587,8 @@ std::pair<std::function<void(float[3])>,std::function<void(float[3])>> compute_r
 
 
 bool CalibrationStrategy::set_parameter(char parameter, float value) {
+    if (isnan(value)) return false;
+
     if (parameter == 'U' || parameter == 'V' || parameter == 'W') {
         if (parameter == 'U') plane_u = value;
         if (parameter == 'V') plane_v = value;
@@ -633,8 +635,10 @@ float CalibrationStrategy::get_parameter(char parameter) {
         }
     } else {
         BaseSolution::arm_options_t options;
-        if(THEKERNEL->robot->arm_solution->get_optional(options)) {
-            return options[parameter];
+        if(THEKERNEL->robot->arm_solution->get_optional(options, true /* force_all */)) {
+            auto f = options.find(parameter);
+            if (f != options.end())
+                return f->second;
         }
     }
     return NAN;

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -283,9 +283,6 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<V3> const& actuator_positi
     JTr.resize(m);
     for (auto &v : JTr) v = 0;
 
-    // step length for central difference approximation
-    // we assume all model parameters are approximately 0 with a scale of ~mm
-    float h = 1e-3;
 
     // iterating over residual terms rather than parameters first saves
     // a lot of memory at the cost of many more get/set_value calls
@@ -294,6 +291,8 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<V3> const& actuator_positi
         // compute numerically derivative of error w.r.t. parameters
         for (int i = 0; i < m; i++) {
             float x0 = get_parameter(parameters[i]);
+            // step length for central difference approximation
+            float h = std::max(fabsf(x0) * 1e-4, 1e-3);
 
             //compute central difference (f(x+h) - f(x-h)) / (2*h)
             set_parameter(parameters[i], x0 + h);

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -1,0 +1,448 @@
+// Generic calibration strategy based on nonlinear optimization
+//
+// Copyright (c) Oskar Linde 2015
+//
+// Licence: GPL v2
+
+#include "CalibrationStrategy.h"
+#include "Kernel.h"
+#include "Config.h"
+#include "Robot.h"
+#include "StreamOutputPool.h"
+#include "Gcode.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "PublicDataRequest.h"
+#include "EndstopsPublicAccess.h"
+#include "PublicData.h"
+#include "Conveyor.h"
+#include "ZProbe.h"
+#include "BaseSolution.h"
+#include "StepperMotor.h"
+#include "Vector3.h"
+#include <cstddef>
+#include <fastmath.h>
+
+#define radius_checksum       CHECKSUM("radius")
+#define delta_calibration_strategy_checksum CHECKSUM("delta-calibration")
+
+float trim[3]; // cache
+
+int endstop_parameter_index(char parameter);
+bool set_parameter(char parameter, float value);
+float get_parameter(char parameter);
+
+bool update_parameter(char parameter, float delta) {
+    return set_parameter(parameter, get_parameter(parameter) + delta);
+}
+
+bool CalibrationStrategy::handleGcode(Gcode *gcode)
+{
+    if( gcode->has_g) {
+        // G code processing
+        if( gcode->g == 32 ) { // auto calibration for delta, Z bed mapping for cartesian
+            // first wait for an empty queue i.e. no moves left
+            THEKERNEL->conveyor->wait_for_empty_queue();
+
+            auto args = gcode->get_args();
+            std::string parameters_to_optimize; parameters_to_optimize.reserve(args.size());
+            int samples = 50;
+
+            for (auto &v : args) {
+                if (v.first == 'N')
+                    samples = int(v.second);
+                else
+                    parameters_to_optimize += v.first;
+            }
+
+            if (parameters_to_optimize.empty()) {
+                parameters_to_optimize = "XYZ"; // endstop only
+            }
+
+            // Make sure we initialize our trim variables
+            get_parameter('X');
+            get_parameter('Y');
+            get_parameter('Z');
+
+            // Make sure all parameters are valid
+            for (auto p = parameters_to_optimize.begin(); p != parameters_to_optimize.end();) {
+                // this is done by attempting to get and then set their values
+                if (!update_parameter(*p,0)) {
+                    gcode->stream->printf("Warning, invalid parameter '%c' ignored.\n", *p);
+                    p = parameters_to_optimize.erase(p);
+                } else {
+                    p++;
+                }
+            }
+
+            gcode->stream->printf("Commencing calibration of parameters: %s\n", parameters_to_optimize.c_str());
+
+            if (samples < 10) samples = 10;
+
+            if (optimize_delta_model(samples, parameters_to_optimize, gcode->stream)) {
+                gcode->stream->printf("Calibration complete. Save settings with M500.\n");
+            } else {
+                gcode->stream->printf("Calibration may not have converged. Use M500 if you want to save settings anyway.\n");
+            }
+
+            // Check if endstop trim was updated
+            if (parameters_to_optimize.find('X') != std::string::npos ||
+                parameters_to_optimize.find('Y') != std::string::npos ||
+                parameters_to_optimize.find('Z') != std::string::npos) {
+
+                // Deficiency: homing is the only way to activate the endstop trim values
+                zprobe->home();
+            }
+
+            return true;
+        }
+    } else if(gcode->has_m) {
+        // handle mcodes
+    }
+
+    return false;
+}
+
+bool CalibrationStrategy::handleConfig()
+{
+    // default is probably wrong
+    float r= THEKERNEL->config->value(leveling_strategy_checksum, calibration_strategy_checksum, radius_checksum)->by_default(-1.0f)->as_number();
+    if(r == -1) {
+        r= THEKERNEL->config->value(leveling_strategy_checksum, delta_calibration_strategy_checksum, radius_checksum)->by_default(65.0f)->as_number();
+    }
+    this->probe_radius= r;
+    return true;
+}
+
+
+bool CalibrationStrategy::setup_probe() {
+    // home
+    zprobe->home();
+    zprobe->coordinated_move(NAN, NAN, 20, zprobe->getFastFeedrate(), false /* relative */);
+
+    int s;
+    if(!zprobe->run_probe(s, false)) return false;
+
+    //float dive_height = zprobe->zsteps_to_mm(s) - zprobe->getProbeHeight(); // distance to move from home to 5mm above bed
+
+    zprobe->coordinated_move(NAN, NAN, zprobe->getProbeHeight(), zprobe->getFastFeedrate(), true /* relative */);
+
+    return true;
+}
+
+
+// fills out n actuator positions where the probe triggered
+// returns false if any probe failed
+bool CalibrationStrategy::probe_spiral(int n, float actuator_positions[/*n*/][3]) {
+    if (THEKERNEL->robot->actuators.size() != 3) return false;
+    // Spiraling probe pattern
+
+    // Archimedes' spiral r = a * theta
+    // arc_length(x) = integrate a * theta * dtheta from 0 to x = a*x^2/2
+    // inversely, theta(len) = sqrt(2*len/a)
+    // we want outer point to be at probe_radius -> theta_max = probe_radius/a
+    // step_length = length(theta_max)) / n == probe_radius^2/(2*a*n)
+    // solve a * 2pi == step_length -> a = probe_radius / (2*sqrt(n)*sqrt(pi))
+
+    float a = probe_radius / (2 * sqrt(n * M_PI));
+
+    auto theta = [a](float length) {
+        return sqrt(2*length/a);
+    };
+    double step_length = probe_radius * probe_radius / (2 * a * n);
+
+    // move the probe to it's starting position a specified height above the bed
+    setup_probe();
+
+    for (int i = 0; i < n; i++) {
+        float angle = theta(i * step_length);
+        float r = angle * a;
+        // polar to cartesian
+        float x = r * cos(angle);
+        float y = r * sin(angle);
+
+        int steps; // dummy
+        if (!zprobe->doProbeAt(steps, x, y, actuator_positions[i])) return false;
+        // remove trim adjustment from returned actuator positions
+        for (int j = 0; j < 3; j++)
+            actuator_positions[i][j] += trim[j];
+    }
+
+    return true;
+}
+
+struct V3 { float m[3]; };
+
+float compute_model_error(float const actuator_position[3]) {
+    float cartesian[3];
+    float trimmed_position[3];
+    // simulate the effect of trim
+    for (int i = 0; i < 3; i++) trimmed_position[i] = actuator_position[i] - trim[i];
+    THEKERNEL->robot->arm_solution->actuator_to_cartesian(trimmed_position, cartesian);
+    // we want our model to map the plane to z == 0
+    return cartesian[2];
+}
+
+float compute_model_rms_error(std::vector<V3> const& actuator_positions) {
+    float err = 0;
+    for (auto &actuator_position : actuator_positions) {
+        float e = compute_model_error(actuator_position.m);
+        err += e*e;
+    }
+    return sqrt(err / actuator_positions.size());
+}
+
+void compute_JTJ_JTr(std::vector<V3> const& actuator_positions,
+                     std::string     const& parameters,
+                     std::vector<float>   & JTJ,
+                     std::vector<float>   & JTr,
+                     std::vector<float>   & scratch) {
+    int m = parameters.size();
+    scratch.resize(m);
+    std::vector<float> &jacobian = scratch;
+
+    // zero JTJ accumulator
+    JTJ.resize(m * m);
+    for (auto &v : JTJ) v = 0;
+
+    JTr.resize(m);
+    for (auto &v : JTr) v = 0;
+
+    // step length for central difference approximation
+    float h = 1e-4;
+    float one_over_2_h = 1. / (2 * h);
+
+    // iterating over residual terms rather than parameters first saves
+    // a lot of memory at the cost of much more get/set_value calls
+    for (int j = 0; j < (int)actuator_positions.size(); j++) {
+
+        // compute numerically derivative of error w.r.t. parameters
+        for (int i = 0; i < m; i++) {
+            float x0 = get_parameter(parameters[i]);
+
+            //compute central difference (f(x+h) - f(x-h)) / (2*h)
+            set_parameter(parameters[i], x0 + h);
+            jacobian[i] = compute_model_error(actuator_positions[j].m);
+
+            set_parameter(parameters[i], x0 - h);
+            jacobian[i] = (jacobian[i] - compute_model_error(actuator_positions[j].m)) * one_over_2_h;
+
+            // restore the original value
+            set_parameter(parameters[i], x0);
+        }
+        // Accumulate outer product of the Jacobian
+        // Only compute upper triangle of the symmetric matrix
+        for (int i = 0; i < m; i++) {
+            for (int j = i; j < m; j++) {
+                JTJ[i * m + j] += jacobian[i] * jacobian[j];
+            }
+        }
+
+        float err = compute_model_error(actuator_positions[j].m);
+        for (int i = 0; i < m; i++) {
+            JTr[i] -= jacobian[i] * err;
+        }
+    }
+
+    // fill in the lower JTJ triangle
+    for (int i = 0; i < m; i++) {
+        for (int j = 0; j < i; j++) {
+            JTJ[i * m + j] = JTJ[j * m + i];
+        }
+    }
+}
+
+// Solve Ax=b for positive semidefinite A using LDL^T decomposition
+// Destroys A and b in the process
+// Result is stored in b
+template<typename T>
+void cholesky_backsub(int n, T A[/* n*n */], T b[/* n */]) {
+
+    // Compute LDL^T decomposition
+    for (int j = 0; j < n; j++) {
+        T inv_diagonal = 1;
+        for (int i = j; i < n; i++) {
+            T v = A[i*n + j];
+            for (int k = 0; k < j; k++) {
+                v -= A[k*n + j] * A[i*n + k];
+            }
+            if (i == j) {
+                A[i*n + j] = v;
+                inv_diagonal = 1/v;
+            } else {
+                A[j*n + i] = v; // store undivided value
+                A[i*n + j] = v * inv_diagonal;
+            }
+        }
+    }
+
+    // Compute A^-1*b, A=LDL^T
+    // L
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < i; j++) {
+            b[i] -= A[i*n + j] * b[j];
+        }
+    }
+
+    // D
+    for (int i = 0; i < n; i++) {
+        b[i] /= A[i*n + i];
+    }
+
+    // L^T
+    for (int i = n-1; i >= 0; i--) {
+        for (int j = i+1; j < n; j++) {
+            b[i] -= A[j*n + i] * b[j];
+        }
+    }
+}
+
+bool CalibrationStrategy::optimize_delta_model(int n, std::string const& parameters, StreamOutput* stream) {
+
+    std::vector<V3> actuator_positions(n);
+    std::vector<float> scratch;
+    std::vector<float> JTJ;
+    std::vector<float> JTr;
+    stream->printf("Probing %d points.\n", n);
+    if (!probe_spiral(n, &actuator_positions[0].m)) return false;
+
+    for (auto &v : actuator_positions) {
+        stream->printf("%.5f %.5f %.5f\n",v.m[0],v.m[1],v.m[2]);
+    }
+
+    int m = parameters.size();
+
+    // Save initial values so we can roll back if we end up with a worse solution
+    std::vector<float> stored_values(m);
+    auto save = [&]() {
+        for (int i = 0; i < m; i++)
+            stored_values[i] = get_parameter(parameters[i]);
+    };
+    auto restore = [&]() {
+        for (int i = 0; i < m; i++)
+            set_parameter(parameters[i], stored_values[i]);
+    };
+    auto print_state = [&]() {
+        for (int i = 0; i < m; i++)
+            stream->printf("%c:%.2f ", parameters[i], stored_values[i]);
+        stream->printf("\n");
+    };
+
+    save();
+
+    float last_error = compute_model_rms_error(actuator_positions);
+    print_state();
+    stream->printf("RMS error before optimization: %.3f mm\n", last_error);
+
+    static const int max_iterations = 50;
+    std::vector<float> A;
+    std::vector<float> b;
+
+    float lambda = 1;
+    for (int iteration = 0; iteration < max_iterations; iteration++) {
+        compute_JTJ_JTr(actuator_positions, parameters, JTJ, JTr, scratch);
+
+again:
+        A = JTJ;
+        b = JTr;
+        // Damp the problem a bit
+        for (int i = 0; i < m; i++) {
+            A[i*m + i] *= (1 + lambda);
+        }
+        cholesky_backsub(m, A.data(), b.data());
+        stream->printf("delta:");
+        for (auto v : b)
+            stream->printf("%f ",v);
+        stream->printf("\n");
+        for (int i = 0; i < m; i++) {
+            update_parameter(parameters[i], b[i]);
+        }
+
+        float new_error = compute_model_rms_error(actuator_positions);
+        print_state();
+        stream->printf("RMS error after iteration %d: %.3f mm", iteration+1, new_error);
+        if (new_error > last_error) {
+            stream->printf(" -> rolling back\n");
+            restore();
+            // increase damping
+            lambda *= 3;
+            if (lambda > 1e10) {
+                stream->printf("Max lambda\n");
+                return false;
+            }
+            goto again;
+        } else {
+            float improvement = (1 - new_error / last_error);
+            stream->printf(" (%.3f%% improvement)\n", 100*improvement);
+            last_error = new_error;
+            save();
+
+            if (improvement < 0.0001) {
+                stream->printf("Done\n");
+                print_state();
+                return true;
+            }
+
+            // reduce damping
+            lambda /= 2;
+            if (lambda < 1e-7) lambda = 1e-7;
+        }
+    }
+    stream->printf("Failed to converge after %d iterations\n", max_iterations);
+    return false;
+}
+
+
+int endstop_parameter_index(char parameter) {
+    switch(parameter) {
+    case 'X': return 0;
+    case 'Y': return 1;
+    case 'Z': return 2;
+    default: return -1;
+    }
+}
+
+
+bool set_parameter(char parameter, float value) {
+    int endstop = endstop_parameter_index(parameter);
+    if (endstop >= 0) {
+        void *returned_data;
+
+        if (PublicData::get_value(endstops_checksum, trim_checksum, &returned_data)) {
+            float *rtrim = static_cast<float *>(returned_data);
+            float t[3] = {rtrim[0],rtrim[1],rtrim[2]};
+            t[endstop] = value;
+            trim[endstop] = value;
+            return PublicData::set_value( endstops_checksum, trim_checksum, t);
+        }
+        return false;
+    } else {
+        BaseSolution::arm_options_t options;
+        if(THEKERNEL->robot->arm_solution->get_optional(options)) {
+            options[parameter] = value;
+            return THEKERNEL->robot->arm_solution->set_optional(options);
+        }
+        return false;
+    }
+}
+
+
+float get_parameter(char parameter) {
+    int endstop = endstop_parameter_index(parameter);
+    if (endstop >= 0) {
+        void *returned_data;
+        bool ok = PublicData::get_value(endstops_checksum, trim_checksum, &returned_data);
+
+        if (ok) {
+            float *rtrim = static_cast<float *>(returned_data);
+            trim[endstop] = rtrim[endstop];
+            return rtrim[endstop];
+        }
+    } else {
+        BaseSolution::arm_options_t options;
+        if(THEKERNEL->robot->arm_solution->get_optional(options)) {
+            return options[parameter];
+        }
+    }
+    return NAN;
+}

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -610,11 +610,8 @@ bool CalibrationStrategy::set_parameter(char parameter, float value) {
         return false;
     } else {
         BaseSolution::arm_options_t options;
-        if(THEKERNEL->robot->arm_solution->get_optional(options)) {
-            options[parameter] = value;
-            return THEKERNEL->robot->arm_solution->set_optional(options);
-        }
-        return false;
+        options[parameter] = value;
+        return THEKERNEL->robot->arm_solution->set_optional(options);
     }
 }
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -284,11 +284,11 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<V3> const& actuator_positi
     for (auto &v : JTr) v = 0;
 
     // step length for central difference approximation
-    float h = 1e-4;
-    float one_over_2_h = 1. / (2 * h);
+    // we assume all model parameters are approximately 0 with a scale of ~mm
+    float h = 1e-3;
 
     // iterating over residual terms rather than parameters first saves
-    // a lot of memory at the cost of much more get/set_value calls
+    // a lot of memory at the cost of many more get/set_value calls
     for (int j = 0; j < (int)actuator_positions.size(); j++) {
 
         // compute numerically derivative of error w.r.t. parameters
@@ -300,6 +300,7 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<V3> const& actuator_positi
             jacobian[i] = compute_model_error(actuator_positions[j].m, home_offs_z);
 
             set_parameter(parameters[i], x0 - h);
+            float one_over_2_h = 1./((x0+h)-(x0-h)); // trick to improve precision
             jacobian[i] = (jacobian[i] - compute_model_error(actuator_positions[j].m, home_offs_z)) * one_over_2_h;
 
             // restore the original value

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -220,7 +220,7 @@ bool CalibrationStrategy::probe_spiral(int n, int repeats, float actuator_positi
     auto theta = [a](float length) {
         return sqrt(2*length/a);
     };
-    double step_length = probe_radius * probe_radius / (2 * a * n);
+    float step_length = probe_radius * probe_radius / (2 * a * n);
 
     // move the probe to it's starting position a specified height above the bed
     setup_probe();
@@ -339,7 +339,7 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<Vector3> const& actuator_p
             jacobian[i] = compute_model_error(actuator_positions[j].data());
 
             set_parameter(parameters[i], x0 - h);
-            float one_over_2_h = 1./((x0+h)-(x0-h)); // trick to improve precision
+            float one_over_2_h = 1.f/((x0+h)-(x0-h)); // trick to improve precision
             jacobian[i] = (jacobian[i] - compute_model_error(actuator_positions[j].data())) * one_over_2_h;
 
             // restore the original value
@@ -497,7 +497,7 @@ again:
 
         if (!(new_error < last_error)) {
             restore();
-            if (sq_sum_delta < 0.0001 * 0.0001) {
+            if (sq_sum_delta < 0.0001f * 0.0001f) {
                 stream->printf("\nConverged\n");
                 return true;
             }
@@ -518,8 +518,8 @@ again:
             save();
             print_state();
 
-            if (improvement < 0.0001 ||
-                sq_sum_delta < 0.0001 * 0.0001) {
+            if (improvement < 0.0001f ||
+                sq_sum_delta < 0.0001f * 0.0001f) {
                 // improvement < 0.01 % or < 0.1 µm adjustment
                 stream->printf("Done\n");
                 return true;
@@ -530,7 +530,7 @@ again:
             if (lambda < 1e-7) lambda = 1e-7; // Reasonable lower limit for float precision
         }
     }
-    if (last_error < 0.001) return true; // We are within 1 µm, let's call that a success
+    if (last_error < 0.001f) return true; // We are within 1 µm, let's call that a success
 
     stream->printf("Failed to converge after %d iterations\n", max_iterations);
     return false;

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -154,7 +154,8 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
         }
     } else if(gcode->has_m) {
         // handle mcodes
-        if(gcode->m == 500 || gcode->m == 503) { // M500 save, M503 display
+        if((gcode->m == 500 && (plane_u != 0 || plane_v != 0 || plane_offset != 0))
+                || gcode->m == 503) { // M500 save, M503 display
             gcode->stream->printf(";Plane tilt:\n");
             gcode->stream->printf("M567 U%.5f V%.5f W%.5f\n", plane_u, plane_v, plane_offset);
             return true;

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -456,7 +456,7 @@ bool CalibrationStrategy::optimize_model(int n, int repeats, std::string const& 
     };
     auto print_state = [&]() {
         for (int i = 0; i < m; i++)
-            stream->printf("%c:%.3g ", parameters[i], stored_values[i]);
+            stream->printf("%c:%.3f ", parameters[i], stored_values[i]);
         stream->printf("\n");
     };
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -99,7 +99,7 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
 
             samples = std::max(samples, (int)parameters_to_optimize.length());
 
-            if (optimize_delta_model(samples, repeats, parameters_to_optimize, gcode->stream)) {
+            if (optimize_model(samples, repeats, parameters_to_optimize, gcode->stream)) {
                 gcode->stream->printf("Calibration complete. Save settings with M500.\n");
             } else {
                 gcode->stream->printf("Calibration may not have converged. Use M500 if you want to save settings anyway.\n");
@@ -375,7 +375,7 @@ bool CalibrationStrategy::probe_pattern(int n, int repeats, float actuator_posit
     }
 }
 
-bool CalibrationStrategy::optimize_delta_model(int n, int repeats, std::string const& parameters, StreamOutput* stream) {
+bool CalibrationStrategy::optimize_model(int n, int repeats, std::string const& parameters, StreamOutput* stream) {
 
     std::vector<V3> actuator_positions(n);
     std::vector<float> scratch;

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -26,8 +26,10 @@
 #define radius_checksum       CHECKSUM("radius")
 #define delta_calibration_strategy_checksum CHECKSUM("delta-calibration")
 
+namespace { // anonymous
 std::pair<std::function<void(float[3])>,std::function<void(float[3])>> compute_rotation_transform(float p, float q, float offset);
 int endstop_parameter_index(char parameter);
+} // anonymous namespace
 
 bool CalibrationStrategy::update_parameter(char parameter, float delta) {
     return set_parameter(parameter, get_parameter(parameter) + delta);
@@ -368,6 +370,7 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<Vector3> const& actuator_p
     }
 }
 
+namespace { // anonymous
 // Solve Ax=b for positive semidefinite A using LDL^T decomposition
 // Destroys A and b in the process
 // Result is stored in b
@@ -411,6 +414,7 @@ void cholesky_backsub(int n, T A[/* n*n */], T b[/* n */]) {
             b[i] -= A[j*n + i] * b[j];
         }
     }
+}
 }
 
 bool CalibrationStrategy::probe_pattern(int n, int repeats, float actuator_positions[/*n*/][3]) {
@@ -536,6 +540,7 @@ again:
     return false;
 }
 
+namespace { // anonymous
 
 int endstop_parameter_index(char parameter) {
     switch(parameter) {
@@ -585,7 +590,7 @@ std::pair<std::function<void(float[3])>,std::function<void(float[3])>> compute_r
         for (int i = 0; i < 3; i++) p[i] = rp[i] - RToffset[i];
     });
 }
-
+} // anonymous namespace
 
 bool CalibrationStrategy::set_parameter(char parameter, float value) {
     if (isnan(value)) return false;

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -217,10 +217,10 @@ bool CalibrationStrategy::probe_spiral(int n, int repeats, float actuator_positi
     // step_length = length(theta_max)) / n == probe_radius^2/(2*a*n)
     // solve a * 2pi == step_length -> a = probe_radius / (2*sqrt(n)*sqrt(pi))
 
-    float a = probe_radius / (2 * sqrt(n * M_PI));
+    float a = probe_radius / (2 * sqrtf(n * M_PI));
 
     auto theta = [a](float length) {
-        return sqrt(2*length/a);
+        return sqrtf(2*length/a);
     };
     float step_length = probe_radius * probe_radius / (2 * a * n);
 
@@ -231,8 +231,8 @@ bool CalibrationStrategy::probe_spiral(int n, int repeats, float actuator_positi
         float angle = theta(i * step_length);
         float r = angle * a;
         // polar to cartesian
-        float x = r * cos(angle);
-        float y = r * sin(angle);
+        float x = r * cosf(angle);
+        float y = r * sinf(angle);
 
         int steps; // dummy
         if (!zprobe->doProbeAt(steps, x, y, actuator_positions[i], repeats)) return false;
@@ -306,7 +306,7 @@ float CalibrationStrategy::compute_model_rms_error(std::vector<Vector3> const& a
         float e = compute_model_error(actuator_position.data());
         err += e*e;
     }
-    return sqrt(err / actuator_positions.size());
+    return sqrtf(err / actuator_positions.size());
 }
 
 void CalibrationStrategy::compute_JTJ_JTr(std::vector<Vector3> const& actuator_positions,

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -152,15 +152,16 @@ bool CalibrationStrategy::handleConfig()
 bool CalibrationStrategy::setup_probe() {
     // home
     zprobe->home();
-    zprobe->coordinated_move(NAN, NAN, 20, zprobe->getFastFeedrate(), false /* relative */);
 
     int s;
     if(!zprobe->run_probe(s, false)) return false;
 
-    //float dive_height = zprobe->zsteps_to_mm(s) - zprobe->getProbeHeight(); // distance to move from home to 5mm above bed
+    // We can not do a relative move now since we have lost our bearings (robot->last_milestone is incorrect)
+    // We also can not do a G92 since that resets our actuator positions.
+    // Luckily, our actuators know where they are.
+    THEKERNEL->robot->reset_position_from_current_actuator_position();
 
     zprobe->coordinated_move(NAN, NAN, zprobe->getProbeHeight(), zprobe->getFastFeedrate(), true /* relative */);
-
     return true;
 }
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -49,6 +49,7 @@ void CalibrationStrategy::update_compensation_transformation()
 
 bool CalibrationStrategy::handleGcode(Gcode *gcode)
 {
+    this->output_stream = gcode->stream;
     if( gcode->has_g) {
         // G code processing
         if (gcode->g == 29 || gcode->g == 32) {
@@ -227,7 +228,7 @@ bool CalibrationStrategy::probe_spiral(int n, int repeats, float actuator_positi
         float y = r * sinf(angle);
 
         int steps; // dummy
-        if (!zprobe->doProbeAt(steps, x, y, actuator_positions[i], repeats)) return false;
+        if (!zprobe->doProbeAt(steps, x, y, actuator_positions[i], repeats, output_stream)) return false;
         // remove trim adjustment from returned actuator positions
         for (int j = 0; j < 3; j++)
             actuator_positions[i][j] += trim[j];
@@ -247,7 +248,7 @@ bool CalibrationStrategy::probe_symmetric(int n, int repeats, float actuator_pos
     int position_index = 0;
     auto probe = [&](float x, float y) {
         int steps; // dummy
-        bool success = zprobe->doProbeAt(steps, x, y, actuator_positions[position_index], repeats);
+        bool success = zprobe->doProbeAt(steps, x, y, actuator_positions[position_index], repeats, output_stream);
         // remove trim adjustment from returned actuator positions
         for (int j = 0; j < 3; j++)
             actuator_positions[position_index][j] += trim[j];

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -156,19 +156,7 @@ bool CalibrationStrategy::handleConfig()
 
 
 bool CalibrationStrategy::setup_probe() {
-    // home
-    zprobe->home();
-
-    int s;
-    if(!zprobe->run_probe(s, false)) return false;
-
-    // We can not do a relative move now since we have lost our bearings (robot->last_milestone is incorrect)
-    // We also can not do a G92 since that resets our actuator positions.
-    // Luckily, our actuators know where they are.
-    THEKERNEL->robot->reset_position_from_current_actuator_position();
-
-    zprobe->coordinated_move(NAN, NAN, zprobe->getProbeHeight(), zprobe->getFastFeedrate(), true /* relative */);
-    return true;
+    return zprobe->find_bed();
 }
 
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -76,7 +76,7 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
 
             gcode->stream->printf("Commencing calibration of parameters: %s\n", parameters_to_optimize.c_str());
 
-            if (samples < 10) samples = 10;
+            samples = std::max(samples, (int)parameters_to_optimize.length());
 
             if (optimize_delta_model(samples, repeats, parameters_to_optimize, gcode->stream)) {
                 gcode->stream->printf("Calibration complete. Save settings with M500.\n");

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -296,6 +296,14 @@ void cholesky_backsub(int n, T A[/* n*n */], T b[/* n */]) {
     }
 }
 
+bool CalibrationStrategy::probe_pattern(int n, int repeats, float actuator_positions[/*N*/][3]) {
+    if (n <= 7) {
+        return probe_symmetric(n, repeats, &actuator_positions[0]);
+    } else {
+        return probe_spiral(n, repeats, &actuator_positions[0]);
+    }
+}
+
 bool CalibrationStrategy::optimize_delta_model(int n, int repeats, std::string const& parameters, StreamOutput* stream) {
 
     std::vector<V3> actuator_positions(n);
@@ -303,7 +311,8 @@ bool CalibrationStrategy::optimize_delta_model(int n, int repeats, std::string c
     std::vector<float> JTJ;
     std::vector<float> JTr;
     stream->printf("Probing %d points (%d repeat(s) per point).\n", n, repeats);
-    if (!probe_spiral(n, repeats, &actuator_positions[0].m)) return false;
+
+    if (!probe_pattern(n, repeats, &actuator_positions[0].m)) return false;
 
     for (auto &v : actuator_positions) {
         stream->printf("%.5f %.5f %.5f\n",v.m[0],v.m[1],v.m[2]);

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -323,7 +323,7 @@ bool CalibrationStrategy::optimize_delta_model(int n, int repeats, std::string c
     };
     auto print_state = [&]() {
         for (int i = 0; i < m; i++)
-            stream->printf("%c:%.2f ", parameters[i], stored_values[i]);
+            stream->printf("%c:%.3g ", parameters[i], stored_values[i]);
         stream->printf("\n");
     };
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -376,9 +376,9 @@ bool CalibrationStrategy::optimize_delta_model(int n, int repeats, std::string c
 
     if (!probe_pattern(n, repeats, &actuator_positions[0].m)) return false;
 
-    for (auto &v : actuator_positions) {
-        stream->printf("%.5f %.5f %.5f\n",v.m[0],v.m[1],v.m[2]);
-    }
+//    for (auto &v : actuator_positions) {
+//        stream->printf("%.5f %.5f %.5f\n",v.m[0],v.m[1],v.m[2]);
+//    }
 
     int m = parameters.size();
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/CalibrationStrategy.cpp
@@ -104,6 +104,7 @@ bool CalibrationStrategy::handleGcode(Gcode *gcode)
             } else {
                 gcode->stream->printf("Calibration may not have converged. Use M500 if you want to save settings anyway.\n");
             }
+            THEKERNEL->call_event(ON_IDLE);
 
             // Check if endstop trim was updated
             if (parameters_to_optimize.find('X') != std::string::npos ||
@@ -317,6 +318,7 @@ void CalibrationStrategy::compute_JTJ_JTr(std::vector<V3> const& actuator_positi
         for (int i = 0; i < m; i++) {
             JTr[i] -= jacobian[i] * err;
         }
+        THEKERNEL->call_event(ON_IDLE);
     }
 
     // fill in the lower JTJ triangle
@@ -454,9 +456,10 @@ again:
         for (int i = 0; i < m; i++) {
             update_parameter(parameters[i], b[i]);
         }
-
+        THEKERNEL->call_event(ON_IDLE);
         float new_error = compute_model_rms_error(actuator_positions, home_offs[2]);
         stream->printf("RMS error after iteration %d: %.3f mm", iteration+1, new_error);
+        THEKERNEL->call_event(ON_IDLE);
 
         float sq_sum_delta = 0;
         for (auto d : b) sq_sum_delta += d*d;
@@ -475,6 +478,7 @@ again:
                 stream->printf("Max lambda\n");
                 return false;
             }
+            THEKERNEL->call_event(ON_IDLE);
             goto again; // adjusted lambda, no need to recompute JTJ, JTr
         } else {
             float improvement = (1 - new_error / last_error);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -8,11 +8,11 @@
 #define _GENERICLEVELINGSTRATEGY
 
 #include "LevelingStrategy.h"
+#include "Vector3.h"
 #include <string>
 #include <vector>
 
 #define calibration_strategy_checksum CHECKSUM("calibration")
-struct V3 { float m[3]; };
 
 class CalibrationStrategy : public LevelingStrategy
 {
@@ -48,14 +48,14 @@ private:
     float get_parameter(char parameter);
     bool  set_parameter(char parameter, float value);
     bool  update_parameter(char parameter, float delta);
-    void  compute_JTJ_JTr(std::vector<V3> const& actuator_positions,
-                          std::string     const& parameters,
-                          std::vector<float>   & JTJ,
-                          std::vector<float>   & JTr,
-                          std::vector<float>   & scratch,
-                          float home_offs_z);
+    void  compute_JTJ_JTr(std::vector<Vector3> const& actuator_positions,
+                          std::string          const& parameters,
+                          std::vector<float>        & JTJ,
+                          std::vector<float>        & JTr,
+                          std::vector<float>        & scratch,
+                          float                       home_offs_z);
     float compute_model_error(float const actuator_position[3], float home_offs_z);
-    float compute_model_rms_error(std::vector<V3> const& actuator_positions, float home_offs_z);
+    float compute_model_rms_error(std::vector<Vector3> const& actuator_positions, float home_offs_z);
     void  update_compensation_transformation();
     bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -35,6 +35,9 @@ private:
     // cache endstop trim values
     float trim[3]{};
 
+    // store output stream during calibration
+    class StreamOutput * output_stream;
+
 
     // impl details
     bool  setup_probe();

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -26,12 +26,6 @@ private:
     // Radius of probe circle. TODO: model other build plate shapes
     float probe_radius;
 
-    // Plane tilt
-    float plane_u{0}, plane_v{0};
-
-    // Separate plane offset variable (to allow Home Offset to be kept constant)
-    float plane_offset{0};
-
     // cache endstop trim values
     float trim[3]{};
 

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -44,7 +44,7 @@ private:
 
     // impl details
     bool  setup_probe();
-    bool  optimize_delta_model(int n, int repeats, const std::string &parameters, class StreamOutput *stream);
+    bool  optimize_model(int n, int repeats, const std::string &parameters, class StreamOutput *stream);
     float get_parameter(char parameter);
     bool  set_parameter(char parameter, float value);
     bool  update_parameter(char parameter, float delta);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -29,6 +29,15 @@ private:
     // Radius of probe circle. TODO: model other build plate shapes
     float probe_radius;
 
+    // Plane tilt
+    float plane_p = 0, plane_q = 0;
+
+    // Separate plane offset variable (to allow Home Offset to be kept constant)
+    float plane_offset = 0;
+
+    // Last row of plane rotation matrix
+    float inverse_r[3] = {0,0,1};
+
     // cache endstop trim values
     float trim[3] = {};
 
@@ -46,6 +55,7 @@ private:
                           std::vector<float>   & scratch);
     float compute_model_error(float const actuator_position[3]);
     float compute_model_rms_error(std::vector<V3> const& actuator_positions);
+    void  update_compensation_transformation();
     bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);
 };

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -30,13 +30,13 @@ private:
     float probe_radius;
 
     // Plane tilt
-    float plane_u = 0, plane_v = 0;
+    float plane_u{0}, plane_v{0};
 
     // Separate plane offset variable (to allow Home Offset to be kept constant)
-    float plane_offset = 0;
+    float plane_offset{0};
 
     // cache endstop trim values
-    float trim[3] = {};
+    float trim[3]{};
 
 
     // impl details

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -21,12 +21,12 @@ public:
     bool handleConfig();
 
     // probes n points in a spiral pattern, return actuator positions of trigger points
-    bool probe_spiral(int n, float actuator_positions[/*N*/][3]);
+    bool probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
 private:
     bool setup_probe();
     
     float probe_radius;
-    bool optimize_delta_model(int n, const std::string &parameters, class StreamOutput *stream);
+    bool optimize_delta_model(int n, int repeats, const std::string &parameters, class StreamOutput *stream);
 };
 
 #endif

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -29,6 +29,9 @@ private:
     // cache endstop trim values
     float trim[3]{};
 
+    // sum of home_offset and homing_position
+    float home_position[3]{};
+
     // store output stream during calibration
     class StreamOutput * output_stream;
 
@@ -48,6 +51,7 @@ private:
     float compute_model_error(float const actuator_position[3]);
     float compute_model_rms_error(std::vector<Vector3> const& actuator_positions);
     void  update_compensation_transformation();
+    void  init_home_position();
 
     // probes n points, return actuator positions of trigger points
     bool  probe_pattern(int n, int repeats, float actuator_positions[/*N*/][3]);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -22,9 +22,6 @@ public:
     bool handleGcode(Gcode* gcode);
     bool handleConfig();
 
-    // probes n points, return actuator positions of trigger points
-    bool probe_pattern(int n, int repeats, float actuator_positions[/*N*/][3]);
-
 private:
     // Radius of probe circle. TODO: model other build plate shapes
     float probe_radius;
@@ -54,6 +51,9 @@ private:
     float compute_model_error(float const actuator_position[3]);
     float compute_model_rms_error(std::vector<Vector3> const& actuator_positions);
     void  update_compensation_transformation();
+
+    // probes n points, return actuator positions of trigger points
+    bool  probe_pattern(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);
 };

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -30,7 +30,7 @@ private:
     float probe_radius;
 
     // Plane tilt
-    float plane_p = 0, plane_q = 0;
+    float plane_u = 0, plane_v = 0;
 
     // Separate plane offset variable (to allow Home Offset to be kept constant)
     float plane_offset = 0;

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -52,9 +52,10 @@ private:
                           std::string     const& parameters,
                           std::vector<float>   & JTJ,
                           std::vector<float>   & JTr,
-                          std::vector<float>   & scratch);
-    float compute_model_error(float const actuator_position[3]);
-    float compute_model_rms_error(std::vector<V3> const& actuator_positions);
+                          std::vector<float>   & scratch,
+                          float home_offs_z);
+    float compute_model_error(float const actuator_position[3], float home_offs_z);
+    float compute_model_rms_error(std::vector<V3> const& actuator_positions, float home_offs_z);
     void  update_compensation_transformation();
     bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -1,0 +1,32 @@
+// Generic calibration strategy based on nonlinear optimization
+//
+// Copyright (c) Oskar Linde 2015
+//
+// Licence: GPL v2
+
+#ifndef _GENERICLEVELINGSTRATEGY
+#define _GENERICLEVELINGSTRATEGY
+
+#include "LevelingStrategy.h"
+#include <string>
+
+#define calibration_strategy_checksum CHECKSUM("calibration")
+
+class CalibrationStrategy : public LevelingStrategy
+{
+public:
+    CalibrationStrategy(class ZProbe *zprobe) : LevelingStrategy(zprobe){}
+    ~CalibrationStrategy(){}
+    bool handleGcode(Gcode* gcode);
+    bool handleConfig();
+
+    // probes n points in a spiral pattern, return actuator positions of trigger points
+    bool probe_spiral(int n, float actuator_positions[/*N*/][3]);
+private:
+    bool setup_probe();
+    
+    float probe_radius;
+    bool optimize_delta_model(int n, const std::string &parameters, class StreamOutput *stream);
+};
+
+#endif

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -9,8 +9,10 @@
 
 #include "LevelingStrategy.h"
 #include <string>
+#include <vector>
 
 #define calibration_strategy_checksum CHECKSUM("calibration")
+struct V3 { float m[3]; };
 
 class CalibrationStrategy : public LevelingStrategy
 {
@@ -23,10 +25,26 @@ public:
     // probes n points in a spiral pattern, return actuator positions of trigger points
     bool probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
 private:
-    bool setup_probe();
-    
+    // Radius of probe circle. TODO: model other build plate shapes
     float probe_radius;
-    bool optimize_delta_model(int n, int repeats, const std::string &parameters, class StreamOutput *stream);
+
+    // cache endstop trim values
+    float trim[3] = {};
+
+
+    // impl details
+    bool  setup_probe();
+    bool  optimize_delta_model(int n, int repeats, const std::string &parameters, class StreamOutput *stream);
+    float get_parameter(char parameter);
+    bool  set_parameter(char parameter, float value);
+    bool  update_parameter(char parameter, float delta);
+    void  compute_JTJ_JTr(std::vector<V3> const& actuator_positions,
+                          std::string     const& parameters,
+                          std::vector<float>   & JTJ,
+                          std::vector<float>   & JTr,
+                          std::vector<float>   & scratch);
+    float compute_model_error(float const actuator_position[3]);
+    float compute_model_rms_error(std::vector<V3> const& actuator_positions);
 };
 
 #endif

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -22,8 +22,9 @@ public:
     bool handleGcode(Gcode* gcode);
     bool handleConfig();
 
-    // probes n points in a spiral pattern, return actuator positions of trigger points
-    bool probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
+    // probes n points, return actuator positions of trigger points
+    bool probe_pattern(int n, int repeats, float actuator_positions[/*N*/][3]);
+
 private:
     // Radius of probe circle. TODO: model other build plate shapes
     float probe_radius;
@@ -45,6 +46,8 @@ private:
                           std::vector<float>   & scratch);
     float compute_model_error(float const actuator_position[3]);
     float compute_model_rms_error(std::vector<V3> const& actuator_positions);
+    bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
+    bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);
 };
 
 #endif

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -52,10 +52,10 @@ private:
                           std::string          const& parameters,
                           std::vector<float>        & JTJ,
                           std::vector<float>        & JTr,
-                          std::vector<float>        & scratch,
-                          float                       home_offs_z);
-    float compute_model_error(float const actuator_position[3], float home_offs_z);
-    float compute_model_rms_error(std::vector<Vector3> const& actuator_positions, float home_offs_z);
+                          std::vector<float>        & scratch);
+    void  compute_cartesian_position(float const actuator_position[3], float cartesian_position[3]);
+    float compute_model_error(float const actuator_position[3]);
+    float compute_model_rms_error(std::vector<Vector3> const& actuator_positions);
     void  update_compensation_transformation();
     bool  probe_spiral(int n, int repeats, float actuator_positions[/*N*/][3]);
     bool  probe_symmetric(int n, int repeats, float actuator_positions[/*N*/][3]);

--- a/src/modules/tools/zprobe/CalibrationStrategy.h
+++ b/src/modules/tools/zprobe/CalibrationStrategy.h
@@ -35,9 +35,6 @@ private:
     // Separate plane offset variable (to allow Home Offset to be kept constant)
     float plane_offset = 0;
 
-    // Last row of plane rotation matrix
-    float inverse_r[3] = {0,0,1};
-
     // cache endstop trim values
     float trim[3] = {};
 

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -103,7 +103,8 @@ bool DeltaCalibrationStrategy::probe_delta_points(Gcode *gcode)
     float last_z= NAN;
     for(auto& i : pp) {
         int s;
-        if(!zprobe->doProbeAt(s, i[0], i[1])) return false;
+        float actuator[3];
+        if(!zprobe->doProbeAt(s, i[0], i[1], actuator)) return false;
         float z = zprobe->zsteps_to_mm(s);
         gcode->stream->printf("X:%1.4f Y:%1.4f Z:%1.4f (%d) A:%1.4f B:%1.4f C:%1.4f\n",
             i[0], i[1], z, s,

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -167,10 +167,6 @@ bool DeltaCalibrationStrategy::calibrate_delta_endstops(Gcode *gcode)
     if(isnan(bedht)) return false;
     gcode->stream->printf("initial Bed ht is %f mm\n", bedht);
 
-    // move to start position
-    zprobe->home();
-    zprobe->coordinated_move(NAN, NAN, -bedht, zprobe->getFastFeedrate(), true); // do a relative move from home to the point above the bed
-
     // get initial probes
     // probe the base of the X tower
     int s;
@@ -268,9 +264,6 @@ bool DeltaCalibrationStrategy::calibrate_delta_radius(Gcode *gcode)
     float bedht= zprobe->find_bed();
     if(isnan(bedht)) return false;
     gcode->stream->printf("initial Bed ht is %f mm\n", bedht);
-
-    zprobe->home();
-    zprobe->coordinated_move(NAN, NAN, -bedht, zprobe->getFastFeedrate(), true); // do a relative move from home to the point above the bed
 
     // probe center to get reference point at this Z height
     int dc;

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.h
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.h
@@ -21,10 +21,8 @@ private:
     bool calibrate_delta_endstops(Gcode *gcode);
     bool calibrate_delta_radius(Gcode *gcode);
     bool probe_delta_points(Gcode *gcode);
-    float findBed();
 
     float probe_radius;
-    float initial_height;
 };
 
 #endif

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -355,10 +355,12 @@ void ThreePointStrategy::setAdjustFunction(bool on)
 {
     if(on) {
         // set the compensationTransform in robot
-        THEKERNEL->robot->compensationTransform= [this](float target[3]) { target[2] += this->plane->getz(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransform        = [this](float target[3]) { target[2] += this->plane->getz(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransformInverse = [this](float target[3]) { target[2] -= this->plane->getz(target[0], target[1]); };
     }else{
         // clear it
         THEKERNEL->robot->compensationTransform= nullptr;
+        THEKERNEL->robot->compensationTransformInverse= nullptr;
     }
 }
 

--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -634,10 +634,12 @@ void ZGridStrategy::setAdjustFunction(bool on)
 {
     if(on) {
         // set the compensationTransform in robot
-        THEKERNEL->robot->compensationTransform= [this](float target[3]) { target[2] += this->getZOffset(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransform=        [this](float target[3]) { target[2] += this->getZOffset(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransformInverse= [this](float target[3]) { target[2] -= this->getZOffset(target[0], target[1]); };
     }else{
         // clear it
         THEKERNEL->robot->compensationTransform= nullptr;
+        THEKERNEL->robot->compensationTransformInverse= nullptr;
     }
 }
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -245,12 +245,19 @@ bool ZProbe::return_probe(int steps)
     return true;
 }
 
-bool ZProbe::doProbeAt(int &steps, float x, float y)
+bool ZProbe::doProbeAt(int &steps, float x, float y, float actuator_positions[])
 {
     int s;
     // move to xy
     coordinated_move(x, y, NAN, getFastFeedrate());
     if(!run_probe(s)) return false;
+
+    // Store actuator positions of trigger point
+    if (actuator_positions) {
+        for (int i = 0; i < (int)THEKERNEL->robot->actuators.size(); i++) {
+            actuator_positions[i] = THEKERNEL->robot->actuators[i]->get_current_position();
+        }
+    }
 
     // return to original Z
     return_probe(s);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -31,6 +31,7 @@
 #include "DeltaCalibrationStrategy.h"
 #include "ThreePointStrategy.h"
 #include "ZGridStrategy.h"
+#include "CalibrationStrategy.h"
 
 #define enable_checksum          CHECKSUM("enable")
 #define probe_pin_checksum       CHECKSUM("probe_pin")
@@ -100,6 +101,11 @@ void ZProbe::on_config_reload(void *argument)
                      this->strategies.push_back(new ZGridStrategy(this));
                      found= true;
                      break;
+
+                case calibration_strategy_checksum:
+                    this->strategies.push_back(new CalibrationStrategy(this));
+                    found= true;
+                    break;
 
                 // add other strategies here
                 //case zheight_map_strategy:

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -339,14 +339,15 @@ float ZProbe::find_bed()
     home();
 
     // move to an initial position fast so as to not take all day, we move down max_z - initial_height, which is set in config, default 10mm
-    float deltaz= getMaxZ() - initial_height;
-    coordinated_move(NAN, NAN, -deltaz, getFastFeedrate(), true);
+    coordinated_move(NAN, NAN, -getMaxZ() + initial_height, getFastFeedrate(), true);
 
     // find bed, run at slow rate so as to not hit bed hard
     int s;
     if(!run_probe(s, false)) return NAN;
 
-    return zsteps_to_mm(s) + deltaz - getProbeHeight(); // distance to move from home to 5mm above bed
+    THEKERNEL->robot->reset_position_from_current_actuator_position();
+    coordinated_move(NAN, NAN, getProbeHeight(), getFastFeedrate(), true); // do a relative move from home to the point above the bed
+    return -(-getMaxZ() + initial_height - zsteps_to_mm(s) + getProbeHeight());
 }
 
 void ZProbe::on_gcode_received(void *argument)

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -35,7 +35,7 @@ public:
     bool run_probe(int& steps, bool fast= false);
     bool run_probe_feed(int& steps, float feedrate);
     bool return_probe(int steps);
-    bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr, int repeats = 1);
+    bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr, int repeats = 1, class StreamOutput *output = nullptr);
     float probeDistance(float x, float y);
     float find_bed();
 

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -35,7 +35,7 @@ public:
     bool run_probe(int& steps, bool fast= false);
     bool run_probe_feed(int& steps, float feedrate);
     bool return_probe(int steps);
-    bool doProbeAt(int &steps, float x, float y);
+    bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr);
     float probeDistance(float x, float y);
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -37,6 +37,7 @@ public:
     bool return_probe(int steps);
     bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr, int repeats = 1);
     float probeDistance(float x, float y);
+    float find_bed();
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);
     void home();
@@ -57,6 +58,8 @@ private:
     float return_feedrate;
     float probe_height;
     float max_z;
+    float initial_height;
+
     volatile struct {
         volatile bool running:1;
         bool is_delta:1;

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -35,7 +35,7 @@ public:
     bool run_probe(int& steps, bool fast= false);
     bool run_probe_feed(int& steps, float feedrate);
     bool return_probe(int steps);
-    bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr);
+    bool doProbeAt(int &steps, float x, float y, float actuator_positions[] = nullptr, int repeats = 1);
     float probeDistance(float x, float y);
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);


### PR DESCRIPTION
Here's a simple implementation of delta calibration that does a single probe pass and computes optimal model parameters to fit the probe results. It also supports bed leveling using a proper rotation transformation rather than the skew transform the other bed mapping strategies use.

The general idea is to store actuator positions for each probe trigger point and then optimize the model parameters until these actuator positions all correspond as closely as possible to z=0 in software. The model parameters are optimized without any knowledge of their meaning, each parameters influence on the solution is dynamically measured by nudging them one by one. (This means that the same method could be applied to other future arm solutions as well.) The model parameters are optimized using a iterative nonlinear solver using the [Levenberg-Marquardt](https://en.wikipedia.org/wiki/Levenberg–Marquardt_algorithm) method.

The general syntax is:

`G32 <variables to optimize> Pp Oo`

| Parameter | &nbsp; |
| --- | --- |
| P | number of probe points, default = 50, min = number of variables |
| O | number of repeats for each probe point (helps flush out false probe results), default = 1 |

Variables available to all arm solutions:

| Variable | &nbsp; |
| --- | --- |
| X,Y,Z | endstop trim |
| U,V | plane tilt |
| W | plane offset (mutually exclusive with X,Y,Z) |

For LinearDelta:

| Variable | &nbsp; |
| --- | --- |
| R | delta radius |
| A,B,C | tower offsets |
| D,E,H | tower angle |

The calibration respects Home Offset Z meaning one can keep Home Offset Z set to "paper thickness". The offset as defined unfortunately needs to be negative. Something to remember.
##### Examples:

| Gcode&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp; |
| --- | --- |
| `G32 X0 Y0 Z0` | Calibrate endstops, 50 probe points |
| `G32 U0 V0 W0 N7` | Bed leveling (plane orientation and offset), 7 probe points |
| `G32 X0 Y0 Z0 R0 L0 O3` | Simple delta calibration (endstops, delta radius, rod length) 50 probe points, 3 repeats per point |
| `G32 W0 P1` | Simple single point bed offset correction. (Useful to correct for different hotend thermal expansions at different temperatures, or removable beds of different thickness) |
| `G32 X0 Y0 Z0 R0 A0 B0 C0 D0 E0 H0 P200 O5` | Full delta calibration, 200 (x5) probe points |
| `G32 X0 Y0 Z0 R0 A0 B0 C0 D0 E0 H0 U0 V0` | Full delta calibration including bed tilt |

**_NOTE:**_ The code is very lightly tested
