### PR TITLE
Increase Z Home Ofs menu setting precision to 0.01 mm

### DIFF
--- a/src/modules/utils/panel/screens/MainMenuScreen.cpp
+++ b/src/modules/utils/panel/screens/MainMenuScreen.cpp
@@ -82,7 +82,7 @@ void MainMenuScreen::setupConfigureScreen()
     mvs->addMenuItem("Z Home Ofs",
         []() -> float { void *rd; PublicData::get_value( endstops_checksum, home_offset_checksum, &rd ); return rd==nullptr ? 0.0F : ((float*)rd)[2]; },
         [this](float v) { send_gcode("M206", 'Z', v); },
-        0.1F
+        0.01F
         );
 
     mvs->addMenuItem("Contrast",


### PR DESCRIPTION
Z Home Ofs is useful for fine adjustment of the "paper thickness" offset between head and bed, but the menu option needs higher precision for this to be usable from the panel. 10 µm seems like a reasonable level of precision for tweaking the first layer offset.