### PR TITLE
Vector3

### DIFF
--- a/src/libs/Vector3.cpp
+++ b/src/libs/Vector3.cpp
@@ -3,13 +3,11 @@
 #include <fastmath.h>
 #include <cstddef>
 
-float Vector3::nan = NAN;
-
 float Vector3::operator[](int i) const
 {
     if (i >= 0 && i <= 2)
         return elem[i];
-    return nan;
+    return NAN;
 }
 
 Vector3 Vector3::cross(const Vector3 &vec) const

--- a/src/libs/Vector3.cpp
+++ b/src/libs/Vector3.cpp
@@ -12,13 +12,6 @@ float Vector3::operator[](int i) const
     return nan;
 }
 
-void Vector3::set(float a, float b, float c)
-{
-    elem[0] = a;
-    elem[1] = b;
-    elem[2] = c;
-}
-
 Vector3 Vector3::cross(const Vector3 &vec) const
 {
     Vector3 out;

--- a/src/libs/Vector3.cpp
+++ b/src/libs/Vector3.cpp
@@ -5,35 +5,6 @@
 
 float Vector3::nan = NAN;
 
-Vector3::Vector3()
-{
-    elem[0] = elem[1] = elem[2] = 0.0F;
-}
-
-Vector3::Vector3(float a, float b, float c)
-{
-    elem[0] = a;
-    elem[1] = b;
-    elem[2] = c;
-}
-
-Vector3::Vector3(const Vector3 &to_copy)
-{
-    elem[0] = to_copy.elem[0];
-    elem[1] = to_copy.elem[1];
-    elem[2] = to_copy.elem[2];
-}
-
-Vector3& Vector3::operator= (const Vector3 &to_copy)
-{
-    if( this != &to_copy ) {
-        elem[0] = to_copy.elem[0];
-        elem[1] = to_copy.elem[1];
-        elem[2] = to_copy.elem[2];
-    }
-    return *this;
-}
-
 float Vector3::operator[](int i) const
 {
     if (i >= 0 && i <= 2)

--- a/src/libs/Vector3.cpp
+++ b/src/libs/Vector3.cpp
@@ -75,17 +75,6 @@ Vector3 Vector3::mul(float scalar) const
     return out;
 }
 
-Vector3 Vector3::mul(const Vector3& v) const
-{
-    Vector3 out;
-
-    out.elem[0] = elem[0] * v[0];
-    out.elem[1] = elem[1] * v[1];
-    out.elem[2] = elem[2] * v[2];
-
-    return out;
-}
-
 Vector3 Vector3::unit() const
 {
     Vector3 out;

--- a/src/libs/Vector3.h
+++ b/src/libs/Vector3.h
@@ -23,6 +23,8 @@ public:
 
     Vector3  unit(void) const;
 
+    float      * data()       { return elem; }
+    float const* data() const { return elem; }
 private:
     float  elem[3]{};
 };

--- a/src/libs/Vector3.h
+++ b/src/libs/Vector3.h
@@ -4,10 +4,9 @@
 class Vector3
 {
 public:
-    Vector3();
-    Vector3(float, float, float);
-    Vector3(const Vector3& to_copy);
-    Vector3& operator= (const Vector3& to_copy);
+    Vector3() = default;
+    Vector3(float a, float b, float c) : elem{a,b,c} {}
+    Vector3(const Vector3& to_copy) = default;
 
     float    operator[](int) const;
     void     set(float a, float b, float c);
@@ -27,7 +26,7 @@ public:
     Vector3  unit(void) const;
 
 private:
-    float  elem[3];
+    float  elem[3]{};
     static float nan;
 };
 

--- a/src/libs/Vector3.h
+++ b/src/libs/Vector3.h
@@ -25,7 +25,6 @@ public:
 
 private:
     float  elem[3]{};
-    static float nan;
 };
 
 // typedef float Vector3[3];

--- a/src/libs/Vector3.h
+++ b/src/libs/Vector3.h
@@ -9,7 +9,6 @@ public:
     Vector3(const Vector3& to_copy) = default;
 
     float    operator[](int) const;
-    void     set(float a, float b, float c);
     Vector3  cross(const Vector3&) const;
 
     float    dot(const Vector3&) const;

--- a/src/libs/Vector3.h
+++ b/src/libs/Vector3.h
@@ -20,7 +20,6 @@ public:
     Vector3  sub(const Vector3&) const;
 
     Vector3  mul(float) const;
-    Vector3  mul(const Vector3& v) const;
 
     Vector3  unit(void) const;
 

--- a/src/modules/tools/zprobe/Plane3D.cpp
+++ b/src/modules/tools/zprobe/Plane3D.cpp
@@ -21,7 +21,7 @@ Plane3D::Plane3D(uint32_t a, uint32_t b, uint32_t c, uint32_t d)
 {
     conv_t ca, cb, cc, cd;
     ca.u= a; cb.u= b; cc.u= c; cd.u= d;
-    this->normal.set(ca.f, cb.f, cc.f);
+    this->normal = Vector3(ca.f, cb.f, cc.f);
     this->d= cd.f;
 }
 

--- a/src/modules/tools/zprobe/Plane3D.cpp
+++ b/src/modules/tools/zprobe/Plane3D.cpp
@@ -11,8 +11,7 @@ Plane3D::Plane3D(const Vector3 &v1, const Vector3 &v2, const Vector3 &v3)
 
     // ax+by+cz+d=0
     // solve for d
-    Vector3 dv = normal.mul(v1);
-    d = -dv[0] - dv[1] - dv[2];
+    d = -normal.dot(v1);
 }
 
 typedef union { float f; uint32_t u; } conv_t;

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -288,7 +288,7 @@ bool ThreePointStrategy::doProbing(StreamOutput *stream)
         if(isnan(z)) return false; // probe failed
         z= zprobe->getProbeHeight() - z; // relative distance between the probe points, lower is negative z
         stream->printf("DEBUG: P%d:%1.4f\n", i, z);
-        v[i].set(x, y, z);
+        v[i] = Vector3(x, y, z);
     }
 
     // if first point is not within tolerance report it, it should ideally be 0


### PR DESCRIPTION
Here's a few small proposed changes to Vector3. Inlining the constructors should make it possible for the compiler to optimize away double initializations.

In addition, this reduces the resulting binary size by 140 bytes.
