### PR TITLE
added failsafe_set_to and ignore_on_halt to switch module config

### DIFF
--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -40,6 +40,8 @@
 #define    output_on_command_checksum   CHECKSUM("output_on_command")
 #define    output_off_command_checksum  CHECKSUM("output_off_command")
 #define    pwm_period_ms_checksum       CHECKSUM("pwm_period_ms")
+#define    failsafe_checksum            CHECKSUM("failsafe_set_to")
+#define    ignore_onhalt_checksum       CHECKSUM("ignore_on_halt")
 
 Switch::Switch() {}
 
@@ -47,6 +49,22 @@ Switch::Switch(uint16_t name)
 {
     this->name_checksum = name;
     //this->dummy_stream = &(StreamOutput::NullStream);
+}
+
+// set the pin to the fail safe value on halt
+void Switch::on_halt(void *arg)
+{
+    if(arg == nullptr) {
+        if(this->ignore_on_halt) return;
+
+        // set pin to failsafe value
+        switch(this->output_type) {
+            case DIGITAL: this->digital_pin->set(this->failsafe); break;
+            case SIGMADELTA: this->sigmadelta_pin->set(this->failsafe); break;
+            case HWPWM: this->pwm_pin->write(0); break;
+            case NONE: break;
+        }
+    }
 }
 
 void Switch::on_module_loaded()
@@ -57,30 +75,36 @@ void Switch::on_module_loaded()
     this->register_for_event(ON_MAIN_LOOP);
     this->register_for_event(ON_GET_PUBLIC_DATA);
     this->register_for_event(ON_SET_PUBLIC_DATA);
+    this->register_for_event(ON_HALT);
 
     // Settings
     this->on_config_reload(this);
 }
 
-
 // Get config
 void Switch::on_config_reload(void *argument)
 {
     this->input_pin.from_string( THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_checksum )->by_default("nc")->as_string())->as_input();
-    this->input_pin_behavior =   THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_behavior_checksum )->by_default(momentary_checksum)->as_number();
-    std::string input_on_command =    THEKERNEL->config->value(switch_checksum, this->name_checksum, input_on_command_checksum )->by_default("")->as_string();
-    std::string input_off_command =   THEKERNEL->config->value(switch_checksum, this->name_checksum, input_off_command_checksum )->by_default("")->as_string();
-    this->output_on_command =    THEKERNEL->config->value(switch_checksum, this->name_checksum, output_on_command_checksum )->by_default("")->as_string();
-    this->output_off_command =   THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->by_default("")->as_string();
-    this->switch_state =         THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->by_default(false)->as_bool();
-    string type =                THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("pwm")->as_string();
+    this->input_pin_behavior = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_pin_behavior_checksum )->by_default(momentary_checksum)->as_number();
+    std::string input_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_on_command_checksum )->by_default("")->as_string();
+    std::string input_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, input_off_command_checksum )->by_default("")->as_string();
+    this->output_on_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_on_command_checksum )->by_default("")->as_string();
+    this->output_off_command = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_off_command_checksum )->by_default("")->as_string();
+    this->switch_state = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_state_checksum )->by_default(false)->as_bool();
+    string type = THEKERNEL->config->value(switch_checksum, this->name_checksum, output_type_checksum )->by_default("pwm")->as_string();
+    this->failsafe= THEKERNEL->config->value(switch_checksum, this->name_checksum, failsafe_checksum )->by_default(0)->as_number();
+    this->ignore_on_halt= THEKERNEL->config->value(switch_checksum, this->name_checksum, ignore_onhalt_checksum )->by_default(false)->as_bool();
 
     if(type == "pwm"){
         this->output_type= SIGMADELTA;
         this->sigmadelta_pin= new Pwm();
         this->sigmadelta_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
         if(this->sigmadelta_pin->connected()) {
-            set_low_on_debug(sigmadelta_pin->port_number, sigmadelta_pin->pin);
+            if(failsafe == 1) {
+                set_high_on_debug(sigmadelta_pin->port_number, sigmadelta_pin->pin);
+            }else{
+                set_low_on_debug(sigmadelta_pin->port_number, sigmadelta_pin->pin);
+            }
         }else{
             this->output_type= NONE;
             delete this->sigmadelta_pin;
@@ -92,7 +116,11 @@ void Switch::on_config_reload(void *argument)
         this->digital_pin= new Pin();
         this->digital_pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
         if(this->digital_pin->connected()) {
-            set_low_on_debug(digital_pin->port_number, digital_pin->pin);
+            if(failsafe == 1) {
+                set_high_on_debug(digital_pin->port_number, digital_pin->pin);
+            }else{
+                set_low_on_debug(digital_pin->port_number, digital_pin->pin);
+            }
         }else{
             this->output_type= NONE;
             delete this->digital_pin;
@@ -104,7 +132,11 @@ void Switch::on_config_reload(void *argument)
         Pin *pin= new Pin();
         pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
         this->pwm_pin= pin->hardware_pwm();
-        set_low_on_debug(pin->port_number, pin->pin);
+        if(failsafe == 1) {
+            set_high_on_debug(pin->port_number, pin->pin);
+        }else{
+            set_low_on_debug(pin->port_number, pin->pin);
+        }
         delete pin;
         if(this->pwm_pin == nullptr) {
             THEKERNEL->streams->printf("Selected Switch output pin is not PWM capable - disabled");

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -33,6 +33,8 @@ class Switch : public Module {
         void on_gcode_received(void* argument);
         void on_get_public_data(void* argument);
         void on_set_public_data(void* argument);
+        void on_halt(void *arg);
+
         uint32_t pinpoll_tick(uint32_t dummy);
         enum OUTPUT_TYPE {NONE, SIGMADELTA, DIGITAL, HWPWM};
 
@@ -61,7 +63,9 @@ class Switch : public Module {
         struct {
             bool      switch_changed:1;
             bool      input_pin_state:1;
-            bool      switch_state;
+            bool      switch_state:1;
+            bool      ignore_on_halt:1;
+            uint8_t   failsafe:1;
         };
 };
 


### PR DESCRIPTION
  failsafe_set_to 0 means on MRI crash or ON_HALT the pin is set low (default)
  failsafe_set_to 1 means on MRI crash or ON_HALT the pin is set high
  ignore_on_halt false means it will set the pin to the failsafe value on ON_HALT (default)
  ignore_on_halt true means it will not set the pin on ON_HALT, it will be left in whatever state it was in