### PR TITLE
Bugfix/robot transformed milestone

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -245,6 +245,7 @@ void Robot::on_config_reload(void *argument)
     // so the first move can be correct if homing is not performed
     float actuator_pos[3];
     arm_solution->cartesian_to_actuator(last_milestone, actuator_pos);
+    // TODO: transformed_milestone???
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 
@@ -639,8 +640,14 @@ void Robot::reset_axis_position(float x, float y, float z)
     this->transformed_last_milestone[Y_AXIS] = y;
     this->transformed_last_milestone[Z_AXIS] = z;
 
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(transformed_last_milestone);
+    }
+
     float actuator_pos[3];
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
@@ -649,10 +656,17 @@ void Robot::reset_axis_position(float x, float y, float z)
 void Robot::reset_axis_position(float position, int axis)
 {
     this->last_milestone[axis] = position;
-    this->transformed_last_milestone[axis] = position;
+    for (int i = 0; i < 3; i++)
+        this->transformed_last_milestone[i] = this->last_milestone[axis];
+
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(transformed_last_milestone);
+    }
 
     float actuator_pos[3];
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
 
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
@@ -662,11 +676,14 @@ void Robot::reset_axis_position(float position, int axis)
 void Robot::reset_position_from_current_actuator_position()
 {
     float actuator_pos[]= {actuators[X_AXIS]->get_current_position(), actuators[Y_AXIS]->get_current_position(), actuators[Z_AXIS]->get_current_position()};
-    arm_solution->actuator_to_cartesian(actuator_pos, this->last_milestone);
-    memcpy(this->transformed_last_milestone, this->last_milestone, sizeof(this->transformed_last_milestone));
+    arm_solution->actuator_to_cartesian(actuator_pos, this->transformed_last_milestone);
+    memcpy(this->last_milestone, this->transformed_last_milestone, sizeof(this->transformed_last_milestone));
+    if (compensationTransformInverse) {
+        compensationTransformInverse(last_milestone);
+    }
 
     // now reset actuator correctly, NOTE this may lose a little precision
-    arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
+    arm_solution->cartesian_to_actuator(this->transformed_last_milestone, actuator_pos);
     for (int i = 0; i < 3; i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -48,6 +48,7 @@ class Robot : public Module {
 
         // set by a leveling strategy to transform the target of a move according to the current plan
         std::function<void(float[3])> compensationTransform;
+        std::function<void(float[3])> compensationTransformInverse;
 
         struct {
             bool inch_mode:1;                                 // true for inch mode, false for millimeter mode ( default )

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -319,10 +319,12 @@ void ThreePointStrategy::setAdjustFunction(bool on)
 {
     if(on) {
         // set the compensationTransform in robot
-        THEKERNEL->robot->compensationTransform= [this](float target[3]) { target[2] += this->plane->getz(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransform        = [this](float target[3]) { target[2] += this->plane->getz(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransformInverse = [this](float target[3]) { target[2] -= this->plane->getz(target[0], target[1]); };
     }else{
         // clear it
         THEKERNEL->robot->compensationTransform= nullptr;
+        THEKERNEL->robot->compensationTransformInverse= nullptr;
     }
 }
 

--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -632,10 +632,12 @@ void ZGridStrategy::setAdjustFunction(bool on)
 {
     if(on) {
         // set the compensationTransform in robot
-        THEKERNEL->robot->compensationTransform= [this](float target[3]) { target[2] += this->getZOffset(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransform=        [this](float target[3]) { target[2] += this->getZOffset(target[0], target[1]); };
+        THEKERNEL->robot->compensationTransformInverse= [this](float target[3]) { target[2] -= this->getZOffset(target[0], target[1]); };
     }else{
         // clear it
         THEKERNEL->robot->compensationTransform= nullptr;
+        THEKERNEL->robot->compensationTransformInverse= nullptr;
     }
 }
 


### PR DESCRIPTION
Basically, the way to think about the coordinate systems is that "last_milestone" is STL coordinates, and "transformed_last_milestone" is machine coordinates.

This bug can be triggered on a delta by applying a compensation transform that makes a large positive increase in Z and then do a G28 home followed by a G1 Z10. Upon G1 Z10 it will crash into the endstops.

NOTE: I can't guarantee that there are no additional places the two milestones get out of sync.
