### PR TITLE
Refactor/switch get public data

### DIFF
--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -308,7 +308,6 @@ void Switch::on_get_public_data(void *argument)
     pad->state = this->switch_state;
     pad->value = this->switch_value;
 
-    pdr->set_data_ptr(&pad);
     pdr->set_taken();
     pdr->clear_returned_data();
 }

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -302,14 +302,15 @@ void Switch::on_get_public_data(void *argument)
     if(!pdr->second_element_is(this->name_checksum)) return; // likely fan, but could be anything
 
     // ok this is targeted at us, so send back the requested data
-    // this must be static as it will be accessed long after we have returned
-    static struct pad_switch pad;
-    pad.name = this->name_checksum;
-    pad.state = this->switch_state;
-    pad.value = this->switch_value;
+    // caller has provided the location to write the state
+    struct pad_switch *pad= static_cast<struct pad_switch *>(pdr->get_data_ptr());
+    pad->name = this->name_checksum;
+    pad->state = this->switch_state;
+    pad->value = this->switch_value;
 
     pdr->set_data_ptr(&pad);
     pdr->set_taken();
+    pdr->clear_returned_data();
 }
 
 void Switch::on_set_public_data(void *argument)

--- a/src/modules/tools/temperatureswitch/TemperatureSwitch.cpp
+++ b/src/modules/tools/temperatureswitch/TemperatureSwitch.cpp
@@ -233,14 +233,14 @@ void TemperatureSwitch::set_switch(bool switch_state)
     if(this->inverted) switch_state= !switch_state; // turn switch on or off inverted
 
     // get current switch state
-    struct pad_switch *pad;
-    bool ok = PublicData::get_value(switch_checksum, this->temperatureswitch_switch_cs, 0, (void **)&pad);
+    struct pad_switch pad;
+    bool ok = PublicData::get_value(switch_checksum, this->temperatureswitch_switch_cs, 0, &pad);
     if (!ok) {
         THEKERNEL->streams->printf("// Failed to get switch state.\r\n");
         return;
     }
 
-    if(pad->state == switch_state) return; // switch is already in the requested state
+    if(pad.state == switch_state) return; // switch is already in the requested state
 
     ok = PublicData::set_value(switch_checksum, this->temperatureswitch_switch_cs, state_checksum, &switch_state);
     if (!ok) {

--- a/src/modules/utils/panel/screens/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/WatchScreen.cpp
@@ -192,13 +192,10 @@ void WatchScreen::on_main_loop()
 // fetch the data we are displaying
 void WatchScreen::get_current_status()
 {
-    void *returned_data;
-    bool ok;
-
     // get fan status
-    ok = PublicData::get_value( switch_checksum, fan_checksum, 0, &returned_data );
+    struct pad_switch s;
+    bool ok = PublicData::get_value( switch_checksum, fan_checksum, 0, &s );
     if (ok) {
-        struct pad_switch s = *static_cast<struct pad_switch *>(returned_data);
         this->fan_state = s.state;
     } else {
         // fan probably disabled


### PR DESCRIPTION
Have the caller supply data location for returned state, saves a static pad.