### PR TITLE
Improved ZGridStrategy:

### DIFF
--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -522,10 +522,6 @@ bool ZGridStrategy::doProbing(StreamOutput *stream)  // probed calibration
         } else {
             this->next_cal();                                     // to not cause damage to machine due to Z-offset
         }
-	// probeDistance() moves to the correct point, so this
-	// move is not only redundant, but wrong.
-        // this->move(this->cal, slow_rate);                         // move to the next position
-
         this->pData[pindex] = z ;                                 // save the offset
     }
 
@@ -662,14 +658,6 @@ float ZGridStrategy::getZOffset(float X, float Y)
     int xIndex = (int)(floorf(xdiff));	// Get the current sector (X)
     int yIndex = (int)(floorf(ydiff));	// Get the current sector (Y)
     
-    // * Care taken for table outside boundary
-    // * Returns zero output when values are outside table boundary
-    // if(xIndex < 0 || xIndex > (this->numRows - 1) || yIndex < 0
-    //    || yIndex > (this->numCols - 1))
-    // {
-    //   return (0);
-    // }
-
     // Index bounds limited to be inside the table
     if (xIndex < 0) xIndex = 0;
     else if (xIndex > (this->numRows - 2)) xIndex = this->numRows - 2;
@@ -677,14 +665,7 @@ float ZGridStrategy::getZOffset(float X, float Y)
     if (yIndex < 0) yIndex = 0;
     else if (yIndex > (this->numCols - 2)) yIndex = this->numCols - 2;
 
-    // if (xIndex == (this->numRows - 1))
-    //     xIndex2 = xIndex;
-    // else
     xIndex2 = xIndex+1;
-
-    // if (yIndex == (this->numCols - 1))
-    //     yIndex2 = yIndex;
-    // else
     yIndex2 = yIndex+1;
 
     xdiff -= xIndex;                    // Find floating point

--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -522,7 +522,9 @@ bool ZGridStrategy::doProbing(StreamOutput *stream)  // probed calibration
         } else {
             this->next_cal();                                     // to not cause damage to machine due to Z-offset
         }
-        this->move(this->cal, slow_rate);                         // move to the next position
+	// probeDistance() moves to the correct point, so this
+	// move is not only redundant, but wrong.
+        // this->move(this->cal, slow_rate);                         // move to the next position
 
         this->pData[pindex] = z ;                                 // save the offset
     }
@@ -654,26 +656,36 @@ float ZGridStrategy::getZOffset(float X, float Y)
 
     float dCartX1, dCartX2;
 
-    int xIndex = (int) xdiff;                  // Get the current sector (X)
-    int yIndex = (int) ydiff;                  // Get the current sector (Y)
+    // Get floor of xdiff.  Note that (int) of a negative number is its
+    // ceiling, not its floor.
 
+    int xIndex = (int)(floorf(xdiff));	// Get the current sector (X)
+    int yIndex = (int)(floorf(ydiff));	// Get the current sector (Y)
+    
     // * Care taken for table outside boundary
     // * Returns zero output when values are outside table boundary
-    if(xIndex < 0 || xIndex > (this->numRows - 1) || yIndex < 0
-       || yIndex > (this->numCols - 1))
-    {
-      return (0);
-    }
+    // if(xIndex < 0 || xIndex > (this->numRows - 1) || yIndex < 0
+    //    || yIndex > (this->numCols - 1))
+    // {
+    //   return (0);
+    // }
 
-    if (xIndex == (this->numRows - 1))
-        xIndex2 = xIndex;
-    else
-        xIndex2 = xIndex+1;
+    // Index bounds limited to be inside the table
+    if (xIndex < 0) xIndex = 0;
+    else if (xIndex > (this->numRows - 2)) xIndex = this->numRows - 2;
 
-    if (yIndex == (this->numCols - 1))
-        yIndex2 = yIndex;
-    else
-        yIndex2 = yIndex+1;
+    if (yIndex < 0) yIndex = 0;
+    else if (yIndex > (this->numCols - 2)) yIndex = this->numCols - 2;
+
+    // if (xIndex == (this->numRows - 1))
+    //     xIndex2 = xIndex;
+    // else
+    xIndex2 = xIndex+1;
+
+    // if (yIndex == (this->numCols - 1))
+    //     yIndex2 = yIndex;
+    // else
+    yIndex2 = yIndex+1;
 
     xdiff -= xIndex;                    // Find floating point
     ydiff -= yIndex;                    // Find floating point


### PR DESCRIPTION
(1) Removed a redundant and incorrect move in the Z-probe.  If
cal_offset and/or probe_offset non-zero, then the calibration
loop first moves the extruder to the grid position, then makes
the correct move.  The first (incorrect) move has been removed.

(2) Corrected the getZOffset() routine, which would incorrectly
compute xIndex and yIndex if cal_offset_x or cal_offset_y is
negative ((int) is not the floor of a negative number).

(3) Improved getZOffset() by extrapolating points outside the
grid using the nearest grid square, such that for purposes of
correction, the plane of each outermost grid square effectively
extends to infinity.  The previous code returned zero for all
areas outside the grid, creating a discontinuity at the grid
boundary.

These changes were made especially for using the ZGridStrategy
with a cartesian printer and the recently popular inductive
proximity sensor.  The proximity sensor must have a metal surface
underneath at all times, so the probe calibration must be set to
a smaller area than the bed plate.  The cal_offset_x and
cal_offset_y plus the bed_x and bed_y serve to create an interior
area for the probe grid.  The new getZOffset() will extrapolate
values to first order from the probe grid out to the edge of the
bed plate.

Changes should not interfere with any existing use of
ZGridStrategy.