### PR TITLE
Feature/abort heat and wait and homing on kill

### DIFF
--- a/ConfigSamples/AzteegX5Mini.delta/config
+++ b/ConfigSamples/AzteegX5Mini.delta/config
@@ -179,8 +179,9 @@ zprobe.probe_height                          5               # how much above be
 #leveling-strategy.delta-calibration.enable   true            # basic delta calibration
 #leveling-strategy.delta-calibration.radius   100             # the probe radius
 
-# Pause button
-pause_button_enable                          true             #
+# kill button (used to be called pause) maybe assigned to a different pin, set to the onboard pin by default
+kill_button_enable                           true             # set to true to enable a kill button
+kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
 
 # Panel See http://smoothieware.org/panel
 panel.enable                                 false             # set to true to enable the panel code

--- a/ConfigSamples/AzteegX5Mini/config
+++ b/ConfigSamples/AzteegX5Mini/config
@@ -188,8 +188,9 @@ zprobe.probe_height                          5               # how much above be
 #leveling-strategy.three-point-leveling.save_plane     false       # set to true to allow the bed plane to be saved with M500 default is false
 
 
-# Pause button
-pause_button_enable                          true             #
+# kill button (used to be called pause) maybe assigned to a different pin, set to the onboard pin by default
+kill_button_enable                           true             # set to true to enable a kill button
+kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
 
 # Panel See http://smoothieware.org/panel
 panel.enable                                 false             # set to true to enable the panel code

--- a/ConfigSamples/Smoothieboard.delta/config
+++ b/ConfigSamples/Smoothieboard.delta/config
@@ -247,8 +247,9 @@ zprobe.probe_height                          5               # how much above be
 #leveling-strategy.delta-calibration.enable   true            # basic delta calibration
 #leveling-strategy.delta-calibration.radius   100             # the probe radius
 
-# Pause button
-pause_button_enable                          true             #
+# kill button (used to be called pause) maybe assigned to a different pin, set to the onboard pin by default
+kill_button_enable                           true             # set to true to enable a kill button
+kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
 
 # Panel
 panel.enable                                 false             # set to true to enable the panel code

--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -60,10 +60,11 @@ second_usb_serial_enable                     false            # This enables a s
                                                               # and a terminal connected)
 #leds_disable                                true             # disable using leds after config loaded
 #play_led_disable                            true             # disable the play led
-pause_button_enable                          true             # Pause button enable
-#pause_button_pin                            2.12             # pause button pin. default is P2.12
-#kill_button_enable                           false            # set to true to enable a kill button
-#kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
+
+# kill button (used to be called pause) maybe assigned to a different pin, set to the onboard pin by default
+kill_button_enable                           true             # set to true to enable a kill button
+kill_button_pin                              2.12             # kill button pin. default is same as pause button 2.12 (2.11 is another good choice)
+
 #msd_disable                                 false            # disable the MSD (USB SDCARD) when set to true (needs special binary)
 #dfu_enable                                  false            # for linux developers, set to true to enable DFU
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -35,11 +35,14 @@
 #define base_stepping_frequency_checksum            CHECKSUM("base_stepping_frequency")
 #define microseconds_per_step_pulse_checksum        CHECKSUM("microseconds_per_step_pulse")
 #define acceleration_ticks_per_second_checksum      CHECKSUM("acceleration_ticks_per_second")
+#define disable_leds_checksum                       CHECKSUM("leds_disable")
 
 Kernel* Kernel::instance;
 
 // The kernel is the central point in Smoothie : it stores modules, and handles event calls
 Kernel::Kernel(){
+    halted= false;
+
     instance= this; // setup the Singleton instance of the kernel
 
     // serial first at fixed baud rate (DEFAULT_SERIAL_BAUD_RATE) so config can report errors to serial
@@ -84,6 +87,9 @@ Kernel::Kernel(){
     if(this->serial == NULL) {
         this->serial = new SerialConsole(USBTX, USBRX, this->config->value(uart0_checksum,baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
     }
+
+    //some boards don't have leds.. TOO BAD!
+    this->use_leds= !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
 
     this->add_module( this->config );
     this->add_module( this->serial );
@@ -153,6 +159,9 @@ void Kernel::register_for_event(_EVENT_ENUM id_event, Module *mod){
 
 // Call a specific event with an argument
 void Kernel::call_event(_EVENT_ENUM id_event, void * argument){
+    if(id_event == ON_HALT) {
+        this->halted= (argument == nullptr);
+    }
     for (auto m : hooks[id_event]) {
         (m->*kernel_callback_functions[id_event])(argument);
     }

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -44,6 +44,9 @@ class Kernel {
         bool kernel_has_event(_EVENT_ENUM id_event, Module *mod);
         void unregister_for_event(_EVENT_ENUM id_event, Module *module);
 
+        bool is_using_leds() const { return use_leds; }
+        bool is_halted() const { return halted; }
+
         // These modules are available to all other modules
         SerialConsole*    serial;
         StreamOutputPool* streams;
@@ -59,7 +62,6 @@ class Kernel {
         SlowTicker*       slow_ticker;
         StepTicker*       step_ticker;
         Adc*              adc;
-        bool              use_leds;
         std::string       current_path;
         uint32_t          base_stepping_frequency;
         uint32_t          acceleration_ticks_per_second;
@@ -67,6 +69,10 @@ class Kernel {
     private:
         // When a module asks to be called for a specific event ( a hook ), this is where that request is remembered
         std::array<std::vector<Module*>, NUMBER_OF_DEFINED_EVENTS> hooks;
+        struct {
+            bool use_leds:1;
+            bool halted:1;
+        };
 
 };
 

--- a/src/libs/Network/uip/telnetd/shell.cpp
+++ b/src/libs/Network/uip/telnetd/shell.cpp
@@ -223,7 +223,9 @@ int Shell::command_result(const char *str, void *p)
 
 /*---------------------------------------------------------------------------*/
 void Shell::start()
-{
+{   // add it to the kernels output stream
+    DEBUG_PRINTF("Shell: Adding stream to kernel streams\n");
+    THEKERNEL->streams->append_stream(pstream);
     telnet->output("Smoothie command shell\r\n> ");
 }
 
@@ -252,11 +254,6 @@ void Shell::close()
 
 void Shell::setConsole()
 {
-    // add it to the kernels output stream if we are a console
-    // TODO do we do this for all connections? so pronterface will get file done when playing from M24?
-    // then we need to turn it off for the streaming app
-    DEBUG_PRINTF("Shell: Adding stream to kernel streams\n");
-    THEKERNEL->streams->append_stream(pstream);
     isConsole= true;
 }
 
@@ -271,10 +268,9 @@ Shell::Shell(Telnetd *telnet)
 
 Shell::~Shell()
 {
-    if(isConsole) {
-        DEBUG_PRINTF("Shell: Removing stream from kernel streams\n");
-        THEKERNEL->streams->remove_stream(pstream);
-    }
+    DEBUG_PRINTF("Shell: Removing stream from kernel streams\n");
+    THEKERNEL->streams->remove_stream(pstream);
+
     // we cannot delete this stream until it is no longer in any command queue entries
     // so mark it as closed, and allow it to delete itself when it is no longer being used
     static_cast<CallbackStream*>(pstream)->mark_closed(); // mark the stream as closed so we do not get any callbacks

--- a/src/libs/Network/uip/telnetd/telnetd.cpp
+++ b/src/libs/Network/uip/telnetd/telnetd.cpp
@@ -285,7 +285,6 @@ void Telnetd::newdata(void)
                 }else if (c == TELNET_GA) {
                     // enable prompt if telnet client running
                     prompt= true;
-                    shell->setConsole(); // tell shell we are a console, as this is sent be telnet clients
                 }else{
                      /* Reply with a WONT */
                     //sendopt(TELNET_WONT, c);

--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -112,7 +112,7 @@ extern GPIO leds[];
 void SlowTicker::on_idle(void*)
 {
     static uint16_t ledcnt= 0;
-    if(THEKERNEL->use_leds) {
+    if(THEKERNEL->is_using_leds()) {
         // flash led 3 to show we are alive
         leds[2]= (ledcnt++ & 0x1000) ? 1 : 0;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,6 @@
 
 #define second_usb_serial_enable_checksum  CHECKSUM("second_usb_serial_enable")
 #define disable_msd_checksum  CHECKSUM("msd_disable")
-#define disable_leds_checksum  CHECKSUM("leds_disable")
 #define dfu_enable_checksum  CHECKSUM("dfu_enable")
 
 // Watchdog wd(5000000, WDT_MRI);
@@ -109,9 +108,6 @@ void init() {
     kernel->streams->printf("Smoothie Running @%ldMHz\r\n", SystemCoreClock / 1000000);
     Version version;
     kernel->streams->printf("  Build version %s, Build date %s\r\n", version.get_build(), version.get_build_date());
-
-    //some boards don't have leds.. TOO BAD!
-    kernel->use_leds= !kernel->config->value( disable_leds_checksum )->by_default(false)->as_bool();
 
     bool sdok= (sd.disk_initialize() == 0);
     if(!sdok) kernel->streams->printf("SDCard is disabled\r\n");
@@ -215,7 +211,7 @@ void init() {
     // clear up the config cache to save some memory
     kernel->config->config_cache_clear();
 
-    if(kernel->use_leds) {
+    if(kernel->is_using_leds()) {
         // set some leds to indicate status... led0 init doe, led1 mainloop running, led2 idle loop running, led3 sdcard ok
         leds[0]= 1; // indicate we are done with init
         leds[3]= sdok?1:0; // 4th led inidicates sdcard is available (TODO maye should indicate config was found)
@@ -249,7 +245,7 @@ int main()
     uint16_t cnt= 0;
     // Main loop
     while(1){
-        if(THEKERNEL->use_leds) {
+        if(THEKERNEL->is_using_leds()) {
             // flash led 2 to show we are alive
             leds[1]= (cnt++ & 0x1000) ? 1 : 0;
         }

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -40,7 +40,6 @@ static bool is_allowed_mcode(int m) {
 
 GcodeDispatch::GcodeDispatch()
 {
-    halted= false;
     uploading = false;
     currentline = -1;
     last_g= 255;
@@ -50,13 +49,6 @@ GcodeDispatch::GcodeDispatch()
 void GcodeDispatch::on_module_loaded()
 {
     this->register_for_event(ON_CONSOLE_LINE_RECEIVED);
-    this->register_for_event(ON_HALT);
-}
-
-void GcodeDispatch::on_halt(void *arg)
-{
-    // set halt stream and ignore everything until M999
-    this->halted= (arg == nullptr);
 }
 
 // When a command is received, if it is a Gcode, dispatch it as an object via an event
@@ -139,11 +131,11 @@ try_again:
                     //Prepare gcode for dispatch
                     Gcode *gcode = new Gcode(single_command, new_message.stream);
 
-                    if(halted) {
+                    if(THEKERNEL->is_halted()) {
                         // we ignore all commands until M999, unless it is in the exceptions list (like M105 get temp)
                         if(gcode->has_m && gcode->m == 999) {
                             THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
-                            halted= false;
+
                             // fall through and pass onto other modules
 
                         }else if(!is_allowed_mcode(gcode->m)) {

--- a/src/modules/communication/GcodeDispatch.h
+++ b/src/modules/communication/GcodeDispatch.h
@@ -21,7 +21,6 @@ public:
 
     virtual void on_module_loaded();
     virtual void on_console_line_received(void *line);
-    void on_halt(void *arg);
 
 private:
     int currentline;
@@ -30,7 +29,6 @@ private:
     uint8_t last_g;
     struct {
         bool uploading: 1;
-        bool halted: 1;
     };
 };
 

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -38,6 +38,7 @@ class Robot : public Module {
         float get_z_maxfeedrate() const { return this->max_speeds[2]; }
         void setToolOffset(const float offset[3]);
         float get_feed_rate() const { return feed_rate; }
+        bool is_halted() const { return halted; }
 
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -26,7 +26,6 @@ class Robot : public Module {
         void on_module_loaded();
         void on_config_reload(void* argument);
         void on_gcode_received(void* argument);
-        void on_halt(void *arg);
 
         void reset_axis_position(float position, int axis);
         void reset_axis_position(float x, float y, float z);
@@ -38,7 +37,6 @@ class Robot : public Module {
         float get_z_maxfeedrate() const { return this->max_speeds[2]; }
         void setToolOffset(const float offset[3]);
         float get_feed_rate() const { return feed_rate; }
-        bool is_halted() const { return halted; }
 
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 
@@ -95,10 +93,6 @@ class Robot : public Module {
         StepperMotor* alpha_stepper_motor;
         StepperMotor* beta_stepper_motor;
         StepperMotor* gamma_stepper_motor;
-
-        struct {
-            bool halted:1;
-        };
 };
 
 // Convert from inches to millimeters ( our internal storage unit ) if needed

--- a/src/modules/robot/Stepper.h
+++ b/src/modules/robot/Stepper.h
@@ -27,7 +27,7 @@ public:
     void on_play(void *argument);
     void on_pause(void *argument);
     void on_halt(void *argument);
-    uint32_t main_interrupt(uint32_t dummy);
+
     void trapezoid_generator_reset();
     void set_step_events_per_second(float);
     void trapezoid_generator_tick(void);

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -643,7 +643,7 @@ void Endstops::on_gcode_received(void *argument)
                         home(a);
                     }
                     // check if on_halt (eg kill)
-                    if(THEKERNEL->is_halted()) return;
+                    if(THEKERNEL->is_halted()) break;
                 }
 
             }else {
@@ -652,7 +652,10 @@ void Endstops::on_gcode_received(void *argument)
             }
 
             // check if on_halt (eg kill)
-            if(THEKERNEL->is_halted()) return;
+            if(THEKERNEL->is_halted()){
+                THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
+                return;
+            }
 
             if(home_all) {
                 // for deltas this may be important rather than setting each individually

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -380,7 +380,7 @@ bool Endstops::wait_for_homed(char axes_to_move)
         THEKERNEL->call_event(ON_IDLE);
 
         // check if on_halt (eg kill)
-        if(THEKERNEL->robot->is_halted()) return false;
+        if(THEKERNEL->is_halted()) return false;
 
         for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
             if ( ( axes_to_move >> c ) & 1 ) {
@@ -406,7 +406,7 @@ bool Endstops::wait_for_homed(char axes_to_move)
 void Endstops::do_homing_cartesian(char axes_to_move)
 {
     // check if on_halt (eg kill)
-    if(THEKERNEL->robot->is_halted()) return;
+    if(THEKERNEL->is_halted()) return;
 
     // this homing works for cartesian and delta printers
     // Start moving the axes to the origin
@@ -466,7 +466,7 @@ bool Endstops::wait_for_homed_corexy(int axis)
         THEKERNEL->call_event(ON_IDLE);
 
         // check if on_halt (eg kill)
-        if(THEKERNEL->robot->is_halted()) return false;
+        if(THEKERNEL->is_halted()) return false;
 
         if ( this->pins[axis + (this->home_direction[axis] ? 0 : 3)].get() ) {
             if ( debounce[axis] < debounce_count ) {
@@ -489,7 +489,7 @@ bool Endstops::wait_for_homed_corexy(int axis)
 void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate, float slow_rate, unsigned int retract_steps)
 {
     // check if on_halt (eg kill)
-    if(THEKERNEL->robot->is_halted()) return;
+    if(THEKERNEL->is_halted()) return;
 
     this->status = MOVING_TO_ENDSTOP_FAST;
     this->feed_rate[X_AXIS]= fast_rate;
@@ -643,7 +643,7 @@ void Endstops::on_gcode_received(void *argument)
                         home(a);
                     }
                     // check if on_halt (eg kill)
-                    if(THEKERNEL->robot->is_halted()) return;
+                    if(THEKERNEL->is_halted()) return;
                 }
 
             }else {
@@ -652,7 +652,7 @@ void Endstops::on_gcode_received(void *argument)
             }
 
             // check if on_halt (eg kill)
-            if(THEKERNEL->robot->is_halted()) return;
+            if(THEKERNEL->is_halted()) return;
 
             if(home_all) {
                 // for deltas this may be important rather than setting each individually

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -371,13 +371,17 @@ void Endstops::move_to_origin(char axes_to_move)
     this->status = NOT_HOMING;
 }
 
-void Endstops::wait_for_homed(char axes_to_move)
+bool Endstops::wait_for_homed(char axes_to_move)
 {
     bool running = true;
     unsigned int debounce[3] = {0, 0, 0};
     while (running) {
         running = false;
         THEKERNEL->call_event(ON_IDLE);
+
+        // check if on_halt (eg kill)
+        if(THEKERNEL->robot->is_halted()) return false;
+
         for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
             if ( ( axes_to_move >> c ) & 1 ) {
                 if ( this->pins[c + (this->home_direction[c] ? 0 : 3)].get() ) {
@@ -396,10 +400,14 @@ void Endstops::wait_for_homed(char axes_to_move)
             }
         }
     }
+    return true;
 }
 
 void Endstops::do_homing_cartesian(char axes_to_move)
 {
+    // check if on_halt (eg kill)
+    if(THEKERNEL->robot->is_halted()) return;
+
     // this homing works for cartesian and delta printers
     // Start moving the axes to the origin
     this->status = MOVING_TO_ENDSTOP_FAST;
@@ -411,7 +419,7 @@ void Endstops::do_homing_cartesian(char axes_to_move)
     }
 
     // Wait for all axes to have homed
-    this->wait_for_homed(axes_to_move);
+    if(!this->wait_for_homed(axes_to_move)) return;
 
     // Move back a small distance
     this->status = MOVING_BACK;
@@ -443,19 +451,23 @@ void Endstops::do_homing_cartesian(char axes_to_move)
     }
 
     // Wait for all axes to have homed
-    this->wait_for_homed(axes_to_move);
+    if(!this->wait_for_homed(axes_to_move)) return;
 
     // Homing is done
     this->status = NOT_HOMING;
 }
 
-void Endstops::wait_for_homed_corexy(int axis)
+bool Endstops::wait_for_homed_corexy(int axis)
 {
     bool running = true;
     unsigned int debounce[3] = {0, 0, 0};
     while (running) {
         running = false;
         THEKERNEL->call_event(ON_IDLE);
+
+        // check if on_halt (eg kill)
+        if(THEKERNEL->robot->is_halted()) return false;
+
         if ( this->pins[axis + (this->home_direction[axis] ? 0 : 3)].get() ) {
             if ( debounce[axis] < debounce_count ) {
                 debounce[axis] ++;
@@ -471,10 +483,14 @@ void Endstops::wait_for_homed_corexy(int axis)
             debounce[axis] = 0;
         }
     }
+    return true;
 }
 
 void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate, float slow_rate, unsigned int retract_steps)
 {
+    // check if on_halt (eg kill)
+    if(THEKERNEL->robot->is_halted()) return;
+
     this->status = MOVING_TO_ENDSTOP_FAST;
     this->feed_rate[X_AXIS]= fast_rate;
     STEPPER[X_AXIS]->move(dirx, 10000000, 0);
@@ -482,7 +498,7 @@ void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate,
     STEPPER[Y_AXIS]->move(diry, 10000000, 0);
 
     // wait for primary axis
-    this->wait_for_homed_corexy(home_axis);
+    if(!this->wait_for_homed_corexy(home_axis)) return;
 
     // Move back a small distance
     this->status = MOVING_BACK;
@@ -504,7 +520,7 @@ void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate,
     STEPPER[Y_AXIS]->move(diry, 10000000, 0);
 
     // wait for primary axis
-    this->wait_for_homed_corexy(home_axis);
+    if(!this->wait_for_homed_corexy(home_axis)) return;
 }
 
 // this homing works for HBots/CoreXY
@@ -623,13 +639,20 @@ void Endstops::on_gcode_received(void *argument)
                 // eg 0b00100001 would be Y X Z, 0b00100100 would be X Y Z
                 for (uint8_t m = homing_order; m != 0; m >>= 2) {
                     int a= (1 << (m & 0x03)); // axis to move
-                    if((a & axes_to_move) != 0)
+                    if((a & axes_to_move) != 0){
                         home(a);
+                    }
+                    // check if on_halt (eg kill)
+                    if(THEKERNEL->robot->is_halted()) return;
                 }
+
             }else {
                 // they all home at the same time
                 home(axes_to_move);
             }
+
+            // check if on_halt (eg kill)
+            if(THEKERNEL->robot->is_halted()) return;
 
             if(home_all) {
                 // for deltas this may be important rather than setting each individually

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -27,8 +27,8 @@ class Endstops : public Module{
         void home(char axes_to_move);
         void do_homing_cartesian(char axes_to_move);
         void do_homing_corexy(char axes_to_move);
-        void wait_for_homed(char axes_to_move);
-        void wait_for_homed_corexy(int axis);
+        bool wait_for_homed(char axes_to_move);
+        bool wait_for_homed_corexy(int axis);
         void corexy_home(int home_axis, bool dirx, bool diry, float fast_rate, float slow_rate, unsigned int retract_steps);
         void back_off_home(char axes_to_move);
         void move_to_origin(char);

--- a/src/modules/tools/temperaturecontrol/PID_Autotuner.h
+++ b/src/modules/tools/temperaturecontrol/PID_Autotuner.h
@@ -10,7 +10,6 @@
 #include "Module.h"
 
 class TemperatureControl;
-class StreamOutput;
 
 class PID_Autotuner : public Module
 {
@@ -23,13 +22,12 @@ public:
     void on_gcode_received(void *);
 
 private:
-    void begin(float, StreamOutput *, int );
+    void begin(float, int );
     void abort();
     void finishUp();
 
     TemperatureControl *temp_control;
     float target_temperature;
-    StreamOutput *s;
 
     float *peaks;
     int requested_cycles;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -330,7 +330,7 @@ void TemperatureControl::on_gcode_received(void *argument)
                         while ( get_temperature() < target_temperature ) {
                             THEKERNEL->call_event(ON_IDLE, this);
                             // check if ON_HALT was called (usually by kill button)
-                            if(this->target_temperature == UNDEFINED) break;
+                            if(THEKERNEL->is_halted() || this->target_temperature == UNDEFINED) break;
                         }
                         this->waiting = false;
                     }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -329,6 +329,8 @@ void TemperatureControl::on_gcode_received(void *argument)
                         this->waiting = true; // on_second_tick will announce temps
                         while ( get_temperature() < target_temperature ) {
                             THEKERNEL->call_event(ON_IDLE, this);
+                            // check if ON_HALT was called (usually by kill button)
+                            if(this->target_temperature == UNDEFINED) break;
                         }
                         this->waiting = false;
                     }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -330,7 +330,10 @@ void TemperatureControl::on_gcode_received(void *argument)
                         while ( get_temperature() < target_temperature ) {
                             THEKERNEL->call_event(ON_IDLE, this);
                             // check if ON_HALT was called (usually by kill button)
-                            if(THEKERNEL->is_halted() || this->target_temperature == UNDEFINED) break;
+                            if(THEKERNEL->is_halted() || this->target_temperature == UNDEFINED) {
+                                THEKERNEL->streams->printf("Wait on temperature aborted by kill\n");
+                                break;
+                            }
                         }
                         this->waiting = false;
                     }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -135,6 +135,11 @@ bool ZProbe::wait_for_probe(int& steps)
     unsigned int debounce = 0;
     while(true) {
         THEKERNEL->call_event(ON_IDLE);
+        if(THEKERNEL->is_halted()){
+            // aborted by kill
+            return false;
+        }
+
         // if no stepper is moving, moves are finished and there was no touch
         if( !STEPPER[Z_AXIS]->is_moving() && (!is_delta || (!STEPPER[Y_AXIS]->is_moving() && !STEPPER[Z_AXIS]->is_moving())) ) {
             return false;

--- a/src/modules/utils/PlayLed/PlayLed.cpp
+++ b/src/modules/utils/PlayLed/PlayLed.cpp
@@ -22,8 +22,6 @@
 #define play_led_disable_checksum   CHECKSUM("play_led_disable")
 
 PlayLed::PlayLed() {
-
-    halted= false;
     cnt= 0;
 }
 
@@ -35,7 +33,7 @@ void PlayLed::on_module_loaded()
     }
 
     on_config_reload(this);
-    this->register_for_event(ON_HALT);
+
     THEKERNEL->slow_ticker->attach(12, this, &PlayLed::led_tick);
 }
 
@@ -51,7 +49,7 @@ void PlayLed::on_config_reload(void *argument)
 
 uint32_t PlayLed::led_tick(uint32_t)
 {
-    if(this->halted) {
+    if(THEKERNEL->is_halted()) {
         led.set(!led.get());
         return 0;
     }
@@ -67,9 +65,4 @@ uint32_t PlayLed::led_tick(uint32_t)
     }
 
     return 0;
-}
-
-void PlayLed::on_halt(void *arg)
-{
-    this->halted= (arg == nullptr);
 }

--- a/src/modules/utils/PlayLed/PlayLed.h
+++ b/src/modules/utils/PlayLed/PlayLed.h
@@ -12,14 +12,12 @@ public:
 
     void on_module_loaded(void);
     void on_config_reload(void *);
-    void on_halt(void *arg);
 
 private:
     uint32_t led_tick(uint32_t);
     Pin  led;
     struct {
         uint8_t cnt:4;
-        bool halted:1;
     };
 };
 

--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -84,7 +84,6 @@ Panel::Panel()
     this->sd= nullptr;
     this->extmounter= nullptr;
     this->external_sd_enable= false;
-    this->halted= false;
     strcpy(this->playing_file, "Playing file");
 }
 
@@ -190,7 +189,6 @@ void Panel::on_module_loaded()
     // Register for events
     this->register_for_event(ON_IDLE);
     this->register_for_event(ON_MAIN_LOOP);
-    this->register_for_event(ON_HALT);
     this->register_for_event(ON_SET_PUBLIC_DATA);
 
     // Refresh timer
@@ -675,9 +673,4 @@ void Panel::on_second_tick(void *arg)
     }else{
         // TODO for panels with no sd card detect we need to poll to see if card is inserted - or not
     }
-}
-
-void Panel::on_halt(void *arg)
-{
-    halted= (arg == nullptr);
 }

--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -35,7 +35,6 @@ class Panel : public Module {
         uint32_t button_tick(uint32_t dummy);
         uint32_t encoder_tick(uint32_t dummy);
         void on_idle(void* argument);
-        void on_halt(void* argument);
         void on_main_loop(void* argument);
         void on_set_public_data(void* argument);
         void on_second_tick(void* argument);
@@ -81,7 +80,6 @@ class Panel : public Module {
 
         string getMessage() { return message; }
         bool hasMessage() { return message.size() > 0; }
-        bool is_halted() const { return halted; }
 
         uint16_t get_screen_lines() const { return screen_lines; }
 
@@ -142,7 +140,6 @@ class Panel : public Module {
             bool menu_changed:1;
             bool control_value_changed:1;
             bool external_sd_enable:1;
-            bool halted:1;
             volatile bool counter_changed:1;
             volatile bool click_changed:1;
             volatile bool refresh_flag:1;

--- a/src/modules/utils/panel/screens/MainMenuScreen.cpp
+++ b/src/modules/utils/panel/screens/MainMenuScreen.cpp
@@ -118,7 +118,7 @@ void MainMenuScreen::display_menu_line(uint16_t line)
 {
     switch ( line ) {
         case 0: THEPANEL->lcd->printf("Watch"); break;
-        case 1: if(THEPANEL->is_halted()) THEPANEL->lcd->printf("Clear HALT"); else THEPANEL->lcd->printf(THEPANEL->is_playing() ? "Abort" : "Play"); break;
+        case 1: if(THEKERNEL->is_halted()) THEPANEL->lcd->printf("Clear HALT"); else THEPANEL->lcd->printf(THEPANEL->is_playing() ? "Abort" : "Play"); break;
         case 2: THEPANEL->lcd->printf("Jog"); break;
         case 3: THEPANEL->lcd->printf("Prepare"); break;
         case 4: THEPANEL->lcd->printf("Custom"); break;
@@ -132,7 +132,7 @@ void MainMenuScreen::clicked_menu_entry(uint16_t line)
     switch ( line ) {
         case 0: THEPANEL->enter_screen(this->watch_screen); break;
         case 1:
-            if(THEPANEL->is_halted()){
+            if(THEKERNEL->is_halted()){
                 send_command("M999");
                 THEPANEL->enter_screen(this->watch_screen);
             }else if(THEPANEL->is_playing()) abort_playing();

--- a/src/modules/utils/panel/screens/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/WatchScreen.cpp
@@ -275,7 +275,7 @@ const char *WatchScreen::get_status()
     if (THEPANEL->hasMessage())
         return THEPANEL->getMessage().c_str();
 
-    if (THEPANEL->is_halted())
+    if (THEKERNEL->is_halted())
         return "HALTED Reset or M999";
 
     if (THEKERNEL->pauser->paused())

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -357,7 +357,7 @@ void Player::abort_command( string parameters, StreamOutput *stream )
         // now the position will think it is at the last received pos, so we need to do FK to get the actuator position and reset the current position
         THEKERNEL->robot->reset_position_from_current_actuator_position();
     }
-    stream->printf("Aborted playing or paused file\r\n");
+    stream->printf("Aborted playing or paused file. Please turn any heaters off manually\r\n");
 }
 
 void Player::on_main_loop(void *argument)

--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -27,7 +27,6 @@ class Player : public Module {
         void on_console_line_received( void* argument );
         void on_main_loop( void* argument );
         void on_second_tick(void* argument);
-        void on_halt(void* argument);
         void on_get_public_data(void* argument);
         void on_set_public_data(void* argument);
         void on_gcode_received(void *argument);
@@ -60,7 +59,6 @@ class Player : public Module {
             bool on_boot_gcode_enable:1;
             bool booted:1;
             bool playing_file:1;
-            bool halted:1;
             bool suspended:1;
             bool saved_inch_mode:1;
             bool saved_absolute_mode:1;


### PR DESCRIPTION
Adds abort of heat and wait and homing if kill switch is used.
Also refactors the ON_HALT in many modules.
Makes kill button the default (rather than the sub optimal pause)
FIxes autopid out-of-band reports killing the web I/F if M303 is issued from web (not recommended)
Fixes pronterface network connection so out of band data is now received 
Abort ZProbe if kill switch asserted.