### PR TITLE
Modify/delta calibrate improved initial probe

### DIFF
--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.h
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.h
@@ -21,8 +21,10 @@ private:
     bool calibrate_delta_endstops(Gcode *gcode);
     bool calibrate_delta_radius(Gcode *gcode);
     bool probe_delta_points(Gcode *gcode);
+    float findBed();
 
     float probe_radius;
+    float initial_height;
 };
 
 #endif

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -42,9 +42,10 @@ public:
     void home();
 
     bool getProbeStatus() { return this->pin.get(); }
-    float getSlowFeedrate() { return slow_feedrate; }
-    float getFastFeedrate() { return fast_feedrate; }
-    float getProbeHeight() { return probe_height; }
+    float getSlowFeedrate() const { return slow_feedrate; }
+    float getFastFeedrate() const { return fast_feedrate; }
+    float getProbeHeight() const { return probe_height; }
+    float getMaxZ() const { return max_z; }
     float zsteps_to_mm(float steps);
 
 private:


### PR DESCRIPTION
added `leveling-strategy.delta-calibration.initial_height` to set the height above gamma_max the initial move off of home move to fast. Then it will slow to the slow probe speed. This is so the initial probe does not hit the bed too hard. (bad for FSRs).

G29 on delta strategy shows the maximum delta of the 7 probe points.