### PR TITLE
Print actuator position adjustments after homing

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -659,6 +659,10 @@ void Endstops::on_gcode_received(void *argument)
 
             if(home_all) {
                 // for deltas this may be important rather than setting each individually
+                float actuators_before[3];
+                for (int i = 0; i < 3; i++) {
+                    actuators_before[i] = THEKERNEL->robot->actuators[i]->get_current_position();
+                }
 
                 // Here's where we would have been if the endstops were perfectly trimmed
                 float ideal_position[3] = {
@@ -688,6 +692,16 @@ void Endstops::on_gcode_received(void *argument)
                     // Reset the actuator positions to correspond our real position
                     THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
                 }
+
+                float actuators_after[3];
+                for (int i = 0; i < 3; i++) {
+                    actuators_after[i] = THEKERNEL->robot->actuators[i]->get_current_position();
+                }
+                gcode->stream->printf("Adjusting actuator positions (mm): %.5f %.5f %.5f\n",
+                                      actuators_after[0] - actuators_before[0],
+                                      actuators_after[1] - actuators_before[1],
+                                      actuators_after[2] - actuators_before[2]);
+
             } else {
                 // Zero the ax(i/e)s position, add in the home offset
                 for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {


### PR DESCRIPTION
***Calibration 101 Lesson 1:*** Make sure your endstops are working properly.

I had suspected my endstops where acting-up sporadically, so I implemented the attached patch to investigate. A large number of ```G28```s (with 100 mm of moving back in between each) later, I got the following results:

![image](https://cloud.githubusercontent.com/assets/3725313/10125529/0406bf3a-652d-11e5-9eda-372cbc252641.png)

These are histograms showing the positions of each endstop trigger position. The x-axis unit is in steps. 80 steps/mm make each step 12.5 µm. Slow homing rate was 5 mm/sec.

Look at that alpha endstop(!). I replaced all three microswitch based endstops with optical ones:

![image](https://cloud.githubusercontent.com/assets/3725313/10125542/6340327e-652d-11e5-8adc-16f0eb54797c.png)

Better – now all three act like the beta-endstop did initially – but there are a number of -75 µm trigger points that look suspicious. Doubling the homing rate to 10 mm/sec:

![image](https://cloud.githubusercontent.com/assets/3725313/10125555/c0e6a00c-652d-11e5-9763-3d26556da95f.png)

Interestingly, those outlier trigger points move twice as far away – their cause seems to be related to time rather than position. Could there be something that the CPU starts doing at the wrong time making it miss the endstop signal by a few milliseconds?

Reducing the homing rate to 1 mm/sec made that problem mostly go away. All endstops are now repeatable to within ± 1 steps:

![image](https://cloud.githubusercontent.com/assets/3725313/10125565/0bf6c414-652e-11e5-82be-4dfb10f3e49e.png)

Anyway, I thought the attached patch, or even better a modified version of it that applies to single-axis homing as well, could help other users make sure their endstops are working as expected.

I also implemented a fix making all my homes end on exactly the same single microstep (>100 trials) by automatically repeating homing. If that sounds interesting, I'll wrap it up with config variables etc...

A few remaining questions:
* What causes the time-related outliers?
* Is it a good idea to lower the default slow homing rate?
* What kind of repeatability are others getting?