### PR TITLE
Fix OS X build script to run without 'ambiguous redirect' errors for references …

### DIFF
--- a/mac_install
+++ b/mac_install
@@ -16,8 +16,8 @@
 
 # Logs the command to be run and then executes the command while logging the results.
 RunAndLog () {
-    echo `date` Executing $@>>"$LOGFILE"
-    $@ 1>>"$LOGFILE" 2>"$ERRORFILE"
+    echo `date` Executing "$@">>"$LOGFILE"
+    "$@" 1>>"$LOGFILE" 2>"$ERRORFILE"
     if [ "$?" != "0" ] ; then
         cat "$ERRORFILE" >>"$LOGFILE"
         echo `date` Failure forced early exit>>"$LOGFILE"
@@ -35,18 +35,18 @@ ROOTDIR=$0
 ROOTDIR=${ROOTDIR%/*}
 pushd $ROOTDIR
 ROOTDIR=$PWD
-LOGFILE=$ROOTDIR/mac_install.log
-ERRORFILE=$ROOTDIR/mac_install.err
+LOGFILE="$ROOTDIR"/mac_install.log
+ERRORFILE="$ROOTDIR"/mac_install.err
 GCC4ARM_VERSION=gcc-arm-none-eabi-4_8-2014q1
 GCC4ARM_FILENAME=gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2
 GCC4ARM_URL=https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/$GCC4ARM_FILENAME
-GCC4ARM_TAR=$ROOTDIR/$GCC4ARM_FILENAME
+GCC4ARM_TAR="$ROOTDIR"/$GCC4ARM_FILENAME
 GCC4ARM_MD5=5d34d95a53ba545f1585b9136cbb6805
-GCC4ARM_EXTRACT=$ROOTDIR/$GCC4ARM_VERSION
-GCC4ARM_DIR=$ROOTDIR/gcc-arm-none-eabi
+GCC4ARM_EXTRACT="$ROOTDIR"/$GCC4ARM_VERSION
+GCC4ARM_DIR="$ROOTDIR"/gcc-arm-none-eabi
 GCC4ARM_BINDIR=$GCC4ARM_DIR/bin
-MACBIN_DIR=$ROOTDIR/build/osx64
-BUILDSHELL_CMD=$ROOTDIR/BuildShell
+MACBIN_DIR="$ROOTDIR"/build/osx64
+BUILDSHELL_CMD="$ROOTDIR"/BuildShell
 
 
 echo Logging install results to "$LOGFILE"
@@ -70,28 +70,29 @@ if [ "$archive_match" != "1" ] ; then
 fi
 
 echo Extracting GNU Tools for ARM Embedded Processors...
-rm -r $GCC4ARM_DIR >/dev/null 2>/dev/null
-RunAndLog tar xf $GCC4ARM_TAR
-RunAndLog mv $GCC4ARM_EXTRACT $GCC4ARM_DIR
+rm -r "$GCC4ARM_DIR" >/dev/null 2>/dev/null
+echo $GCC4ARM_TAR
+RunAndLog tar xf "$GCC4ARM_TAR"
+RunAndLog mv "$GCC4ARM_EXTRACT" "$GCC4ARM_DIR"
 
 echo Installing patched 64-bit Intel Mac OS X GDB binaries...
-RunAndLog cp $MACBIN_DIR/arm-none-eabi-gdb* $GCC4ARM_BINDIR/
+RunAndLog cp "$MACBIN_DIR"/arm-none-eabi-gdb* "$GCC4ARM_BINDIR/"
 
 echo Creating helper scripts...
-echo "#! /usr/bin/env bash">$BUILDSHELL_CMD
-echo "# Modify next line and set destination drive to match mbed device">>$BUILDSHELL_CMD
-echo "export LPC_DEPLOY='cp PROJECT.bin /Volumes/MBED/ ; sync'">>$BUILDSHELL_CMD
-echo>>$BUILDSHELL_CMD
-echo "SCRIPT_PATH=\$0">>$BUILDSHELL_CMD
-echo "SCRIPT_PATH=\${SCRIPT_PATH%/*}">>$BUILDSHELL_CMD
-echo "cd \$SCRIPT_PATH">>$BUILDSHELL_CMD
-echo "SCRIPT_PATH=\$PWD">>$BUILDSHELL_CMD
-echo "export PATH=\$SCRIPT_PATH/gcc-arm-none-eabi/bin:\$SCRIPT_PATH/build/osx64:\$PATH">>$BUILDSHELL_CMD
-echo "exec bash">>$BUILDSHELL_CMD
-chmod +x $BUILDSHELL_CMD
+echo "#! /usr/bin/env bash">"$BUILDSHELL_CMD"
+echo "# Modify next line and set destination drive to match mbed device">>"$BUILDSHELL_CMD"
+echo "export LPC_DEPLOY='cp PROJECT.bin /Volumes/MBED/ ; sync'">>"$BUILDSHELL_CMD"
+echo>>"$BUILDSHELL_CMD"
+echo "SCRIPT_PATH=\$0">>"$BUILDSHELL_CMD"
+echo "SCRIPT_PATH=\${SCRIPT_PATH%/*}">>"$BUILDSHELL_CMD"
+echo "cd \$SCRIPT_PATH">>"$BUILDSHELL_CMD"
+echo "SCRIPT_PATH=\$PWD">>"$BUILDSHELL_CMD"
+echo "export PATH=\$SCRIPT_PATH/gcc-arm-none-eabi/bin:\$SCRIPT_PATH/build/osx64:\$PATH">>"$BUILDSHELL_CMD"
+echo "exec bash">>"$BUILDSHELL_CMD"
+chmod +x "$BUILDSHELL_CMD"
 
 echo Cleaning up intermediate files...
-RunAndLog rm $GCC4ARM_TAR
+RunAndLog rm "$GCC4ARM_TAR"
 
 echo
 echo To build Smoothie, you will first need to run the following script

--- a/mac_install
+++ b/mac_install
@@ -16,13 +16,13 @@
 
 # Logs the command to be run and then executes the command while logging the results.
 RunAndLog () {
-    echo `date` Executing $@>>$LOGFILE
-    $@ 1>>$LOGFILE 2>$ERRORFILE
+    echo `date` Executing $@>>"$LOGFILE"
+    $@ 1>>"$LOGFILE" 2>"$ERRORFILE"
     if [ "$?" != "0" ] ; then
-        cat $ERRORFILE >>$LOGFILE
-        echo `date` Failure forced early exit>>$LOGFILE
-        cat $LOGFILE
-        rm -f $ERRORFILE
+        cat "$ERRORFILE" >>"$LOGFILE"
+        echo `date` Failure forced early exit>>"$LOGFILE"
+        cat "$LOGFILE"
+        rm -f "$ERRORFILE"
         popd >/dev/null
         read -n 1 -sp "Press any key to continue..." dummy ; echo
         exit 1
@@ -49,21 +49,21 @@ MACBIN_DIR=$ROOTDIR/build/osx64
 BUILDSHELL_CMD=$ROOTDIR/BuildShell
 
 
-echo Logging install results to $LOGFILE
-echo `date` Starting $0 $*>$LOGFILE
+echo Logging install results to "$LOGFILE"
+echo `date` Starting $0 $*>"$LOGFILE"
 
 echo Downloading GNU Tools for ARM Embedded Processors...
-echo `date` Executing curl -L0 $GCC4ARM_URL>>$LOGFILE
+echo `date` Executing curl -L0 $GCC4ARM_URL>>"$LOGFILE"
 curl -L0 $GCC4ARM_URL >$GCC4ARM_FILENAME
 
 echo Validating md5 signature of GNU Tools for ARM Embedded Processors...
-echo `date` Validating md5 signature of GNU Tools for ARM Embedded Processors>>$LOGFILE
+echo `date` Validating md5 signature of GNU Tools for ARM Embedded Processors>>"$LOGFILE"
 archive_match=`md5 -q $GCC4ARM_FILENAME | grep -c $GCC4ARM_MD5`
 if [ "$archive_match" != "1" ] ; then
-    echo $GCC4ARM_FILENAME failed MD5 signature check.>>$LOGFILE
-    echo `date` Failure forced early exit>>$LOGFILE
-    cat $LOGFILE
-    rm -f $ERRORFILE
+    echo $GCC4ARM_FILENAME failed MD5 signature check.>>"$LOGFILE"
+    echo `date` Failure forced early exit>>"$LOGFILE"
+    cat "$LOGFILE"
+    rm -f "$ERRORFILE"
     popd >/dev/null
     read -n 1 -sp "Press any key to continue..." dummy ; echo
     exit 1
@@ -108,8 +108,8 @@ echo  $GCC4ARM_BINDIR
 
 
 # Restore current directory and exit script on success.
-echo `date` Finished successfully>>$LOGFILE
+echo `date` Finished successfully>>"$LOGFILE"
 echo Finished successfully
-rm -f $ERRORFILE
+rm -f "$ERRORFILE"
 popd >/dev/null
 read -n 1 -sp "Press any key to continue..." dummy ; echo


### PR DESCRIPTION
…to $LOGFILE and $ERRORFILE when directory path has spaces in it