### PR TITLE
Added an panel.init property to the ST7565 module to specify a custom display init sequence

### DIFF
--- a/src/modules/utils/panel/panels/ST7565.h
+++ b/src/modules/utils/panel/panels/ST7565.h
@@ -72,6 +72,9 @@ private:
     Pin red_led;
     Pin blue_led;
 
+	unsigned char Init[50];
+	uint16_t InitLen=0;
+	
 	// text cursor position
 	uint8_t tx, ty;
     uint8_t contrast;


### PR DESCRIPTION
Hi Arthur,

I don't know if this will be useful to others but I have added an option to the ST7565 module so that the user can specify the initial display init bytes. I have a display that has a different row/column config and is upside down and reversed with the default init code.

Sample:
panel.lcd                                    st7565_glcd
panel.init                                    e2,a6,a4,a0,ae,c0,a2,2f,21,25,81,2f,af

If there are any violated standards then please tell me.

Thank you,
Errol

