### PR TITLE
Reset Watchdog introduced to capture especially heating problems afte…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include "libs/Kernel.h"
 
+#include "ResetWatchdog.h"
 #include "modules/tools/laser/Laser.h"
 #include "modules/tools/spindle/Spindle.h"
 #include "modules/tools/extruder/ExtruderMaker.h"
@@ -17,8 +18,7 @@
 #include "modules/tools/switch/SwitchPool.h"
 #include "modules/tools/temperatureswitch/TemperatureSwitch.h"
 #include "modules/tools/drillingcycles/Drillingcycles.h"
-#include "FilamentDetector.h"
-
+#include "modules/tools/filamentdetector/FilamentDetector.h"
 #include "modules/robot/Conveyor.h"
 #include "modules/utils/simpleshell/SimpleShell.h"
 #include "modules/utils/configurator/Configurator.h"
@@ -128,6 +128,7 @@ void init() {
 
 
     // Create and add main modules
+    kernel->add_module(new ResetWatchdog);
     kernel->add_module( new SimpleShell() );
     kernel->add_module( new Configurator() );
     kernel->add_module( new CurrentControl() );

--- a/src/modules/utils/resetWatchdog/ResetWatchdog.cpp
+++ b/src/modules/utils/resetWatchdog/ResetWatchdog.cpp
@@ -1,0 +1,40 @@
+#include "ResetWatchdog.h"
+#include "Kernel.h"
+#include "SlowTicker.h"
+#include "StreamOutputPool.h"
+#include "SerialMessage.h"
+
+ResetWatchdog::ResetWatchdog(){
+   if(WDT_ReadTimeOutFlag() == SET){
+      awaked_from_reset = true;
+      WDT_ClrTimeOutFlag();
+      connected = false;
+   }
+}
+
+void ResetWatchdog::on_module_loaded(){
+   WDT_Init(WDT_CLKSRC_PCLK,WDT_MODE_RESET);
+   WDT_Start(100000);   // in micrseconds
+   THEKERNEL->slow_ticker->attach( (unsigned int)11, this, &ResetWatchdog::watchdog_tick ); // readings per second must be appropriate to restart the watchdog before timeout
+   this->register_for_event(ON_GCODE_RECEIVED);
+}
+
+uint32_t ResetWatchdog::watchdog_tick(uint32_t dummy){
+   WDT_Feed();
+   return 0;
+}
+
+// G-Code can be only received if connected.
+// Needed to ensure that the user sees the message
+void ResetWatchdog::on_gcode_received( void *argument ) {
+   //Gcode *gcode = static_cast<Gcode *>(argument);
+
+   if(!connected){
+      connected = true;
+      if(awaked_from_reset){
+         THEKERNEL->streams->printf("// Booted after internal Reset trigger, because of a firmware crash.\n");
+         awaked_from_reset = false;
+      }
+   }
+}
+

--- a/src/modules/utils/resetWatchdog/ResetWatchdog.h
+++ b/src/modules/utils/resetWatchdog/ResetWatchdog.h
@@ -1,0 +1,22 @@
+#ifndef RESETWATCHDOG_H
+#define RESETWATCHDOG_H
+
+#include "lpc17xx_wdt.h"
+#include "Module.h"
+
+class ResetWatchdog : public Module {
+    public:
+        ResetWatchdog();
+
+        void on_module_loaded();
+        void on_gcode_received( void *argument );
+        uint32_t watchdog_tick(uint32_t dummy);
+
+    private:
+        struct {
+              bool awaked_from_reset:1;
+              bool connected:1;
+        };
+};
+
+#endif


### PR DESCRIPTION
…r firmware crash.

This is especially important for firmware crashes in the heating environment.
Since after a firmware crash there may be no control over the heating mechanism anymore!
The feature itself is used in our 3d printer, but with some code modifications, because of other dependencies.
