### PR TITLE
Add support for AD8495 Thermocouple amplifier

### DIFF
--- a/src/modules/tools/temperaturecontrol/AD8495.cpp
+++ b/src/modules/tools/temperaturecontrol/AD8495.cpp
@@ -1,0 +1,84 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "AD8495.h"
+#include "libs/Kernel.h"
+#include "libs/Pin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "Adc.h"
+#include "ConfigValue.h"
+#include "libs/Median.h"
+#include "utils.h"
+#include "StreamOutputPool.h"
+
+#include <fastmath.h>
+
+#include "MRI_Hooks.h"
+
+#define UNDEFINED -1
+
+#define AD8495_checksum                CHECKSUM("AD8495")
+#define AD8495_pin_checksum            CHECKSUM("AD8495_pin")
+
+AD8495::AD8495()
+{
+    min_temp= 999;
+    max_temp= 0;
+}
+
+AD8495::~AD8495()
+{
+}
+
+// Get configuration from the config file
+void AD8495::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
+{
+    // Thermistor pin for ADC readings
+    this->AD8495_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, AD8495_pin_checksum)->required()->as_string());
+    THEKERNEL->adc->enable_pin(&AD8495_pin);
+}
+
+
+float AD8495::get_temperature()
+{
+    float t= adc_value_to_temperature(new_AD8495_reading());
+    // keep track of min/max for M305
+    if(t > max_temp) max_temp= t;
+    if(t < min_temp) min_temp= t;
+    return t;
+}
+
+void AD8495::get_raw()
+{
+
+    int adc_value= new_AD8495_reading();
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
+    float t=((float)adc_value)/(((float)max_adc_value)/3.3*0.005);
+
+    THEKERNEL->streams->printf("adc= %d, max_adc= %u, temp= %f\n", adc_value,max_adc_value,t);
+
+    // reset the min/max
+    min_temp= max_temp= t;
+}
+
+float AD8495::adc_value_to_temperature(uint32_t adc_value)
+{
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
+    if ((adc_value >= max_adc_value))
+        return infinityf();
+
+    float t=((float)adc_value)/(((float)max_adc_value)/3.3*0.005);
+
+    return t;
+}
+
+int AD8495::new_AD8495_reading()
+{
+    // filtering now done in ADC
+    return THEKERNEL->adc->read(&AD8495_pin);
+}

--- a/src/modules/tools/temperaturecontrol/AD8495.h
+++ b/src/modules/tools/temperaturecontrol/AD8495.h
@@ -1,0 +1,41 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef AD8495_H
+#define AD8495_H
+
+#include "TempSensor.h"
+#include "RingBuffer.h"
+#include "Pin.h"
+
+#include <tuple>
+
+#define QUEUE_LEN 32
+
+class StreamOutput;
+
+class AD8495 : public TempSensor
+{
+    public:
+        AD8495();
+        ~AD8495();
+
+        // TempSensor interface.
+        void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
+        float get_temperature();
+        void get_raw();
+
+    private:
+        int new_AD8495_reading();
+        float adc_value_to_temperature(uint32_t adc_value);
+
+        Pin  AD8495_pin;
+
+        float min_temp, max_temp;
+};
+
+#endif

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -32,6 +32,7 @@
 // Temp sensor implementations:
 #include "Thermistor.h"
 #include "max31855.h"
+#include "AD8495.h"
 
 #include "MRI_Hooks.h"
 
@@ -157,6 +158,8 @@ void TemperatureControl::load_config()
         sensor = new Thermistor();
     } else if(sensor_type.compare("max31855") == 0) {
         sensor = new Max31855();
+    } else if(sensor_type.compare("ad8495") == 0) {
+        sensor = new AD8495();
     } else {
         sensor = new TempSensor(); // A dummy implementation
     }


### PR DESCRIPTION
Added support for the AD8495 amplifier that outputs 5mV/C. 

If the AD8495 connects to a thermistor input, but gets disconnected then Infinity is returned as the temperature.

If the thermocouple disconnects from the amplifier, if disconnection detection is set up on the amplifier, it will return around 630C.
