### PR TITLE
Allow bulge detector without encoder in filament detector

### DIFF
--- a/src/modules/tools/filamentdetector/FilamentDetector.cpp
+++ b/src/modules/tools/filamentdetector/FilamentDetector.cpp
@@ -58,15 +58,6 @@ void FilamentDetector::on_module_loaded()
     Pin dummy_pin;
     dummy_pin.from_string( THEKERNEL->config->value(filament_detector_checksum, encoder_pin_checksum)->by_default("nc" )->as_string());
     this->encoder_pin= dummy_pin.interrupt_pin();
-    if(this->encoder_pin == nullptr) {
-        // was not a valid interrupt pin
-        delete this;
-        return;
-    }
-
-    // set interrupt on rising edge
-    this->encoder_pin->rise(this, &FilamentDetector::on_pin_rise);
-    NVIC_SetPriority(EINT3_IRQn, 16); // set to low priority
 
     // optional bulge detector
     bulge_pin.from_string( THEKERNEL->config->value(filament_detector_checksum, bulge_pin_checksum)->by_default("nc" )->as_string())->as_input();
@@ -75,6 +66,21 @@ void FilamentDetector::on_module_loaded()
         THEKERNEL->slow_ticker->attach( 100, this, &FilamentDetector::button_tick);
     }
 
+    //Valid configurations contain an encoder pin, a bulge pin or both.
+    //free the module if not a valid configuration
+    if(this->encoder_pin == nullptr && !bulge_pin.connected()) {
+        delete this;
+        return;
+    }
+
+    //only monitor the encoder if we are using the encodeer.
+    if (this->encoder_pin != nullptr) {
+        // set interrupt on rising edge
+        this->encoder_pin->rise(this, &FilamentDetector::on_pin_rise);
+        NVIC_SetPriority(EINT3_IRQn, 16); // set to low priority
+    }
+
+
     // how many seconds between checks, must be long enough for several pulses to be detected, but not too long
     seconds_per_check= THEKERNEL->config->value(filament_detector_checksum, seconds_per_check_checksum)->by_default(2)->as_number();
 
@@ -82,11 +88,16 @@ void FilamentDetector::on_module_loaded()
     pulses_per_mm= THEKERNEL->config->value(filament_detector_checksum, pulses_per_mm_checksum)->by_default(1)->as_number();
 
     // register event-handlers
-    register_for_event(ON_SECOND_TICK);
+    if (this->encoder_pin != nullptr) {
+        //This event is only valid if we are using the encodeer.
+        register_for_event(ON_SECOND_TICK); 
+    }
+    
     register_for_event(ON_MAIN_LOOP);
     register_for_event(ON_CONSOLE_LINE_RECEIVED);
     this->register_for_event(ON_GCODE_RECEIVED);
 }
+
 
 void FilamentDetector::send_command(std::string msg, StreamOutput *stream)
 {
@@ -224,7 +235,7 @@ void FilamentDetector::check_encoder()
 
 uint32_t FilamentDetector::button_tick(uint32_t dummy)
 {
-    if(!bulge_pin.connected() || suspended) return 0;
+    if(!bulge_pin.connected() || suspended || !active) return 0;
 
     if(bulge_pin.get()) {
         // we got a trigger from the bulge detector


### PR DESCRIPTION
Allows the module to be instantiated if the bulge detector exists but
the encoder does not. Inhibits attachment to events for the encoder if
the encoder doesn’t exist.

I was able to test this with the bulge detector and it works as expected. I am not able to test the encoder functionality but that functionality should be completely untouched by this pull request.