### PR TITLE
Implement G54-G59.3 Select Coordinate System, and change G92 handling, merge nmotors

### DIFF
--- a/src/libs/nuts_bolts.h
+++ b/src/libs/nuts_bolts.h
@@ -28,6 +28,9 @@ along with Grbl. If not, see <http://www.gnu.org/licenses/>.
 #define ALPHA_STEPPER 0
 #define BETA_STEPPER 1
 #define GAMMA_STEPPER 2
+#define DELTA_STEPPER 3
+#define EPSILON_STEPPER 4
+#define ZETA_STEPPER 5
 
 #define clear_vector(a) memset(a, 0, sizeof(a))
 #define clear_vector_float(a) memset(a, 0, sizeof(a))

--- a/src/modules/robot/ActuatorCoordinates.h
+++ b/src/modules/robot/ActuatorCoordinates.h
@@ -1,0 +1,21 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ACTUATOR_COORDINATES_H
+#define ACTUATOR_COORDINATES_H
+#include <array>
+
+#ifndef MAX_ROBOT_ACTUATORS
+#define MAX_ROBOT_ACTUATORS 3
+#endif
+
+//The subset in use is determined by the arm solution's get_actuator_count().
+//Keep MAX_ROBOT_ACTUATORS as small as practical it impacts block size and therefore free memory.
+const size_t k_max_actuators = MAX_ROBOT_ACTUATORS;
+typedef struct std::array<float, k_max_actuators> ActuatorCoordinates;
+
+#endif

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -39,7 +39,7 @@ void Block::clear()
     gcodes.clear();
     std::vector<Gcode>().swap(gcodes); // this resizes the vector releasing its memory
 
-    clear_vector(this->steps);
+    this->steps.fill(0);
 
     steps_event_count   = 0;
     nominal_rate        = 0;

--- a/src/modules/robot/Block.h
+++ b/src/modules/robot/Block.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <bitset>
+#include "ActuatorCoordinates.h"
 
 class Gcode;
 
@@ -41,14 +42,14 @@ class Block {
 
         std::vector<Gcode> gcodes;
 
-        unsigned int   steps[3];           // Number of steps for each axis for this block
+        std::array<int, k_max_actuators>   steps; // Number of steps for each axis for this block
         unsigned int   steps_event_count;  // Steps for the longest axis
         unsigned int   nominal_rate;       // Nominal rate in steps per second
         float          nominal_speed;      // Nominal speed in mm per second
         float          millimeters;        // Distance for this move
         float          entry_speed;
         float          exit_speed;
-        float          rate_delta;         // Nomber of steps to add to the speed for each acceleration tick
+        float          rate_delta;         // Number of steps to add to the speed for each acceleration tick
         float          acceleration;       // the acceleratoin for this block
         unsigned int   initial_rate;       // Initial speed in steps per second
         unsigned int   final_rate;         // Final speed in steps per second
@@ -59,7 +60,7 @@ class Block {
 
         short times_taken;    // A block can be "taken" by any number of modules, and the next block is not moved to until all the modules have "released" it. This value serves as a tracker.
 
-        std::bitset<3> direction_bits;     // Direction for each axis in bit form, relative to the direction port's mask
+        std::bitset<k_max_actuators> direction_bits;     // Direction for each axis in bit form, relative to the direction port's mask
         struct {
             bool recalculate_flag:1;             // Planner flag to recalculate trapezoids on entry junction
             bool nominal_length_flag:1;          // Planner flag for nominal speed always reached

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -53,7 +53,7 @@ void Planner::config_load(){
 
 
 // Append a block to the queue, compute it's speed factors
-void Planner::append_block( float actuator_pos[], float rate_mm_s, float distance, float unit_vec[] )
+void Planner::append_block( ActuatorCoordinates &actuator_pos, float rate_mm_s, float distance, float unit_vec[] )
 {
     float acceleration, junction_deviation;
 
@@ -62,7 +62,7 @@ void Planner::append_block( float actuator_pos[], float rate_mm_s, float distanc
 
 
     // Direction bits
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < THEKERNEL->robot->actuators.size(); i++)
     {
         int steps = THEKERNEL->robot->actuators[i]->steps_to_target(actuator_pos[i]);
 
@@ -88,7 +88,10 @@ void Planner::append_block( float actuator_pos[], float rate_mm_s, float distanc
     block->acceleration= acceleration; // save in block
 
     // Max number of steps, for all axes
-    block->steps_event_count = max( block->steps[ALPHA_STEPPER], max( block->steps[BETA_STEPPER], block->steps[GAMMA_STEPPER] ) );
+    int steps_event_count = 0;
+    for (size_t s = 0; s < THEKERNEL->robot->actuators.size(); s++)
+        steps_event_count = std::max(steps_event_count, block->steps[s]);
+    block->steps_event_count = steps_event_count;
 
     block->millimeters = distance;
 

--- a/src/modules/robot/Planner.h
+++ b/src/modules/robot/Planner.h
@@ -8,13 +8,14 @@
 #ifndef PLANNER_H
 #define PLANNER_H
 
+#include "ActuatorCoordinates.h"
 class Block;
 
 class Planner
 {
 public:
     Planner();
-    void append_block( float target[], float rate_mm_s, float distance, float unit_vec[] );
+    void append_block(ActuatorCoordinates &target, float rate_mm_s, float distance, float unit_vec[] );
     float max_allowable_speed( float acceleration, float target_velocity, float distance);
     void recalculate();
     Block *get_current_block();

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -329,9 +329,9 @@ void Robot::on_gcode_received(void *argument)
                 } else {
                     float x, y, z;
                     std::tie(x, y, z)= g92_offset;
-                    if(gcode->has_letter('X')) x= to_millimeters(gcode->get_value('X')) - last_milestone[0];
-                    if(gcode->has_letter('Y')) y= to_millimeters(gcode->get_value('Y')) - last_milestone[1];
-                    if(gcode->has_letter('Z')) z= to_millimeters(gcode->get_value('Z')) - last_milestone[2];
+                    if(gcode->has_letter('X')) x= last_milestone[0] - to_millimeters(gcode->get_value('X'));
+                    if(gcode->has_letter('Y')) y= last_milestone[1] - to_millimeters(gcode->get_value('Y'));
+                    if(gcode->has_letter('Z')) z= last_milestone[2] - to_millimeters(gcode->get_value('Z'));
                     g92_offset= wcs_t(x, y, z);
                 }
                 return;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -373,9 +373,9 @@ void Robot::on_gcode_received(void *argument)
                 }else if(gcode->subcode == 1) { // M114.1 print Machine coordinate system
                     // TODO figure this out
                      n = snprintf(buf, sizeof(buf), "X:%1.3f Y:%1.3f Z:%1.3f",
-                                 from_millimeters(this->last_milestone[0]),
-                                 from_millimeters(this->last_milestone[1]),
-                                 from_millimeters(this->last_milestone[2]));
+                                 from_millimeters(this->last_milestone[0]) - (std::get<0>(wcs_offsets[current_wcs]) + std::get<0>(g92_offset)),
+                                 from_millimeters(this->last_milestone[1]) - (std::get<1>(wcs_offsets[current_wcs]) + std::get<1>(g92_offset)),
+                                 from_millimeters(this->last_milestone[2]) - (std::get<2>(wcs_offsets[current_wcs]) + std::get<2>(g92_offset)) );
 
                 }else if(gcode->subcode == 2) { // M114.2 print realtime actuator position
                     n = snprintf(buf, sizeof(buf), "A:%1.3f B:%1.3f C:%1.3f",

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -114,9 +114,9 @@ Robot::Robot()
     this->arm_solution = NULL;
     seconds_per_minute = 60.0F;
     this->clearToolOffset();
-    this->compensationTransform= nullptr;
-    this->wcs_offsets.fill(wcs_t(0.0F,0.0F,0.0F));
-    this->g92_offset= wcs_t(0.0F,0.0F,0.0F);
+    this->compensationTransform = nullptr;
+    this->wcs_offsets.fill(wcs_t(0.0F, 0.0F, 0.0F));
+    this->g92_offset = wcs_t(0.0F, 0.0F, 0.0F);
 }
 
 //Called when the module has just been loaded
@@ -192,7 +192,7 @@ void Robot::load_config()
         ACTUATOR_CHECKSUMS("zeta")
 #endif
     };
-    constexpr size_t actuator_checksum_count = sizeof(checksums)/sizeof(checksums[0]);
+    constexpr size_t actuator_checksum_count = sizeof(checksums) / sizeof(checksums[0]);
     static_assert(actuator_checksum_count >= k_max_actuators, "Robot checksum array too small for k_max_actuators");
 
     size_t motor_count = std::min(this->arm_solution->get_actuator_count(), k_max_actuators);
@@ -201,9 +201,9 @@ void Robot::load_config()
         for (size_t i = 0; i < 3; i++) {
             pins[i].from_string(THEKERNEL->config->value(checksums[a][i])->by_default("nc")->as_string())->as_output();
         }
-        actuators[a]= new StepperMotor(pins[0], pins[1], pins[2]);
+        actuators[a] = new StepperMotor(pins[0], pins[1], pins[2]);
 
-        actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a==2 ? 2560.0F : 80.0F)->as_number());
+        actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
         actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number());
     }
 
@@ -221,21 +221,21 @@ void Robot::load_config()
 
 void  Robot::push_state()
 {
-    bool am= this->absolute_mode;
-    bool im= this->inch_mode;
+    bool am = this->absolute_mode;
+    bool im = this->inch_mode;
     saved_state_t s(this->feed_rate, this->seek_rate, am, im);
     state_stack.push(s);
 }
 
 void Robot::pop_state()
 {
-   if(!state_stack.empty()) {
-        auto s= state_stack.top();
+    if(!state_stack.empty()) {
+        auto s = state_stack.top();
         state_stack.pop();
-        this->feed_rate= std::get<0>(s);
-        this->seek_rate= std::get<1>(s);
-        this->absolute_mode= std::get<2>(s);
-        this->inch_mode= std::get<3>(s);
+        this->feed_rate = std::get<0>(s);
+        this->seek_rate = std::get<1>(s);
+        this->absolute_mode = std::get<2>(s);
+        this->inch_mode = std::get<3>(s);
     }
 }
 
@@ -247,7 +247,7 @@ void Robot::check_max_actuator_speeds()
         float step_freq = actuators[i]->get_max_rate() * actuators[i]->get_steps_per_mm();
         if (step_freq > THEKERNEL->base_stepping_frequency) {
             actuators[i]->set_max_rate(floorf(THEKERNEL->base_stepping_frequency / actuators[i]->get_steps_per_mm()));
-            THEKERNEL->streams->printf("WARNING: actuator %c rate exceeds base_stepping_frequency * alpha_steps_per_mm: %f, setting to %f\n", 'A'+i, step_freq, actuators[i]->max_rate);
+            THEKERNEL->streams->printf("WARNING: actuator %c rate exceeds base_stepping_frequency * alpha_steps_per_mm: %f, setting to %f\n", 'A' + i, step_freq, actuators[i]->max_rate);
         }
     }
 }
@@ -268,19 +268,19 @@ void Robot::on_gcode_received(void *argument)
             case 2:  this->motion_mode = MOTION_MODE_CW_ARC;   break;
             case 3:  this->motion_mode = MOTION_MODE_CCW_ARC;   break;
             case 4: {
-                uint32_t delay_ms= 0;
+                uint32_t delay_ms = 0;
                 if (gcode->has_letter('P')) {
-                    delay_ms= gcode->get_int('P');
+                    delay_ms = gcode->get_int('P');
                 }
                 if (gcode->has_letter('S')) {
                     delay_ms += gcode->get_int('S') * 1000;
                 }
-                if (delay_ms > 0){
+                if (delay_ms > 0) {
                     // drain queue
                     THEKERNEL->conveyor->wait_for_empty_queue();
                     // wait for specified time
-                    uint32_t start= us_ticker_read(); // mbed call
-                    while ((us_ticker_read() - start) < delay_ms*1000) {
+                    uint32_t start = us_ticker_read(); // mbed call
+                    while ((us_ticker_read() - start) < delay_ms * 1000) {
                         THEKERNEL->call_event(ON_IDLE, this);
                     }
                 }
@@ -290,16 +290,16 @@ void Robot::on_gcode_received(void *argument)
             case 10: // G10 L2 Pn Xn Yn Zn set WCS
                 // TODO implement G10 L20
                 if(gcode->has_letter('L') && gcode->get_int('L') == 2 && gcode->has_letter('P')) {
-                    size_t n= gcode->get_uint('P');
-                    if(n == 0) n= current_wcs; // set current coordinate system
+                    size_t n = gcode->get_uint('P');
+                    if(n == 0) n = current_wcs; // set current coordinate system
                     else --n;
                     if(n < k_max_wcs) {
                         float x, y, z;
-                        std::tie(x, y, z)= wcs_offsets[n];
-                        if(gcode->has_letter('X')) x= this->to_millimeters(gcode->get_value('X'));
-                        if(gcode->has_letter('Y')) y= this->to_millimeters(gcode->get_value('Y'));
-                        if(gcode->has_letter('Z')) z= this->to_millimeters(gcode->get_value('Z'));
-                        wcs_offsets[n]= wcs_t(x, y, z);
+                        std::tie(x, y, z) = wcs_offsets[n];
+                        if(gcode->has_letter('X')) x = this->to_millimeters(gcode->get_value('X'));
+                        if(gcode->has_letter('Y')) y = this->to_millimeters(gcode->get_value('Y'));
+                        if(gcode->has_letter('Z')) z = this->to_millimeters(gcode->get_value('Z'));
+                        wcs_offsets[n] = wcs_t(x, y, z);
                     }
                 }
                 break;
@@ -312,10 +312,10 @@ void Robot::on_gcode_received(void *argument)
 
             case 54: case 55: case 56: case 57: case 58: case 59:
                 // select WCS 0-8: G54..G59, G59.1, G59.2, G59.3
-                current_wcs= gcode->g - 54;
+                current_wcs = gcode->g - 54;
                 if(gcode->g == 59 && gcode->subcode > 0) {
                     current_wcs += gcode->subcode;
-                    if(current_wcs >= k_max_wcs) current_wcs= k_max_wcs-1;
+                    if(current_wcs >= k_max_wcs) current_wcs = k_max_wcs - 1;
                 }
                 break;
 
@@ -324,15 +324,43 @@ void Robot::on_gcode_received(void *argument)
 
             case 92: {
                 if(gcode->subcode == 1 || gcode->subcode == 2 || gcode->get_num_args() == 0) {
-                    g92_offset= wcs_t(0,0,0);
+                    // reset G92 offsets to 0
+                    g92_offset = wcs_t(0, 0, 0);
+
+                } else if(gcode->subcode == 3) {
+                    // non-standard - set machine coordinates (like old G92 would do) basically a manual home
+                    if(gcode->get_num_args() == 0) {
+                        // sets current position to 0,0,0 in machine coordinates
+                        for (int i = X_AXIS; i <= Z_AXIS; ++i) reset_axis_position(0, i);
+
+                        // now we need to clear the g92 offsets, and set last_milestone
+                        // TODO is this correct? What about the compensationTransform? do we need the dreaded inverseCompensation Transform?
+                        g92_offset = wcs_t(0, 0, 0);
+                        this->last_milestone[0] -= std::get<0>(wcs_offsets[current_wcs]);
+                        this->last_milestone[1] -= std::get<1>(wcs_offsets[current_wcs]);
+                        this->last_milestone[2] -= std::get<2>(wcs_offsets[current_wcs]);
+
+                    } else {
+                        // sets the given axis to the provided value
+                        float x, y, z;
+                        std::tie(x, y, z) = g92_offset;
+                        if(gcode->has_letter('X')) { reset_axis_position(this->to_millimeters(gcode->get_value('X')), X_AXIS); this->last_milestone[0] -= std::get<0>(wcs_offsets[current_wcs]); x= 0; }
+                        if(gcode->has_letter('Y')) { reset_axis_position(this->to_millimeters(gcode->get_value('Y')), Y_AXIS); this->last_milestone[1] -= std::get<1>(wcs_offsets[current_wcs]); y= 0; }
+                        if(gcode->has_letter('Z')) { reset_axis_position(this->to_millimeters(gcode->get_value('Z')), Z_AXIS); this->last_milestone[2] -= std::get<2>(wcs_offsets[current_wcs]); z= 0; }
+
+                        // reset the g92 offset
+                        g92_offset = wcs_t(x, y, z);
+                    }
+
 
                 } else {
+                    // standard setting of the g92 offsets, making current position whatever the coordinate arguments are
                     float x, y, z;
-                    std::tie(x, y, z)= g92_offset;
-                    if(gcode->has_letter('X')) x= last_milestone[0] - to_millimeters(gcode->get_value('X'));
-                    if(gcode->has_letter('Y')) y= last_milestone[1] - to_millimeters(gcode->get_value('Y'));
-                    if(gcode->has_letter('Z')) z= last_milestone[2] - to_millimeters(gcode->get_value('Z'));
-                    g92_offset= wcs_t(x, y, z);
+                    std::tie(x, y, z) = g92_offset;
+                    if(gcode->has_letter('X')) x = last_milestone[0] - to_millimeters(gcode->get_value('X'));
+                    if(gcode->has_letter('Y')) y = last_milestone[1] - to_millimeters(gcode->get_value('Y'));
+                    if(gcode->has_letter('Z')) z = last_milestone[2] - to_millimeters(gcode->get_value('Z'));
+                    g92_offset = wcs_t(x, y, z);
                 }
                 return;
             }
@@ -341,8 +369,8 @@ void Robot::on_gcode_received(void *argument)
     } else if( gcode->has_m) {
         switch( gcode->m ) {
             case 2: // M2 end of program
-                current_wcs= 0;
-                absolute_mode= true;
+                current_wcs = 0;
+                absolute_mode = true;
                 motion_mode = MOTION_MODE_LINEAR; // feed
                 break;
 
@@ -363,21 +391,21 @@ void Robot::on_gcode_received(void *argument)
 
             case 114: {
                 char buf[64];
-                int n= 0;
+                int n = 0;
                 if(gcode->subcode == 0) { // M114 print WCS
                     n = snprintf(buf, sizeof(buf), "C: X:%1.3f Y:%1.3f Z:%1.3f",
                                  from_millimeters(this->last_milestone[0]),
                                  from_millimeters(this->last_milestone[1]),
                                  from_millimeters(this->last_milestone[2]));
 
-                }else if(gcode->subcode == 1) { // M114.1 print Machine coordinate system
+                } else if(gcode->subcode == 1) { // M114.1 print Machine coordinate system
                     // TODO figure this out
-                     n = snprintf(buf, sizeof(buf), "X:%1.3f Y:%1.3f Z:%1.3f",
-                                 from_millimeters(this->last_milestone[0]) - (std::get<0>(wcs_offsets[current_wcs]) + std::get<0>(g92_offset)),
-                                 from_millimeters(this->last_milestone[1]) - (std::get<1>(wcs_offsets[current_wcs]) + std::get<1>(g92_offset)),
-                                 from_millimeters(this->last_milestone[2]) - (std::get<2>(wcs_offsets[current_wcs]) + std::get<2>(g92_offset)) );
+                    n = snprintf(buf, sizeof(buf), "X:%1.3f Y:%1.3f Z:%1.3f",
+                                 from_millimeters(this->last_milestone[0]) + (std::get<0>(wcs_offsets[current_wcs]) + std::get<0>(g92_offset)),
+                                 from_millimeters(this->last_milestone[1]) + (std::get<1>(wcs_offsets[current_wcs]) + std::get<1>(g92_offset)),
+                                 from_millimeters(this->last_milestone[2]) + (std::get<2>(wcs_offsets[current_wcs]) + std::get<2>(g92_offset)) );
 
-                }else if(gcode->subcode == 2) { // M114.2 print realtime actuator position
+                } else if(gcode->subcode == 2) { // M114.2 print realtime actuator position
                     n = snprintf(buf, sizeof(buf), "A:%1.3f B:%1.3f C:%1.3f",
                                  actuators[X_AXIS]->get_current_position(),
                                  actuators[Y_AXIS]->get_current_position(),
@@ -411,7 +439,7 @@ void Robot::on_gcode_received(void *argument)
 
                 if(gcode->get_num_args() == 0) {
                     gcode->stream->printf("X:%g Y:%g Z:%g",
-                        this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS]);
+                                          this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS]);
                     for (size_t i = 0; i < 3 && i < actuators.size(); i++) {
                         gcode->stream->printf(" %c : %g", 'A' + i, actuators[i]->get_max_rate()); //xxx
                     }
@@ -474,7 +502,7 @@ void Robot::on_gcode_received(void *argument)
                         factor = 1000.0F;
 
                     seconds_per_minute = 6000.0F / factor;
-                }else{
+                } else {
                     gcode->stream->printf("Speed factor at %6.2f %%\n", 6000.0F / seconds_per_minute);
                 }
                 break;
@@ -490,7 +518,7 @@ void Robot::on_gcode_received(void *argument)
                 gcode->stream->printf(";X- Junction Deviation, Z- Z junction deviation, S - Minimum Planner speed mm/sec:\nM205 X%1.5f Z%1.5f S%1.5f\n", THEKERNEL->planner->junction_deviation, THEKERNEL->planner->z_junction_deviation, THEKERNEL->planner->minimum_planner_speed);
                 gcode->stream->printf(";Max feedrates in mm/sec, XYZ cartesian, ABC actuator:\nM203 X%1.5f Y%1.5f Z%1.5f",
                                       this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS]);
-                for (size_t i=0; i < 3 && i < actuators.size(); i++){
+                for (size_t i = 0; i < 3 && i < actuators.size(); i++) {
                     gcode->stream->printf(" %c%1.5f", 'A' + i, actuators[i]->get_max_rate());
                 }
                 gcode->stream->printf("\n");
@@ -510,13 +538,13 @@ void Robot::on_gcode_received(void *argument)
                 gcode->stream->printf(";WCS settings\n");
                 gcode->stream->printf("G5%c", std::min(current_wcs, (uint8_t)(5 + '4')));
                 if(current_wcs >= 6) {
-                   gcode->stream->printf(".%c\n",  '1' + (current_wcs-5));
-                }else{
+                    gcode->stream->printf(".%c\n",  '1' + (current_wcs - 5));
+                } else {
                     gcode->stream->printf("\n");
                 }
-                int n= 1;
+                int n = 1;
                 for(auto &i : wcs_offsets) {
-                    if(i != wcs_t(0,0,0)) {
+                    if(i != wcs_t(0, 0, 0)) {
                         float x, y, z;
                         std::tie(x, y, z) = i;
                         gcode->stream->printf("G10 L2 P%d X%f Y%f Z%f\n", n, x, y, z);
@@ -527,7 +555,7 @@ void Robot::on_gcode_received(void *argument)
 
             if(gcode->m == 503) {
                 // just print the G92 setting as it is not saved
-                if(g92_offset != wcs_t(0,0,0)) {
+                if(g92_offset != wcs_t(0, 0, 0)) {
                     float x, y, z;
                     std::tie(x, y, z) = g92_offset;
                     gcode->stream->printf("G92 X%f Y%f Z%f ; NOT SAVED\n", x, y, z);
@@ -537,7 +565,7 @@ void Robot::on_gcode_received(void *argument)
 
             case 665: { // M665 set optional arm solution variables based on arm solution.
                 // the parameter args could be any letter each arm solution only accepts certain ones
-                BaseSolution::arm_options_t options= gcode->get_args();
+                BaseSolution::arm_options_t options = gcode->get_args();
                 options.erase('S'); // don't include the S
                 options.erase('U'); // don't include the U
                 if(options.size() > 0) {
@@ -558,7 +586,7 @@ void Robot::on_gcode_received(void *argument)
                     this->delta_segments_per_second = gcode->get_value('S');
                     gcode->stream->printf("Delta segments set to %8.4f segs/sec\n", this->delta_segments_per_second);
 
-                }else if(gcode->has_letter('U')) { // or set mm_per_line_segment, not saved by M500
+                } else if(gcode->has_letter('U')) { // or set mm_per_line_segment, not saved by M500
                     this->mm_per_line_segment = gcode->get_value('U');
                     this->delta_segments_per_second = 0;
                     gcode->stream->printf("mm per line segment set to %8.4f\n", this->mm_per_line_segment);
@@ -572,7 +600,7 @@ void Robot::on_gcode_received(void *argument)
     if( this->motion_mode < 0)
         return;
 
-    //Get parameters
+//Get parameters
     float target[3], offset[3];
     clear_vector(offset);
 
@@ -596,7 +624,7 @@ void Robot::on_gcode_received(void *argument)
             this->feed_rate = this->to_millimeters( gcode->get_value('F') );
     }
 
-    //Perform any physical actions
+//Perform any physical actions
     switch(this->motion_mode) {
         case MOTION_MODE_CANCEL: break;
         case MOTION_MODE_SEEK  : this->append_line(gcode, target, this->seek_rate / seconds_per_minute ); break;
@@ -605,14 +633,14 @@ void Robot::on_gcode_received(void *argument)
         case MOTION_MODE_CCW_ARC: this->compute_arc(gcode, offset, target ); break;
     }
 
-    // last_milestone was set to target in append_milestone, no need to do it again
+// last_milestone was set to target in append_milestone, no need to do it again
 
 }
 
 // We received a new gcode, and one of the functions
 // determined the distance for that given gcode. So now we can attach this gcode to the right block
 // and continue
-void Robot::distance_in_gcode_is_known(Gcode *gcode)
+void Robot::distance_in_gcode_is_known(Gcode * gcode)
 {
     //If the queue is empty, execute immediatly, otherwise attach to the last added block
     THEKERNEL->conveyor->append_gcode(gcode);
@@ -632,6 +660,9 @@ void Robot::reset_axis_position(float x, float y, float z)
     arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
     for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
+
+    // we also reset G92 offsets
+    g92_offset = wcs_t(0, 0, 0);
 }
 
 // Reset the position for an axis (used in homing)
@@ -643,8 +674,17 @@ void Robot::reset_axis_position(float position, int axis)
     ActuatorCoordinates actuator_pos;
     arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
 
-    for (size_t i = 0; i < actuators.size(); i++)
+    for (size_t i = 0; i < actuators.size(); i++){
         actuators[i]->change_last_milestone(actuator_pos[i]);
+    }
+
+    // we also reset G92 offsets
+    switch(axis) {
+        case X_AXIS: std::get<0>(g92_offset)= 0; break;
+        case Y_AXIS: std::get<1>(g92_offset)= 0; break;
+        case Z_AXIS: std::get<2>(g92_offset)= 0; break;
+    }
+
 }
 
 // Use FK to find out where actuator is and reset lastmilestone to match
@@ -664,12 +704,12 @@ void Robot::reset_position_from_current_actuator_position()
 }
 
 // Convert target from millimeters to steps, and append this to the planner
-void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
+void Robot::append_milestone(Gcode * gcode, float target[], float rate_mm_s)
 {
     float deltas[3];
     float unit_vec[3];
     ActuatorCoordinates actuator_pos;
-    float transformed_target[3]; // adjust target for bed compensation
+    float transformed_target[3]; // adjust target for bed compensation and WCS offsets
     float millimeters_of_travel;
 
     // unity transform by default
@@ -687,7 +727,7 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
     transformed_target[2] += (std::get<2>(wcs_offsets[current_wcs]) + std::get<2>(g92_offset));
 
     // find distance moved by each axis, use transformed target from last_transformed_target
-    for (int axis = X_AXIS; axis <= Z_AXIS; axis++){
+    for (int axis = X_AXIS; axis <= Z_AXIS; axis++) {
         deltas[axis] = transformed_target[axis] - transformed_last_milestone[axis];
     }
     // store last transformed
@@ -713,13 +753,13 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
     // find actuator position given cartesian position, use actual adjusted target
     arm_solution->cartesian_to_actuator( transformed_target, actuator_pos );
 
-    float isecs= rate_mm_s / millimeters_of_travel;
+    float isecs = rate_mm_s / millimeters_of_travel;
     // check per-actuator speed limits
     for (size_t actuator = 0; actuator < actuators.size(); actuator++) {
         float actuator_rate  = fabsf(actuator_pos[actuator] - actuators[actuator]->last_milestone_mm) * isecs;
-        if (actuator_rate > actuators[actuator]->get_max_rate()){
+        if (actuator_rate > actuators[actuator]->get_max_rate()) {
             rate_mm_s *= (actuators[actuator]->get_max_rate() / actuator_rate);
-            isecs= rate_mm_s / millimeters_of_travel;
+            isecs = rate_mm_s / millimeters_of_travel;
         }
     }
 
@@ -732,7 +772,7 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
 }
 
 // Append a move to the queue ( cutting it into segments if needed )
-void Robot::append_line(Gcode *gcode, float target[], float rate_mm_s )
+void Robot::append_line(Gcode * gcode, float target[], float rate_mm_s )
 {
     // Find out the distance for this gcode
     // NOTE we need to do sqrt here as this setting of millimeters_of_travel is used by extruder and other modules even if there is no XYZ move
@@ -754,8 +794,8 @@ void Robot::append_line(Gcode *gcode, float target[], float rate_mm_s )
     // NOTE we need to do this before we segment the line (for deltas)
     if(gcode->has_letter('E')) {
         float data[2];
-        data[0]= gcode->get_value('E'); // E target (maybe absolute or relative)
-        data[1]= rate_mm_s / gcode->millimeters_of_travel; // inverted seconds for the move
+        data[0] = gcode->get_value('E'); // E target (maybe absolute or relative)
+        data[1] = rate_mm_s / gcode->millimeters_of_travel; // inverted seconds for the move
         if(PublicData::set_value(extruder_checksum, target_checksum, data)) {
             rate_mm_s *= data[1];
             //THEKERNEL->streams->printf("Extruder has changed the rate by %f to %f\n", data[1], rate_mm_s);
@@ -815,7 +855,7 @@ void Robot::append_line(Gcode *gcode, float target[], float rate_mm_s )
 
 
 // Append an arc to the queue ( cutting it into segments as needed )
-void Robot::append_arc(Gcode *gcode, float target[], float offset[], float radius, bool is_clockwise )
+void Robot::append_arc(Gcode * gcode, float target[], float offset[], float radius, bool is_clockwise )
 {
 
     // Scary math
@@ -829,11 +869,11 @@ void Robot::append_arc(Gcode *gcode, float target[], float offset[], float radiu
 
     // Patch from GRBL Firmware - Christoph Baumann 04072015
     // CCW angle between position and target from circle center. Only one atan2() trig computation required.
-    float angular_travel = atan2(r_axis0*rt_axis1-r_axis1*rt_axis0, r_axis0*rt_axis0+r_axis1*rt_axis1);
+    float angular_travel = atan2(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
     if (is_clockwise) { // Correct atan2 output per direction
-        if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= 2*M_PI; }
+        if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= 2 * M_PI; }
     } else {
-        if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += 2*M_PI; }
+        if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += 2 * M_PI; }
     }
 
     // Find the distance for this gcode
@@ -924,7 +964,7 @@ void Robot::append_arc(Gcode *gcode, float target[], float offset[], float radiu
 }
 
 // Do the math for an arc and add it to the queue
-void Robot::compute_arc(Gcode *gcode, float offset[], float target[])
+void Robot::compute_arc(Gcode * gcode, float offset[], float target[])
 {
 
     // Find the radius

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -329,14 +329,15 @@ void Robot::on_gcode_received(void *argument)
                 } else {
                     float x, y, z;
                     std::tie(x, y, z)= g92_offset;
-                    if(gcode->has_letter('X')) x= this->to_millimeters(gcode->get_value('X'));
-                    if(gcode->has_letter('Y')) y= this->to_millimeters(gcode->get_value('Y'));
-                    if(gcode->has_letter('Z')) z= this->to_millimeters(gcode->get_value('Z'));
+                    if(gcode->has_letter('X')) x= to_millimeters(gcode->get_value('X')) - last_milestone[0];
+                    if(gcode->has_letter('Y')) y= to_millimeters(gcode->get_value('Y')) - last_milestone[1];
+                    if(gcode->has_letter('Z')) z= to_millimeters(gcode->get_value('Z')) - last_milestone[2];
                     g92_offset= wcs_t(x, y, z);
                 }
                 return;
             }
         }
+
     } else if( gcode->has_m) {
         switch( gcode->m ) {
             case 2: // M2 end of program
@@ -521,6 +522,15 @@ void Robot::on_gcode_received(void *argument)
                         gcode->stream->printf("G10 L2 P%d X%f Y%f Z%f\n", n, x, y, z);
                     }
                     ++n;
+                }
+            }
+
+            if(gcode->m == 503) {
+                // just print the G92 setting as it is not saved
+                if(g92_offset != wcs_t(0,0,0)) {
+                    float x, y, z;
+                    std::tie(x, y, z) = g92_offset;
+                    gcode->stream->printf("G92 X%f Y%f Z%f ; NOT SAVED\n", x, y, z);
                 }
             }
             break;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -63,26 +63,6 @@ using std::string;
 #define  kossel_checksum                     CHECKSUM("kossel")
 #define  morgan_checksum                     CHECKSUM("morgan")
 
-// stepper motor stuff
-#define  alpha_step_pin_checksum             CHECKSUM("alpha_step_pin")
-#define  beta_step_pin_checksum              CHECKSUM("beta_step_pin")
-#define  gamma_step_pin_checksum             CHECKSUM("gamma_step_pin")
-#define  alpha_dir_pin_checksum              CHECKSUM("alpha_dir_pin")
-#define  beta_dir_pin_checksum               CHECKSUM("beta_dir_pin")
-#define  gamma_dir_pin_checksum              CHECKSUM("gamma_dir_pin")
-#define  alpha_en_pin_checksum               CHECKSUM("alpha_en_pin")
-#define  beta_en_pin_checksum                CHECKSUM("beta_en_pin")
-#define  gamma_en_pin_checksum               CHECKSUM("gamma_en_pin")
-
-#define  alpha_steps_per_mm_checksum         CHECKSUM("alpha_steps_per_mm")
-#define  beta_steps_per_mm_checksum          CHECKSUM("beta_steps_per_mm")
-#define  gamma_steps_per_mm_checksum         CHECKSUM("gamma_steps_per_mm")
-
-#define  alpha_max_rate_checksum             CHECKSUM("alpha_max_rate")
-#define  beta_max_rate_checksum              CHECKSUM("beta_max_rate")
-#define  gamma_max_rate_checksum             CHECKSUM("gamma_max_rate")
-
-
 // new-style actuator stuff
 #define  actuator_checksum                   CHEKCSUM("actuator")
 
@@ -135,6 +115,8 @@ Robot::Robot()
     seconds_per_minute = 60.0F;
     this->clearToolOffset();
     this->compensationTransform= nullptr;
+    this->wcs_offsets.fill(wcs_t(0.0F,0.0F,0.0F));
+    this->g92_offset= wcs_t(0.0F,0.0F,0.0F);
 }
 
 //Called when the module has just been loaded
@@ -143,12 +125,19 @@ void Robot::on_module_loaded()
     this->register_for_event(ON_GCODE_RECEIVED);
 
     // Configuration
-    this->on_config_reload(this);
+    this->load_config();
 }
 
-void Robot::on_config_reload(void *argument)
-{
+#define ACTUATOR_CHECKSUMS(X) {     \
+    CHECKSUM(X "_step_pin"),        \
+    CHECKSUM(X "_dir_pin"),         \
+    CHECKSUM(X "_en_pin"),          \
+    CHECKSUM(X "_steps_per_mm"),    \
+    CHECKSUM(X "_max_rate")         \
+}
 
+void Robot::load_config()
+{
     // Arm solutions are used to convert positions in millimeters into position in steps for each stepper motor.
     // While for a cartesian arm solution, this is a simple multiplication, in other, less simple cases, there is some serious math to be done.
     // To make adding those solution easier, they have their own, separate object.
@@ -171,7 +160,6 @@ void Robot::on_config_reload(void *argument)
     } else if(solution_checksum == rotatable_delta_checksum) {
         this->arm_solution = new RotatableDeltaSolution(THEKERNEL->config);
 
-
     } else if(solution_checksum == morgan_checksum) {
         this->arm_solution = new MorganSCARASolution(THEKERNEL->config);
 
@@ -181,7 +169,6 @@ void Robot::on_config_reload(void *argument)
     } else {
         this->arm_solution = new CartesianSolution(THEKERNEL->config);
     }
-
 
     this->feed_rate           = THEKERNEL->config->value(default_feed_rate_checksum   )->by_default(  100.0F)->as_number();
     this->seek_rate           = THEKERNEL->config->value(default_seek_rate_checksum   )->by_default(  100.0F)->as_number();
@@ -194,58 +181,39 @@ void Robot::on_config_reload(void *argument)
     this->max_speeds[Y_AXIS]  = THEKERNEL->config->value(y_axis_max_speed_checksum    )->by_default(60000.0F)->as_number() / 60.0F;
     this->max_speeds[Z_AXIS]  = THEKERNEL->config->value(z_axis_max_speed_checksum    )->by_default(  300.0F)->as_number() / 60.0F;
 
-    Pin alpha_step_pin;
-    Pin alpha_dir_pin;
-    Pin alpha_en_pin;
-    Pin beta_step_pin;
-    Pin beta_dir_pin;
-    Pin beta_en_pin;
-    Pin gamma_step_pin;
-    Pin gamma_dir_pin;
-    Pin gamma_en_pin;
-
-    alpha_step_pin.from_string( THEKERNEL->config->value(alpha_step_pin_checksum )->by_default("2.0"  )->as_string())->as_output();
-    alpha_dir_pin.from_string(  THEKERNEL->config->value(alpha_dir_pin_checksum  )->by_default("0.5"  )->as_string())->as_output();
-    alpha_en_pin.from_string(   THEKERNEL->config->value(alpha_en_pin_checksum   )->by_default("0.4"  )->as_string())->as_output();
-    beta_step_pin.from_string(  THEKERNEL->config->value(beta_step_pin_checksum  )->by_default("2.1"  )->as_string())->as_output();
-    beta_dir_pin.from_string(   THEKERNEL->config->value(beta_dir_pin_checksum   )->by_default("0.11" )->as_string())->as_output();
-    beta_en_pin.from_string(    THEKERNEL->config->value(beta_en_pin_checksum    )->by_default("0.10" )->as_string())->as_output();
-    gamma_step_pin.from_string( THEKERNEL->config->value(gamma_step_pin_checksum )->by_default("2.2"  )->as_string())->as_output();
-    gamma_dir_pin.from_string(  THEKERNEL->config->value(gamma_dir_pin_checksum  )->by_default("0.20" )->as_string())->as_output();
-    gamma_en_pin.from_string(   THEKERNEL->config->value(gamma_en_pin_checksum   )->by_default("0.19" )->as_string())->as_output();
-
-    float steps_per_mm[3] = {
-        THEKERNEL->config->value(alpha_steps_per_mm_checksum)->by_default(  80.0F)->as_number(),
-        THEKERNEL->config->value(beta_steps_per_mm_checksum )->by_default(  80.0F)->as_number(),
-        THEKERNEL->config->value(gamma_steps_per_mm_checksum)->by_default(2560.0F)->as_number(),
-    };
-
-    // TODO: delete or detect old steppermotors
     // Make our 3 StepperMotors
-    this->alpha_stepper_motor  = new StepperMotor(alpha_step_pin, alpha_dir_pin, alpha_en_pin);
-    this->beta_stepper_motor   = new StepperMotor(beta_step_pin,  beta_dir_pin,  beta_en_pin );
-    this->gamma_stepper_motor  = new StepperMotor(gamma_step_pin, gamma_dir_pin, gamma_en_pin);
+    uint16_t const checksums[][5] = {
+        ACTUATOR_CHECKSUMS("alpha"),
+        ACTUATOR_CHECKSUMS("beta"),
+        ACTUATOR_CHECKSUMS("gamma"),
+#if MAX_ROBOT_ACTUATORS > 3
+        ACTUATOR_CHECKSUMS("delta"),
+        ACTUATOR_CHECKSUMS("epsilon"),
+        ACTUATOR_CHECKSUMS("zeta")
+#endif
+    };
+    constexpr size_t actuator_checksum_count = sizeof(checksums)/sizeof(checksums[0]);
+    static_assert(actuator_checksum_count >= k_max_actuators, "Robot checksum array too small for k_max_actuators");
 
-    alpha_stepper_motor->change_steps_per_mm(steps_per_mm[0]);
-    beta_stepper_motor->change_steps_per_mm(steps_per_mm[1]);
-    gamma_stepper_motor->change_steps_per_mm(steps_per_mm[2]);
+    size_t motor_count = std::min(this->arm_solution->get_actuator_count(), k_max_actuators);
+    for (size_t a = 0; a < motor_count; a++) {
+        Pin pins[3]; //step, dir, enable
+        for (size_t i = 0; i < 3; i++) {
+            pins[i].from_string(THEKERNEL->config->value(checksums[a][i])->by_default("nc")->as_string())->as_output();
+        }
+        actuators[a]= new StepperMotor(pins[0], pins[1], pins[2]);
 
-    alpha_stepper_motor->set_max_rate(THEKERNEL->config->value(alpha_max_rate_checksum)->by_default(30000.0F)->as_number() / 60.0F);
-    beta_stepper_motor->set_max_rate(THEKERNEL->config->value(beta_max_rate_checksum )->by_default(30000.0F)->as_number() / 60.0F);
-    gamma_stepper_motor->set_max_rate(THEKERNEL->config->value(gamma_max_rate_checksum)->by_default(30000.0F)->as_number() / 60.0F);
+        actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a==2 ? 2560.0F : 80.0F)->as_number());
+        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number());
+    }
+
     check_max_actuator_speeds(); // check the configs are sane
-
-    actuators.clear();
-    actuators.push_back(alpha_stepper_motor);
-    actuators.push_back(beta_stepper_motor);
-    actuators.push_back(gamma_stepper_motor);
-
 
     // initialise actuator positions to current cartesian position (X0 Y0 Z0)
     // so the first move can be correct if homing is not performed
-    float actuator_pos[3];
+    ActuatorCoordinates actuator_pos;
     arm_solution->cartesian_to_actuator(last_milestone, actuator_pos);
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 
     //this->clearToolOffset();
@@ -275,22 +243,12 @@ void Robot::pop_state()
 // we will override the actuator max_rate if the combination of max_rate and steps/sec exceeds base_stepping_frequency
 void Robot::check_max_actuator_speeds()
 {
-    float step_freq= alpha_stepper_motor->get_max_rate() * alpha_stepper_motor->get_steps_per_mm();
-    if(step_freq > THEKERNEL->base_stepping_frequency) {
-        alpha_stepper_motor->set_max_rate(floorf(THEKERNEL->base_stepping_frequency / alpha_stepper_motor->get_steps_per_mm()));
-        THEKERNEL->streams->printf("WARNING: alpha_max_rate exceeds base_stepping_frequency * alpha_steps_per_mm: %f, setting to %f\n", step_freq, alpha_stepper_motor->max_rate);
-    }
-
-    step_freq= beta_stepper_motor->get_max_rate() * beta_stepper_motor->get_steps_per_mm();
-    if(step_freq > THEKERNEL->base_stepping_frequency) {
-        beta_stepper_motor->set_max_rate(floorf(THEKERNEL->base_stepping_frequency / beta_stepper_motor->get_steps_per_mm()));
-        THEKERNEL->streams->printf("WARNING: beta_max_rate exceeds base_stepping_frequency * beta_steps_per_mm: %f, setting to %f\n", step_freq, beta_stepper_motor->max_rate);
-    }
-
-    step_freq= gamma_stepper_motor->get_max_rate() * gamma_stepper_motor->get_steps_per_mm();
-    if(step_freq > THEKERNEL->base_stepping_frequency) {
-        gamma_stepper_motor->set_max_rate(floorf(THEKERNEL->base_stepping_frequency / gamma_stepper_motor->get_steps_per_mm()));
-        THEKERNEL->streams->printf("WARNING: gamma_max_rate exceeds base_stepping_frequency * gamma_steps_per_mm: %f, setting to %f\n", step_freq, gamma_stepper_motor->max_rate);
+    for (size_t i = 0; i < actuators.size(); i++) {
+        float step_freq = actuators[i]->get_max_rate() * actuators[i]->get_steps_per_mm();
+        if (step_freq > THEKERNEL->base_stepping_frequency) {
+            actuators[i]->set_max_rate(floorf(THEKERNEL->base_stepping_frequency / actuators[i]->get_steps_per_mm()));
+            THEKERNEL->streams->printf("WARNING: actuator %c rate exceeds base_stepping_frequency * alpha_steps_per_mm: %f, setting to %f\n", 'A'+i, step_freq, actuators[i]->max_rate);
+        }
     }
 }
 
@@ -328,31 +286,65 @@ void Robot::on_gcode_received(void *argument)
                 }
             }
             break;
+
+            case 10: // G10 L2 Pn Xn Yn Zn set WCS
+                // TODO implement G10 L20
+                if(gcode->has_letter('L') && gcode->get_int('L') == 2 && gcode->has_letter('P')) {
+                    size_t n= gcode->get_uint('P');
+                    if(n == 0) n= current_wcs; // set current coordinate system
+                    else --n;
+                    if(n < k_max_wcs) {
+                        float x, y, z;
+                        std::tie(x, y, z)= wcs_offsets[n];
+                        if(gcode->has_letter('X')) x= this->to_millimeters(gcode->get_value('X'));
+                        if(gcode->has_letter('Y')) y= this->to_millimeters(gcode->get_value('Y'));
+                        if(gcode->has_letter('Z')) z= this->to_millimeters(gcode->get_value('Z'));
+                        wcs_offsets[n]= wcs_t(x, y, z);
+                    }
+                }
+                break;
+
             case 17: this->select_plane(X_AXIS, Y_AXIS, Z_AXIS);   break;
             case 18: this->select_plane(X_AXIS, Z_AXIS, Y_AXIS);   break;
             case 19: this->select_plane(Y_AXIS, Z_AXIS, X_AXIS);   break;
             case 20: this->inch_mode = true;   break;
             case 21: this->inch_mode = false;   break;
+
+            case 54: case 55: case 56: case 57: case 58: case 59:
+                // select WCS 0-8: G54..G59, G59.1, G59.2, G59.3
+                current_wcs= gcode->g - 54;
+                if(gcode->g == 59 && gcode->subcode > 0) {
+                    current_wcs += gcode->subcode;
+                    if(current_wcs >= k_max_wcs) current_wcs= k_max_wcs-1;
+                }
+                break;
+
             case 90: this->absolute_mode = true;   break;
             case 91: this->absolute_mode = false;   break;
+
             case 92: {
-                if(gcode->get_num_args() == 0) {
-                    for (int i = X_AXIS; i <= Z_AXIS; ++i) {
-                        reset_axis_position(0, i);
-                    }
+                if(gcode->subcode == 1 || gcode->subcode == 2 || gcode->get_num_args() == 0) {
+                    g92_offset= wcs_t(0,0,0);
 
                 } else {
-                    for (char letter = 'X'; letter <= 'Z'; letter++) {
-                        if ( gcode->has_letter(letter) ) {
-                            reset_axis_position(this->to_millimeters(gcode->get_value(letter)), letter - 'X');
-                        }
-                    }
+                    float x, y, z;
+                    std::tie(x, y, z)= g92_offset;
+                    if(gcode->has_letter('X')) x= this->to_millimeters(gcode->get_value('X'));
+                    if(gcode->has_letter('Y')) y= this->to_millimeters(gcode->get_value('Y'));
+                    if(gcode->has_letter('Z')) z= this->to_millimeters(gcode->get_value('Z'));
+                    g92_offset= wcs_t(x, y, z);
                 }
                 return;
             }
         }
     } else if( gcode->has_m) {
         switch( gcode->m ) {
+            case 2: // M2 end of program
+                current_wcs= 0;
+                absolute_mode= true;
+                motion_mode = MOTION_MODE_LINEAR; // feed
+                break;
+
             case 92: // M92 - set steps per mm
                 if (gcode->has_letter('X'))
                     actuators[0]->change_steps_per_mm(this->to_millimeters(gcode->get_value('X')));
@@ -370,14 +362,28 @@ void Robot::on_gcode_received(void *argument)
 
             case 114: {
                 char buf[64];
-                int n = snprintf(buf, sizeof(buf), "C: X:%1.3f Y:%1.3f Z:%1.3f A:%1.3f B:%1.3f C:%1.3f ",
+                int n= 0;
+                if(gcode->subcode == 0) { // M114 print WCS
+                    n = snprintf(buf, sizeof(buf), "C: X:%1.3f Y:%1.3f Z:%1.3f",
                                  from_millimeters(this->last_milestone[0]),
                                  from_millimeters(this->last_milestone[1]),
-                                 from_millimeters(this->last_milestone[2]),
+                                 from_millimeters(this->last_milestone[2]));
+
+                }else if(gcode->subcode == 1) { // M114.1 print Machine coordinate system
+                    // TODO figure this out
+                     n = snprintf(buf, sizeof(buf), "X:%1.3f Y:%1.3f Z:%1.3f",
+                                 from_millimeters(this->last_milestone[0]),
+                                 from_millimeters(this->last_milestone[1]),
+                                 from_millimeters(this->last_milestone[2]));
+
+                }else if(gcode->subcode == 2) { // M114.2 print realtime actuator position
+                    n = snprintf(buf, sizeof(buf), "A:%1.3f B:%1.3f C:%1.3f",
                                  actuators[X_AXIS]->get_current_position(),
                                  actuators[Y_AXIS]->get_current_position(),
                                  actuators[Z_AXIS]->get_current_position() );
-                gcode->txt_after_ok.append(buf, n);
+                }
+                if(n > 0)
+                    gcode->txt_after_ok.append(buf, n);
             }
             return;
 
@@ -396,22 +402,20 @@ void Robot::on_gcode_received(void *argument)
                     this->max_speeds[Y_AXIS] = gcode->get_value('Y');
                 if (gcode->has_letter('Z'))
                     this->max_speeds[Z_AXIS] = gcode->get_value('Z');
-                if (gcode->has_letter('A'))
-                    alpha_stepper_motor->set_max_rate(gcode->get_value('A'));
-                if (gcode->has_letter('B'))
-                    beta_stepper_motor->set_max_rate(gcode->get_value('B'));
-                if (gcode->has_letter('C'))
-                    gamma_stepper_motor->set_max_rate(gcode->get_value('C'));
-
+                for (size_t i = 0; i < 3 && i < actuators.size(); i++) {
+                    if (gcode->has_letter('A' + i))
+                        actuators[i]->set_max_rate(gcode->get_value('A' + i));
+                }
                 check_max_actuator_speeds();
 
                 if(gcode->get_num_args() == 0) {
-                    gcode->stream->printf("X:%g Y:%g Z:%g  A:%g B:%g C:%g ",
-                                          this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS],
-                                          alpha_stepper_motor->get_max_rate(), beta_stepper_motor->get_max_rate(), gamma_stepper_motor->get_max_rate());
+                    gcode->stream->printf("X:%g Y:%g Z:%g",
+                        this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS]);
+                    for (size_t i = 0; i < 3 && i < actuators.size(); i++) {
+                        gcode->stream->printf(" %c : %g", 'A' + i, actuators[i]->get_max_rate()); //xxx
+                    }
                     gcode->add_nl = true;
                 }
-
                 break;
 
             case 204: // M204 Snnn - set acceleration to nnn, Znnn sets z acceleration
@@ -454,7 +458,7 @@ void Robot::on_gcode_received(void *argument)
                     THEKERNEL->planner->minimum_planner_speed = mps;
                 }
                 if (gcode->has_letter('Y')) {
-                    alpha_stepper_motor->default_minimum_actuator_rate = gcode->get_value('Y');
+                    actuators[0]->default_minimum_actuator_rate = gcode->get_value('Y');
                 }
                 break;
 
@@ -483,9 +487,12 @@ void Robot::on_gcode_received(void *argument)
                 gcode->stream->printf(";Steps per unit:\nM92 X%1.5f Y%1.5f Z%1.5f\n", actuators[0]->steps_per_mm, actuators[1]->steps_per_mm, actuators[2]->steps_per_mm);
                 gcode->stream->printf(";Acceleration mm/sec^2:\nM204 S%1.5f Z%1.5f\n", THEKERNEL->planner->acceleration, THEKERNEL->planner->z_acceleration);
                 gcode->stream->printf(";X- Junction Deviation, Z- Z junction deviation, S - Minimum Planner speed mm/sec:\nM205 X%1.5f Z%1.5f S%1.5f\n", THEKERNEL->planner->junction_deviation, THEKERNEL->planner->z_junction_deviation, THEKERNEL->planner->minimum_planner_speed);
-                gcode->stream->printf(";Max feedrates in mm/sec, XYZ cartesian, ABC actuator:\nM203 X%1.5f Y%1.5f Z%1.5f A%1.5f B%1.5f C%1.5f\n",
-                                      this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS],
-                                      alpha_stepper_motor->get_max_rate(), beta_stepper_motor->get_max_rate(), gamma_stepper_motor->get_max_rate());
+                gcode->stream->printf(";Max feedrates in mm/sec, XYZ cartesian, ABC actuator:\nM203 X%1.5f Y%1.5f Z%1.5f",
+                                      this->max_speeds[X_AXIS], this->max_speeds[Y_AXIS], this->max_speeds[Z_AXIS]);
+                for (size_t i=0; i < 3 && i < actuators.size(); i++){
+                    gcode->stream->printf(" %c%1.5f", 'A' + i, actuators[i]->get_max_rate());
+                }
+                gcode->stream->printf("\n");
 
                 // get or save any arm solution specific optional values
                 BaseSolution::arm_options_t options;
@@ -497,8 +504,26 @@ void Robot::on_gcode_received(void *argument)
                     gcode->stream->printf("\n");
                 }
 
-                break;
+                // save wcs_offsets and current_wcs
+                // TODO this may need to be done whenever they change to be compliant
+                gcode->stream->printf(";WCS settings\n");
+                gcode->stream->printf("G5%c", std::min(current_wcs, (uint8_t)(5 + '4')));
+                if(current_wcs >= 6) {
+                   gcode->stream->printf(".%c\n",  '1' + (current_wcs-5));
+                }else{
+                    gcode->stream->printf("\n");
+                }
+                int n= 1;
+                for(auto &i : wcs_offsets) {
+                    if(i != wcs_t(0,0,0)) {
+                        float x, y, z;
+                        std::tie(x, y, z) = i;
+                        gcode->stream->printf("G10 L2 P%d X%f Y%f Z%f\n", n, x, y, z);
+                    }
+                    ++n;
+                }
             }
+            break;
 
             case 665: { // M665 set optional arm solution variables based on arm solution.
                 // the parameter args could be any letter each arm solution only accepts certain ones
@@ -593,35 +618,38 @@ void Robot::reset_axis_position(float x, float y, float z)
     this->transformed_last_milestone[Y_AXIS] = y;
     this->transformed_last_milestone[Z_AXIS] = z;
 
-    float actuator_pos[3];
+    ActuatorCoordinates actuator_pos;
     arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
 
-// Reset the position for an axis (used in homing and G92)
+// Reset the position for an axis (used in homing)
 void Robot::reset_axis_position(float position, int axis)
 {
     this->last_milestone[axis] = position;
     this->transformed_last_milestone[axis] = position;
 
-    float actuator_pos[3];
+    ActuatorCoordinates actuator_pos;
     arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
 
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
 
 // Use FK to find out where actuator is and reset lastmilestone to match
 void Robot::reset_position_from_current_actuator_position()
 {
-    float actuator_pos[]= {actuators[X_AXIS]->get_current_position(), actuators[Y_AXIS]->get_current_position(), actuators[Z_AXIS]->get_current_position()};
+    ActuatorCoordinates actuator_pos;
+    for (size_t i = 0; i < actuators.size(); i++) {
+        actuator_pos[i] = actuators[i]->get_current_position();
+    }
     arm_solution->actuator_to_cartesian(actuator_pos, this->last_milestone);
     memcpy(this->transformed_last_milestone, this->last_milestone, sizeof(this->transformed_last_milestone));
 
     // now reset actuator correctly, NOTE this may lose a little precision
     arm_solution->cartesian_to_actuator(this->last_milestone, actuator_pos);
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
 
@@ -630,7 +658,7 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
 {
     float deltas[3];
     float unit_vec[3];
-    float actuator_pos[3];
+    ActuatorCoordinates actuator_pos;
     float transformed_target[3]; // adjust target for bed compensation
     float millimeters_of_travel;
 
@@ -642,6 +670,11 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
         // some compensation strategies can transform XYZ, some just change Z
         compensationTransform(transformed_target);
     }
+
+    // apply wcs offsets and g92 offset
+    transformed_target[0] += (std::get<0>(wcs_offsets[current_wcs]) + std::get<0>(g92_offset));
+    transformed_target[1] += (std::get<1>(wcs_offsets[current_wcs]) + std::get<1>(g92_offset));
+    transformed_target[2] += (std::get<2>(wcs_offsets[current_wcs]) + std::get<2>(g92_offset));
 
     // find distance moved by each axis, use transformed target from last_transformed_target
     for (int axis = X_AXIS; axis <= Z_AXIS; axis++){
@@ -672,7 +705,7 @@ void Robot::append_milestone(Gcode *gcode, float target[], float rate_mm_s)
 
     float isecs= rate_mm_s / millimeters_of_travel;
     // check per-actuator speed limits
-    for (int actuator = 0; actuator <= 2; actuator++) {
+    for (size_t actuator = 0; actuator < actuators.size(); actuator++) {
         float actuator_rate  = fabsf(actuator_pos[actuator] - actuators[actuator]->last_milestone_mm) * isecs;
         if (actuator_rate > actuators[actuator]->get_max_rate()){
             rate_mm_s *= (actuators[actuator]->get_max_rate() / actuator_rate);

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -104,10 +104,10 @@ class Robot : public Module {
 
 // Convert from inches to millimeters ( our internal storage unit ) if needed
 inline float Robot::to_millimeters( float value ){
-    return this->inch_mode ? value * 25.4 : value;
+    return this->inch_mode ? value * 25.4F : value;
 }
 inline float Robot::from_millimeters( float value){
-    return this->inch_mode ? value/25.4 : value;
+    return this->inch_mode ? value/25.4F : value;
 }
 inline void Robot::get_axis_position(float position[]){
     memcpy(position, this->last_milestone, sizeof(float)*3 );

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -15,6 +15,7 @@ using std::string;
 #include <stack>
 
 #include "libs/Module.h"
+#include "ActuatorCoordinates.h"
 
 class Gcode;
 class BaseSolution;
@@ -24,7 +25,6 @@ class Robot : public Module {
     public:
         Robot();
         void on_module_loaded();
-        void on_config_reload(void* argument);
         void on_gcode_received(void* argument);
 
         void reset_axis_position(float position, int axis);
@@ -44,7 +44,7 @@ class Robot : public Module {
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 
         // gets accessed by Panel, Endstops, ZProbe
-        std::vector<StepperMotor*> actuators;
+        std::array<StepperMotor*, k_max_actuators> actuators;
 
         // set by a leveling strategy to transform the target of a move according to the current plan
         std::function<void(float[3])> compensationTransform;
@@ -55,6 +55,7 @@ class Robot : public Module {
         };
 
     private:
+        void load_config();
         void distance_in_gcode_is_known(Gcode* gcode);
         void append_milestone( Gcode *gcode, float target[], float rate_mm_s);
         void append_line( Gcode* gcode, float target[], float rate_mm_s);
@@ -65,8 +66,16 @@ class Robot : public Module {
         void select_plane(uint8_t axis_0, uint8_t axis_1, uint8_t axis_2);
         void clearToolOffset();
 
-        typedef std::tuple<float, float, bool, bool> saved_state_t; // save current feedrate and absolute mode, inch mode
+        // Workspace coordinate systems
+        using wcs_t= std::tuple<float, float, float>;
+        static const size_t k_max_wcs= 9; // setup 9 WCS offsets
+        std::array<wcs_t, k_max_wcs> wcs_offsets; // these are persistent once set
+        uint8_t current_wcs{0}; // 0 means G54 in enabled this is persistent
+        wcs_t g92_offset;
+
+        using saved_state_t= std::tuple<float, float, bool, bool>; // save current feedrate and absolute mode, inch mode
         std::stack<saved_state_t> state_stack;               // saves state from M120
+
         float last_milestone[3];                             // Last position, in millimeters
         float transformed_last_milestone[3];                 // Last transformed position
         int8_t motion_mode;                                  // Motion mode for the current received Gcode
@@ -91,10 +100,6 @@ class Robot : public Module {
         // Used by Stepper, Planner
         friend class Planner;
         friend class Stepper;
-
-        StepperMotor* alpha_stepper_motor;
-        StepperMotor* beta_stepper_motor;
-        StepperMotor* gamma_stepper_motor;
 };
 
 // Convert from inches to millimeters ( our internal storage unit ) if needed

--- a/src/modules/robot/arm_solutions/BaseSolution.h
+++ b/src/modules/robot/arm_solutions/BaseSolution.h
@@ -3,6 +3,8 @@
 #define BASESOLUTION_H
 
 #include <map>
+#include "ActuatorCoordinates.h"
+
 class Config;
 
 class BaseSolution {
@@ -10,11 +12,12 @@ class BaseSolution {
         BaseSolution(){};
         BaseSolution(Config*){};
         virtual ~BaseSolution() {};
-        virtual void cartesian_to_actuator(const float[], float[] ) = 0;
-        virtual void actuator_to_cartesian(const float[], float[] ) = 0;
+        virtual void cartesian_to_actuator(const float[], ActuatorCoordinates &) = 0;
+        virtual void actuator_to_cartesian(const ActuatorCoordinates &, float[]) = 0;
         typedef std::map<char, float> arm_options_t;
         virtual bool set_optional(const arm_options_t& options) { return false; };
         virtual bool get_optional(arm_options_t& options, bool force_all= false) { return false; };
+        virtual size_t get_actuator_count() const { return 3; }
 };
 
 #endif

--- a/src/modules/robot/arm_solutions/CartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/CartesianSolution.cpp
@@ -1,13 +1,14 @@
 #include "CartesianSolution.h"
+#include "ActuatorCoordinates.h"
 #include <math.h>
 
-void CartesianSolution::cartesian_to_actuator( const float cartesian_mm[], float actuator_mm[] ){
+void CartesianSolution::cartesian_to_actuator( const float cartesian_mm[], ActuatorCoordinates &actuator_mm ){
     actuator_mm[ALPHA_STEPPER] = cartesian_mm[X_AXIS];
     actuator_mm[BETA_STEPPER ] = cartesian_mm[Y_AXIS];
     actuator_mm[GAMMA_STEPPER] = cartesian_mm[Z_AXIS];
 }
 
-void CartesianSolution::actuator_to_cartesian( const float actuator_mm[], float cartesian_mm[] ){
+void CartesianSolution::actuator_to_cartesian( const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ){
     cartesian_mm[ALPHA_STEPPER] = actuator_mm[X_AXIS];
     cartesian_mm[BETA_STEPPER ] = actuator_mm[Y_AXIS];
     cartesian_mm[GAMMA_STEPPER] = actuator_mm[Z_AXIS];

--- a/src/modules/robot/arm_solutions/CartesianSolution.h
+++ b/src/modules/robot/arm_solutions/CartesianSolution.h
@@ -11,8 +11,8 @@ class CartesianSolution : public BaseSolution {
     public:
         CartesianSolution(){};
         CartesianSolution(Config*){};
-        void cartesian_to_actuator( const float millimeters[], float steps[] );
-        void actuator_to_cartesian( const float steps[], float millimeters[] );
+        void cartesian_to_actuator( const float millimeters[], ActuatorCoordinates &steps ) override;
+        void actuator_to_cartesian( const ActuatorCoordinates &steps, float millimeters[] ) override;
 };
 
 

--- a/src/modules/robot/arm_solutions/CoreXZSolution.cpp
+++ b/src/modules/robot/arm_solutions/CoreXZSolution.cpp
@@ -1,4 +1,5 @@
 #include "CoreXZSolution.h"
+#include "ActuatorCoordinates.h"
 #include "ConfigValue.h"
 #include "checksumm.h"
 
@@ -11,13 +12,13 @@ CoreXZSolution::CoreXZSolution(Config* config)
     z_reduction = config->value(z_reduction_checksum)->by_default(3.0f)->as_number();
 }
 
-void CoreXZSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] ){
+void CoreXZSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ){
     actuator_mm[ALPHA_STEPPER] = (this->x_reduction * cartesian_mm[X_AXIS]) + (this->z_reduction * cartesian_mm[Z_AXIS]);
     actuator_mm[BETA_STEPPER ] = (this->x_reduction * cartesian_mm[X_AXIS]) - (this->z_reduction * cartesian_mm[Z_AXIS]);
     actuator_mm[GAMMA_STEPPER] = cartesian_mm[Y_AXIS];
 }
 
-void CoreXZSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] ){
+void CoreXZSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ){
     cartesian_mm[X_AXIS] = (0.5F/this->x_reduction) * (actuator_mm[ALPHA_STEPPER] + actuator_mm[BETA_STEPPER]);
     cartesian_mm[Z_AXIS] = (0.5F/this->z_reduction) * (actuator_mm[ALPHA_STEPPER] - actuator_mm[BETA_STEPPER]);
     cartesian_mm[Y_AXIS] = actuator_mm[GAMMA_STEPPER];

--- a/src/modules/robot/arm_solutions/CoreXZSolution.h
+++ b/src/modules/robot/arm_solutions/CoreXZSolution.h
@@ -10,8 +10,8 @@
 class CoreXZSolution : public BaseSolution {
     public:
         CoreXZSolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates & ) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
     private:
         float x_reduction;

--- a/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.cpp
@@ -1,6 +1,7 @@
 #include "ExperimentalDeltaSolution.h"
 
 #include <fastmath.h>
+#include "ActuatorCoordinates.h"
 #include "ConfigValue.h"
 #include "libs/Kernel.h"
 #include "libs/nuts_bolts.h"
@@ -37,7 +38,7 @@ ExperimentalDeltaSolution::ExperimentalDeltaSolution(Config* config)
     arm_length_squared = powf(arm_length, 2);
 }
 
-void ExperimentalDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] ){
+void ExperimentalDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ){
     float alpha_rotated[3], rotated[3];
 
     if( sin_alpha == 0 && cos_alpha == 1){
@@ -56,7 +57,7 @@ void ExperimentalDeltaSolution::cartesian_to_actuator(const float cartesian_mm[]
     actuator_mm[GAMMA_STEPPER] = solve_arm( rotated );
 }
 
-void ExperimentalDeltaSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] ){
+void ExperimentalDeltaSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ){
     // unimplemented
 }
 

--- a/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.h
+++ b/src/modules/robot/arm_solutions/ExperimentalDeltaSolution.h
@@ -8,13 +8,13 @@ class Config;
 class ExperimentalDeltaSolution : public BaseSolution {
     public:
         ExperimentalDeltaSolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
+    private:
         float solve_arm( float millimeters[] );
         void rotate(const float in[], float out[], float sin, float cos );
 
-    private:
         float arm_length;
         float arm_radius;
         float arm_length_squared;

--- a/src/modules/robot/arm_solutions/HBotSolution.cpp
+++ b/src/modules/robot/arm_solutions/HBotSolution.cpp
@@ -1,13 +1,14 @@
 #include "HBotSolution.h"
+#include "ActuatorCoordinates.h"
 #include <math.h>
 
-void HBotSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] ){
+void HBotSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ){
     actuator_mm[ALPHA_STEPPER] = cartesian_mm[X_AXIS] + cartesian_mm[Y_AXIS];
     actuator_mm[BETA_STEPPER ] = cartesian_mm[X_AXIS] - cartesian_mm[Y_AXIS];
     actuator_mm[GAMMA_STEPPER] = cartesian_mm[Z_AXIS];
 }
 
-void HBotSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] ){
+void HBotSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ){
     cartesian_mm[X_AXIS] = 0.5F * (actuator_mm[ALPHA_STEPPER] + actuator_mm[BETA_STEPPER]);
     cartesian_mm[Y_AXIS] = 0.5F * (actuator_mm[ALPHA_STEPPER] - actuator_mm[BETA_STEPPER]);
     cartesian_mm[Z_AXIS] = actuator_mm[GAMMA_STEPPER];

--- a/src/modules/robot/arm_solutions/HBotSolution.h
+++ b/src/modules/robot/arm_solutions/HBotSolution.h
@@ -11,8 +11,8 @@ class HBotSolution : public BaseSolution {
     public:
         HBotSolution();
         HBotSolution(Config*){};
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[]) override;
 };
 
 

--- a/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/LinearDeltaSolution.cpp
@@ -1,4 +1,5 @@
 #include "LinearDeltaSolution.h"
+#include "ActuatorCoordinates.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
 #include "libs/Kernel.h"
@@ -54,7 +55,7 @@ void LinearDeltaSolution::init() {
     delta_tower3_y = (delta_radius + tower3_offset) * sinf((90.0F  + tower3_angle) * PIOVER180);
 }
 
-void LinearDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] )
+void LinearDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm )
 {
 
     actuator_mm[ALPHA_STEPPER] = sqrtf(this->arm_length_squared
@@ -71,7 +72,7 @@ void LinearDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], floa
                                       ) + cartesian_mm[Z_AXIS];
 }
 
-void LinearDeltaSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] )
+void LinearDeltaSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] )
 {
     // from http://en.wikipedia.org/wiki/Circumscribed_circle#Barycentric_coordinates_from_cross-_and_dot-products
     // based on https://github.com/ambrop72/aprinter/blob/2de69a/aprinter/printer/DeltaTransform.h#L81

--- a/src/modules/robot/arm_solutions/LinearDeltaSolution.h
+++ b/src/modules/robot/arm_solutions/LinearDeltaSolution.h
@@ -8,11 +8,11 @@ class Config;
 class LinearDeltaSolution : public BaseSolution {
     public:
         LinearDeltaSolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
-        bool set_optional(const arm_options_t& options);
-        bool get_optional(arm_options_t& options, bool force_all);
+        bool set_optional(const arm_options_t& options) override;
+        bool get_optional(arm_options_t& options, bool force_all) override;
 
     private:
         void init();

--- a/src/modules/robot/arm_solutions/MorganSCARASolution.cpp
+++ b/src/modules/robot/arm_solutions/MorganSCARASolution.cpp
@@ -1,6 +1,7 @@
 #include "MorganSCARASolution.h"
 #include <fastmath.h>
 #include "checksumm.h"
+#include "ActuatorCoordinates.h"
 #include "ConfigValue.h"
 #include "libs/Kernel.h"
 #include "StreamOutputPool.h"
@@ -58,7 +59,7 @@ float MorganSCARASolution::to_degrees(float radians) {
     return radians*(180.0F/3.14159265359f);
 }
 
-void MorganSCARASolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] )
+void MorganSCARASolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm )
 {
 
     float SCARA_pos[2],
@@ -103,7 +104,7 @@ void MorganSCARASolution::cartesian_to_actuator(const float cartesian_mm[], floa
 
 }
 
-void MorganSCARASolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] ) {
+void MorganSCARASolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ) {
     // Perform forward kinematics, and place results in cartesian_mm[]
 
     float y1, y2,

--- a/src/modules/robot/arm_solutions/MorganSCARASolution.h
+++ b/src/modules/robot/arm_solutions/MorganSCARASolution.h
@@ -8,11 +8,11 @@ class Config;
 class MorganSCARASolution : public BaseSolution {
     public:
         MorganSCARASolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
-        bool set_optional(const arm_options_t& options);
-        bool get_optional(arm_options_t& options, bool force_all);
+        bool set_optional(const arm_options_t& options) override;
+        bool get_optional(arm_options_t& options, bool force_all) override;
 
     private:
         void init();

--- a/src/modules/robot/arm_solutions/RotatableCartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotatableCartesianSolution.cpp
@@ -1,5 +1,6 @@
 #include "RotatableCartesianSolution.h"
 #include <math.h>
+#include "ActuatorCoordinates.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
 
@@ -12,12 +13,12 @@ RotatableCartesianSolution::RotatableCartesianSolution(Config* config) {
     cos_alpha          = cosf(alpha_angle);
 }
 
-void RotatableCartesianSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] ){
-    rotate( cartesian_mm, actuator_mm, sin_alpha, cos_alpha );
+void RotatableCartesianSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ){
+    rotate( cartesian_mm, &actuator_mm[0], sin_alpha, cos_alpha );
 }
 
-void RotatableCartesianSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] ){
-    rotate( actuator_mm, cartesian_mm, - sin_alpha, cos_alpha );
+void RotatableCartesianSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ){
+    rotate( &actuator_mm[0], cartesian_mm, - sin_alpha, cos_alpha );
 }
 
 void RotatableCartesianSolution::rotate(const float in[], float out[], float sin, float cos ){

--- a/src/modules/robot/arm_solutions/RotatableCartesianSolution.h
+++ b/src/modules/robot/arm_solutions/RotatableCartesianSolution.h
@@ -12,10 +12,11 @@
 class RotatableCartesianSolution : public BaseSolution {
     public:
         RotatableCartesianSolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
-        void rotate(const float in[], float out[], float sin, float cos );
+    private:
+        void rotate(const float in[], float out[], float sin, float cos);
 
         float sin_alpha;
         float cos_alpha;

--- a/src/modules/robot/arm_solutions/RotatableDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotatableDeltaSolution.cpp
@@ -1,4 +1,5 @@
 #include "RotatableDeltaSolution.h"
+#include "ActuatorCoordinates.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
 #include "ConfigCache.h"
@@ -134,7 +135,7 @@ void RotatableDeltaSolution::init()
     z_calc_offset  = (delta_z_offset - tool_offset - delta_ee_offs) * -1.0F;
 }
 
-void RotatableDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], float actuator_mm[] )
+void RotatableDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm )
 {
     //We need to translate the Cartesian coordinates in mm to the actuator position required in mm so the stepper motor  functions
     float alpha_theta = 0.0F;
@@ -180,7 +181,7 @@ void RotatableDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], f
 
 }
 
-void RotatableDeltaSolution::actuator_to_cartesian(const float actuator_mm[], float cartesian_mm[] )
+void RotatableDeltaSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] )
 {
     //Use forward kinematics
     delta_calcForward(actuator_mm[ALPHA_STEPPER], actuator_mm[BETA_STEPPER ], actuator_mm[GAMMA_STEPPER], cartesian_mm[X_AXIS], cartesian_mm[Y_AXIS], cartesian_mm[Z_AXIS]);

--- a/src/modules/robot/arm_solutions/RotatableDeltaSolution.h
+++ b/src/modules/robot/arm_solutions/RotatableDeltaSolution.h
@@ -8,11 +8,11 @@ class Config;
 class RotatableDeltaSolution : public BaseSolution {
     public:
         RotatableDeltaSolution(Config*);
-        void cartesian_to_actuator(const float[], float[] );
-        void actuator_to_cartesian(const float[], float[] );
+        void cartesian_to_actuator(const float[], ActuatorCoordinates &) override;
+        void actuator_to_cartesian(const ActuatorCoordinates &, float[] ) override;
 
-        bool set_optional(const arm_options_t& options);
-        bool get_optional(arm_options_t& options, bool force_all);
+        bool set_optional(const arm_options_t& options) override;
+        bool get_optional(arm_options_t& options, bool force_all) override;
 
     private:
         void init();

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -9,6 +9,7 @@
 #include "libs/Kernel.h"
 #include "modules/communication/utils/Gcode.h"
 #include "modules/robot/Conveyor.h"
+#include "modules/robot/ActuatorCoordinates.h"
 #include "Endstops.h"
 #include "libs/nuts_bolts.h"
 #include "libs/Pin.h"
@@ -671,11 +672,11 @@ void Endstops::on_gcode_received(void *argument)
 
                 bool has_endstop_trim = this->is_delta || this->is_scara;
                 if (has_endstop_trim) {
-                    float ideal_actuator_position[3];
+                    ActuatorCoordinates ideal_actuator_position;
                     THEKERNEL->robot->arm_solution->cartesian_to_actuator(ideal_position, ideal_actuator_position);
 
                     // We are actually not at the ideal position, but a trim away
-                    float real_actuator_position[3] = {
+                    ActuatorCoordinates real_actuator_position = {
                         ideal_actuator_position[X_AXIS] - this->trim_mm[X_AXIS],
                         ideal_actuator_position[Y_AXIS] - this->trim_mm[Y_AXIS],
                         ideal_actuator_position[Z_AXIS] - this->trim_mm[Z_AXIS]

--- a/src/modules/tools/scaracal/SCARAcal.cpp
+++ b/src/modules/tools/scaracal/SCARAcal.cpp
@@ -130,8 +130,8 @@ bool SCARAcal::set_home_offset(float x, float y, float z, StreamOutput *stream)
 bool SCARAcal::translate_trim(StreamOutput *stream)
 {
     float S_trim[3],
-          home_off[3],
-          actuator[3];;
+        home_off[3];
+    ActuatorCoordinates actuator;
 
     this->get_home_offset(home_off[0], home_off[1], home_off[2]);               // get home offsets
     this->get_trim(S_trim[0], S_trim[1], S_trim[2]);	                          // get current trim
@@ -162,8 +162,8 @@ bool SCARAcal::translate_trim(StreamOutput *stream)
 void SCARAcal::SCARA_ang_move(float theta, float psi, float z, float feedrate)
 {
     char cmd[64];
-    float actuator[3],
-          cartesian[3];
+    float cartesian[3];
+    ActuatorCoordinates actuator;
 
     // Assign the actuator angles from input
     actuator[0] = theta;
@@ -193,8 +193,8 @@ void SCARAcal::on_gcode_received(void *argument)
 
             case 114: {    // Extra stuff for Morgan calibration
                 char buf[32];
-                float cartesian[3],
-                      actuators[3];
+                float cartesian[3];
+                ActuatorCoordinates actuators;
 
                 THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
                 THEKERNEL->robot->arm_solution->cartesian_to_actuator( cartesian, actuators );      // translate to get actuator position
@@ -215,8 +215,8 @@ void SCARAcal::on_gcode_received(void *argument)
 
                 if(gcode->has_letter('P')) {
                     // Program the current position as target
-                    float actuators[3],
-                          S_delta[2],
+                    ActuatorCoordinates actuators;
+                    float S_delta[2],
                           S_trim[3];
 
                     THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
@@ -240,7 +240,7 @@ void SCARAcal::on_gcode_received(void *argument)
 
                 if(gcode->has_letter('P')) {
                     // Program the current position as target
-                    float actuators[3];
+                    ActuatorCoordinates actuators;
 
                     THEKERNEL->robot->get_axis_position(cartesian);                                // get actual position from robot
                     THEKERNEL->robot->arm_solution->cartesian_to_actuator( cartesian, actuators ); // translate to get actuator position
@@ -265,8 +265,8 @@ void SCARAcal::on_gcode_received(void *argument)
 
                 if(gcode->has_letter('P')) {
                     // Program the current position as target
-                    float actuators[3],
-                          S_delta[2];
+                    ActuatorCoordinates actuators;
+                    float S_delta[2];
 
                     THEKERNEL->robot->get_axis_position(cartesian);                                     // get actual position from robot
                     THEKERNEL->robot->arm_solution->cartesian_to_actuator( cartesian, actuators );      // translate it to get actual actuator angles

--- a/src/modules/tools/touchprobe/Touchprobe.cpp
+++ b/src/modules/tools/touchprobe/Touchprobe.cpp
@@ -42,12 +42,15 @@ void Touchprobe::on_module_loaded() {
 }
 
 void Touchprobe::on_config_reload(void* argument){
+    if (THEKERNEL->robot->actuators.size() > 3) {
+        THEKERNEL->streams->printf("Touchpprobe in use withmore than 3 motors - may need port\n");
+    }
     this->pin.from_string(  THEKERNEL->config->value(touchprobe_pin_checksum)->by_default("nc" )->as_string())->as_input();
     this->debounce_count =  THEKERNEL->config->value(touchprobe_debounce_count_checksum)->by_default(100  )->as_number();
 
-    this->steppers[0] = THEKERNEL->robot->alpha_stepper_motor;
-    this->steppers[1] = THEKERNEL->robot->beta_stepper_motor;
-    this->steppers[2] = THEKERNEL->robot->gamma_stepper_motor;
+    this->steppers[0] = THEKERNEL->robot->actuators[0];
+    this->steppers[1] = THEKERNEL->robot->actuators[1];
+    this->steppers[2] = THEKERNEL->robot->actuators[2];
 
     this->should_log = this->enabled = THEKERNEL->config->value( touchprobe_log_enable_checksum )->by_default(false)->as_bool();
     if( this->should_log){
@@ -113,7 +116,8 @@ void Touchprobe::on_gcode_received(void* argument)
 
     if( gcode->has_g) {
         if( gcode->g == 31 ) {
-            float tmp[3], pos[3], mm[3];
+            float tmp[3], pos[3];
+            ActuatorCoordinates mm;
             int steps[3];
             // first wait for an empty queue i.e. no moves left
             THEKERNEL->conveyor->wait_for_empty_queue();


### PR DESCRIPTION
This is still a WIP, no where near ready to merge :)

    add handling for G54-G59.3 Select Coordinate System
    add handling for G10 L2 to set them
    change the way G92 is handled, just sets a global offset which is not persistent across reset
    Save the WCS offsets in M500 and display them in M503 (if they are non zero)

    Merge branch 'feature/nmotors' of https://github.com/trayracing/Smoothieware into feature/wcs
