### PR TITLE
feature: Soft Limits

### DIFF
--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -62,6 +62,7 @@ class Robot : public Module {
             uint8_t plane_axis_0:2;                           // Current plane ( XY, XZ, YZ )
             uint8_t plane_axis_1:2;
             uint8_t plane_axis_2:2;
+            bool software_limits:1;                           // true if system is bound by software limits: default is false
         };
 
     private:
@@ -98,6 +99,8 @@ class Robot : public Module {
         float mm_per_arc_segment;                            // Setting : Used to split arcs into segmentrs
         float delta_segments_per_second;                     // Setting : Used to split lines into segments for delta based on speed
         float seconds_per_minute;                            // for realtime speed change
+
+        float softlimits[3][2];                              // minimum and maximum movement limits
 
         // Number of arc generation iterations by small angle approximation before exact arc trajectory
         // correction. This parameter maybe decreased if there are issues with the accuracy of the arc


### PR DESCRIPTION
Added config controlled soft limits to the cartesian movement of any system

config example for a machine with dimentions X:380 Y220 Z200
* Cartesian axis soft limits
software_limits                              true
software_limits.x_axis_min                   0.0
software_limits.x_axis_max                   380.0
software_limits.y_axis_min                   0.0
software_limits.y_axis_max                   220.0
software_limits.z_axis_min                   -10.0
software_limits.z_axis_max                   210.0

Movement will be constrained to the set build envoronment except if
the last_milestone is outside the build environment.  In that case it
will not allow movements further from the build environment, only closer.