### PR TITLE
needs definition in cpp file to compile with optimization off (-O0)

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -105,6 +105,8 @@ using std::string;
 // The Robot converts GCodes into actual movements, and then adds them to the Planner, which passes them to the Conveyor so they can be added to the queue
 // It takes care of cutting arcs into segments, same thing for line that are too long
 
+const size_t Robot::k_max_wcs; // a static member requires definition
+
 Robot::Robot()
 {
     this->inch_mode = false;


### PR DESCRIPTION
When switching off optimization in current edge branch (-O0) Smoothieware does not compile. A definition for a static member is missing. Note: it compiles with -O2 because the static is const and the compiler optimizes out the static entirely. Therefore it will not eat any memory, it is always optimized out in -O2.