### PR TITLE
Feature/add grbl queries

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -38,6 +38,7 @@
 #define microseconds_per_step_pulse_checksum        CHECKSUM("microseconds_per_step_pulse")
 #define acceleration_ticks_per_second_checksum      CHECKSUM("acceleration_ticks_per_second")
 #define disable_leds_checksum                       CHECKSUM("leds_disable")
+#define grbl_mode_checksum                          CHECKSUM("grbl_mode")
 
 Kernel* Kernel::instance;
 
@@ -92,6 +93,7 @@ Kernel::Kernel(){
 
     //some boards don't have leds.. TOO BAD!
     this->use_leds= !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
+    this->grbl_mode= this->config->value( grbl_mode_checksum )->by_default(false)->as_bool();
 
     this->add_module( this->config );
     this->add_module( this->serial );

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -46,6 +46,7 @@ Kernel* Kernel::instance;
 // The kernel is the central point in Smoothie : it stores modules, and handles event calls
 Kernel::Kernel(){
     halted= false;
+    feed_hold= false;
 
     instance= this; // setup the Singleton instance of the kernel
 
@@ -164,6 +165,8 @@ std::string Kernel::get_query_string()
         str.append("Alarm,");
     }else if(homing) {
         str.append("Home,");
+    }else if(feed_hold) {
+        str.append("Hold,");
     }else if(this->conveyor->is_queue_empty()) {
         str.append("Idle,");
     }else{

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -26,6 +26,7 @@
 #include "modules/robot/Conveyor.h"
 #include "StepperMotor.h"
 #include "BaseSolution.h"
+#include "EndstopsPublicAccess.h"
 
 #include <malloc.h>
 #include <array>
@@ -154,9 +155,15 @@ Kernel::Kernel(){
 std::string Kernel::get_query_string()
 {
     std::string str;
+    bool homing;
+    bool ok = PublicData::get_value(endstops_checksum, get_homing_status_checksum, 0, &homing);
+    if(!ok) homing= false;
+
     str.append("<");
     if(halted) {
         str.append("Alarm,");
+    }else if(homing) {
+        str.append("Home,");
     }else if(this->conveyor->is_queue_empty()) {
         str.append("Idle,");
     }else{

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -47,6 +47,9 @@ class Kernel {
         bool is_halted() const { return halted; }
         bool is_grbl_mode() const { return grbl_mode; }
 
+        void set_feed_hold(bool f) { feed_hold= f; }
+        bool get_feed_hold() const { return feed_hold; }
+
         std::string get_query_string();
 
         // These modules are available to all other modules
@@ -74,6 +77,7 @@ class Kernel {
             bool use_leds:1;
             bool halted:1;
             bool grbl_mode:1;
+            bool feed_hold:1;
         };
 
 };

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -45,6 +45,8 @@ class Kernel {
 
         bool is_using_leds() const { return use_leds; }
         bool is_halted() const { return halted; }
+        bool is_grbl_mode() const { return grbl_mode; }
+
         std::string get_query_string();
 
         // These modules are available to all other modules
@@ -71,6 +73,7 @@ class Kernel {
         struct {
             bool use_leds:1;
             bool halted:1;
+            bool grbl_mode:1;
         };
 
 };

--- a/src/libs/PublicDataRequest.h
+++ b/src/libs/PublicDataRequest.h
@@ -31,7 +31,7 @@ class PublicDataRequest {
         void* data;
         struct {
             bool data_taken:1;
-            bool returned_data:1;
+            bool returned_data:1; // this is set if the callee returns the data, it is false if the caller supplied the storage for the return
         };
 };
 

--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -278,7 +278,11 @@ void USBSerial::on_idle(void *argument)
     if(halt_flag) {
         halt_flag= false;
         THEKERNEL->call_event(ON_HALT, nullptr);
-        puts("ALARM: Abort during cycle, M999 to exit Alarm state\r\n");
+        if(THEKERNEL->is_grbl_mode()) {
+            puts("ALARM: Abort during cycle\r\n");
+        }else{
+            puts("HALTED, M999 or $X to exit HALT state\r\n");
+        }
     }
 
     if(query_flag) {

--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -279,7 +279,7 @@ void USBSerial::on_idle(void *argument)
         halt_flag= false;
         THEKERNEL->call_event(ON_HALT, nullptr);
         if(THEKERNEL->is_grbl_mode()) {
-            puts("ALARM: Abort during cycle\r\n");
+            puts("ALARM:Abort during cycle\r\n");
         }else{
             puts("HALTED, M999 or $X to exit HALT state\r\n");
         }

--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -207,6 +207,16 @@ bool USBSerial::USBEvent_EPOut(uint8_t bEP, uint8_t bEPStatus)
             continue;
         }
 
+        if(c[i] == '!'){ // safe pause
+            THEKERNEL->set_feed_hold(true);
+            continue;
+        }
+
+        if(c[i] == '~'){ // safe resume
+            THEKERNEL->set_feed_hold(false);
+            continue;
+        }
+
         if (flush_to_nl == false)
             rxbuf.queue(c[i]);
 
@@ -315,6 +325,10 @@ void USBSerial::on_main_loop(void *argument)
             nl_in_rx = 0;
         }
     }
+
+    // if we are in feed hold we do not process anything
+    if(THEKERNEL->get_feed_hold()) return;
+
     if (nl_in_rx)
     {
         string received;

--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -207,14 +207,16 @@ bool USBSerial::USBEvent_EPOut(uint8_t bEP, uint8_t bEPStatus)
             continue;
         }
 
-        if(c[i] == '!'){ // safe pause
-            THEKERNEL->set_feed_hold(true);
-            continue;
-        }
+        if(THEKERNEL->is_grbl_mode()) {
+            if(c[i] == '!'){ // safe pause
+                THEKERNEL->set_feed_hold(true);
+                continue;
+            }
 
-        if(c[i] == '~'){ // safe resume
-            THEKERNEL->set_feed_hold(false);
-            continue;
+            if(c[i] == '~'){ // safe resume
+                THEKERNEL->set_feed_hold(false);
+                continue;
+            }
         }
 
         if (flush_to_nl == false)

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -65,6 +65,16 @@ try_again:
 
     char first_char = possible_command[0];
     unsigned int n;
+
+    if(first_char == '$') {
+        // ignore as simpleshell will handle it
+        return;
+
+    }else if(islower(first_char)) {
+        // ignore all lowercase as they are simpleshell commands
+        return;
+    }
+
     if ( first_char == 'G' || first_char == 'M' || first_char == 'T' || first_char == 'N' ) {
 
         //Get linenumber
@@ -141,7 +151,12 @@ try_again:
 
                         }else if(!is_allowed_mcode(gcode->m)) {
                             // ignore everything, return error string to host
-                            new_message.stream->printf("!!\r\n");
+                            if(THEKERNEL->is_grbl_mode()) {
+                                new_message.stream->printf("error: Alarm lock\n");
+
+                            }else{
+                                new_message.stream->printf("!!\r\n");
+                            }
                             delete gcode;
                             continue;
                         }

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -152,7 +152,7 @@ try_again:
                         }else if(!is_allowed_mcode(gcode->m)) {
                             // ignore everything, return error string to host
                             if(THEKERNEL->is_grbl_mode()) {
-                                new_message.stream->printf("error: Alarm lock\n");
+                                new_message.stream->printf("error:Alarm lock\n");
 
                             }else{
                                 new_message.stream->printf("!!\r\n");

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -221,6 +221,17 @@ try_again:
                                 //printf("Start Uploading file: %s, %p\n", upload_filename.c_str(), upload_fd);
                                 continue;
 
+                            case 2: case 30: // end of program
+                                {
+                                    modal_group_1= 1; // set to G1
+                                    // issue M5 and M9 in case spindle and coolant are being used
+                                    Gcode gc1("M5", &StreamOutput::NullStream);
+                                    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc1);
+                                    Gcode gc2("M9", &StreamOutput::NullStream);
+                                    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc2);
+                                }
+                                break;
+
                             case 112: // emergency stop, do the best we can with this
                                 // TODO this really needs to be handled out-of-band
                                 // disables heaters and motors, ignores further incoming Gcode and clears block queue

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -322,8 +322,17 @@ try_again:
                     if(!gcode->txt_after_ok.empty()) {
                         new_message.stream->printf("ok %s\r\n", gcode->txt_after_ok.c_str());
                         gcode->txt_after_ok.clear();
-                    } else
-                        new_message.stream->printf("ok\r\n");
+
+                    } else {
+                        if(THEKERNEL->is_grbl_mode()) {
+                            // only send ok once per line if this is a multi g code line send ok on the last one
+                            if(possible_command.empty())
+                                new_message.stream->printf("ok\r\n");
+                        } else {
+                            // TODO maybe should do the above for all hosts?
+                            new_message.stream->printf("ok\r\n");
+                        }
+                    }
 
                     delete gcode;
 

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -233,10 +233,10 @@ try_again:
                                 break;
 
                             case 112: // emergency stop, do the best we can with this
-                                // TODO this really needs to be handled out-of-band
+                                // this is also handled out-of-band (it is now with ^X in the serial driver)
                                 // disables heaters and motors, ignores further incoming Gcode and clears block queue
                                 THEKERNEL->call_event(ON_HALT, nullptr);
-                                THEKERNEL->streams->printf("ok Emergency Stop Requested - reset or M999 required to continue\r\n");
+                                THEKERNEL->streams->printf("ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
                                 delete gcode;
                                 return;
 
@@ -249,7 +249,7 @@ try_again:
                                 return;
                             }
 
-                            case 1000: // M1000 is a special comanad that will pass thru the raw lowercased command to the simpleshell (for hosts that do not allow such things)
+                            case 1000: // M1000 is a special command that will pass thru the raw lowercased command to the simpleshell (for hosts that do not allow such things)
                             {
                                 // reconstruct entire command line again
                                 string str= single_command.substr(5) + possible_command;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -444,6 +444,7 @@ void Robot::on_gcode_received(void *argument)
     } else if( gcode->has_m) {
         switch( gcode->m ) {
             case 2: // M2 end of program
+            case 30: // M30 end of program
                 current_wcs = 0;
                 absolute_mode = true;
                 break;

--- a/src/modules/robot/arm_solutions/RotatableDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotatableDeltaSolution.cpp
@@ -10,14 +10,14 @@
 #include "StreamOutputPool.h"
 #include <fastmath.h>
 
-#define delta_e_checksum                CHECKSUM("delta_e_checksum")
-#define delta_f_checksum                CHECKSUM("delta_f_checksum")
-#define delta_re_checksum               CHECKSUM("delta_re_checksum")
-#define delta_rf_checksum               CHECKSUM("delta_rf_checksum")
-#define delta_z_offset_checksum         CHECKSUM("delta_z_offset_checksum")
+#define delta_e_checksum                CHECKSUM("delta_e")
+#define delta_f_checksum                CHECKSUM("delta_f")
+#define delta_re_checksum               CHECKSUM("delta_re")
+#define delta_rf_checksum               CHECKSUM("delta_rf")
+#define delta_z_offset_checksum         CHECKSUM("delta_z_offset")
 
-#define delta_ee_offs_checksum          CHECKSUM("delta_ee_offs_checksum")
-#define tool_offset_checksum            CHECKSUM("tool_offset_checksum")
+#define delta_ee_offs_checksum          CHECKSUM("delta_ee_offs")
+#define tool_offset_checksum            CHECKSUM("tool_offset")
 
 const static float pi     = 3.14159265358979323846;    // PI
 const static float two_pi = 2 * pi;
@@ -132,7 +132,7 @@ void RotatableDeltaSolution::init()
 {
 
     //these are calculated here and not in the config() as these variables can be fine tuned by the user.
-    z_calc_offset  = (delta_z_offset - tool_offset - delta_ee_offs) * -1.0F;
+    z_calc_offset  = -(delta_z_offset - tool_offset - delta_ee_offs);
 }
 
 void RotatableDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm )

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -110,7 +110,7 @@
 
 
 // Homing States
-enum{
+enum {
     MOVING_TO_ENDSTOP_FAST, // homing move
     MOVING_BACK,            // homing move
     MOVING_TO_ENDSTOP_SLOW, // homing move
@@ -138,7 +138,7 @@ void Endstops::on_module_loaded()
     register_for_event(ON_GET_PUBLIC_DATA);
     register_for_event(ON_SET_PUBLIC_DATA);
 
-    THEKERNEL->step_ticker->register_acceleration_tick_handler([this](){acceleration_tick(); });
+    THEKERNEL->step_ticker->register_acceleration_tick_handler([this]() {acceleration_tick(); });
 
     // Settings
     this->on_config_reload(this);
@@ -197,14 +197,14 @@ void Endstops::on_config_reload(void *argument)
     this->is_scara                  =  THEKERNEL->config->value(scara_homing_checksum)->by_default(false)->as_bool();
 
     // see if an order has been specified, must be three characters, XYZ or YXZ etc
-    string order= THEKERNEL->config->value(homing_order_checksum)->by_default("")->as_string();
-    this->homing_order= 0;
+    string order = THEKERNEL->config->value(homing_order_checksum)->by_default("")->as_string();
+    this->homing_order = 0;
     if(order.size() == 3 && !this->is_delta) {
-        int shift= 0;
+        int shift = 0;
         for(auto c : order) {
-            uint8_t i= toupper(c) - 'X';
+            uint8_t i = toupper(c) - 'X';
             if(i > 2) { // bad value
-                this->homing_order= 0;
+                this->homing_order = 0;
                 break;
             }
             homing_order |= (i << shift);
@@ -219,37 +219,37 @@ void Endstops::on_config_reload(void *argument)
     this->trim_mm[2] = THEKERNEL->config->value(gamma_trim_checksum )->by_default(0  )->as_number();
 
     // limits enabled
-    this->limit_enable[X_AXIS]= THEKERNEL->config->value(alpha_limit_enable_checksum)->by_default(false)->as_bool();
-    this->limit_enable[Y_AXIS]= THEKERNEL->config->value(beta_limit_enable_checksum)->by_default(false)->as_bool();
-    this->limit_enable[Z_AXIS]= THEKERNEL->config->value(gamma_limit_enable_checksum)->by_default(false)->as_bool();
+    this->limit_enable[X_AXIS] = THEKERNEL->config->value(alpha_limit_enable_checksum)->by_default(false)->as_bool();
+    this->limit_enable[Y_AXIS] = THEKERNEL->config->value(beta_limit_enable_checksum)->by_default(false)->as_bool();
+    this->limit_enable[Z_AXIS] = THEKERNEL->config->value(gamma_limit_enable_checksum)->by_default(false)->as_bool();
 
     //s et to true by default for deltas duwe to trim, false on cartesians
-    this->move_to_origin_after_home= THEKERNEL->config->value(move_to_origin_checksum)->by_default(is_delta)->as_bool();
+    this->move_to_origin_after_home = THEKERNEL->config->value(move_to_origin_checksum)->by_default(is_delta)->as_bool();
 
-    if(this->limit_enable[X_AXIS] || this->limit_enable[Y_AXIS] || this->limit_enable[Z_AXIS]){
+    if(this->limit_enable[X_AXIS] || this->limit_enable[Y_AXIS] || this->limit_enable[Z_AXIS]) {
         register_for_event(ON_IDLE);
         if(this->is_delta) {
             // we must enable all the limits not just one
-            this->limit_enable[X_AXIS]= true;
-            this->limit_enable[Y_AXIS]= true;
-            this->limit_enable[Z_AXIS]= true;
+            this->limit_enable[X_AXIS] = true;
+            this->limit_enable[Y_AXIS] = true;
+            this->limit_enable[Z_AXIS] = true;
         }
     }
 
     // NOTE this may also be true of scara. TBD
     if(this->is_delta) {
         // some things must be the same or they will die, so force it here to avoid config errors
-        this->fast_rates[1]= this->fast_rates[2]= this->fast_rates[0];
-        this->slow_rates[1]= this->slow_rates[2]= this->slow_rates[0];
-        this->retract_mm[1]= this->retract_mm[2]= this->retract_mm[0];
-        this->home_direction[1]= this->home_direction[2]= this->home_direction[0];
-        this->homing_position[0]= this->homing_position[1]= 0;
+        this->fast_rates[1] = this->fast_rates[2] = this->fast_rates[0];
+        this->slow_rates[1] = this->slow_rates[2] = this->slow_rates[0];
+        this->retract_mm[1] = this->retract_mm[2] = this->retract_mm[0];
+        this->home_direction[1] = this->home_direction[2] = this->home_direction[0];
+        this->homing_position[0] = this->homing_position[1] = 0;
     }
 }
 
 bool Endstops::debounced_get(int pin)
 {
-    uint8_t debounce= 0;
+    uint8_t debounce = 0;
     while(this->pins[pin].get()) {
         if ( ++debounce >= this->debounce_count ) {
             // pin triggered
@@ -259,7 +259,7 @@ bool Endstops::debounced_get(int pin)
     return false;
 }
 
-static const char *endstop_names[]= {"min_x", "min_y", "min_z", "max_x", "max_y", "max_z"};
+static const char *endstop_names[] = {"min_x", "min_y", "min_z", "max_x", "max_y", "max_z"};
 
 void Endstops::on_idle(void *argument)
 {
@@ -270,10 +270,10 @@ void Endstops::on_idle(void *argument)
                 std::array<int, 2> minmax{{0, 3}};
                 // check min and max endstops
                 for (int i : minmax) {
-                    int n= c+i;
+                    int n = c + i;
                     if(this->pins[n].get()) {
                         // still triggered, so exit
-                        bounce_cnt= 0;
+                        bounce_cnt = 0;
                         return;
                     }
                 }
@@ -281,11 +281,11 @@ void Endstops::on_idle(void *argument)
         }
         if(++bounce_cnt > 10) { // can use less as it calls on_idle in between
             // clear the state
-            this->status= NOT_HOMING;
+            this->status = NOT_HOMING;
         }
         return;
 
-    }else if(this->status != NOT_HOMING) {
+    } else if(this->status != NOT_HOMING) {
         // don't check while homing
         return;
     }
@@ -295,11 +295,11 @@ void Endstops::on_idle(void *argument)
             std::array<int, 2> minmax{{0, 3}};
             // check min and max endstops
             for (int i : minmax) {
-                int n= c+i;
+                int n = c + i;
                 if(debounced_get(n)) {
                     // endstop triggered
                     THEKERNEL->streams->printf("Limit switch %s was hit - reset or M999 required\n", endstop_names[n]);
-                    this->status= LIMIT_TRIGGERED;
+                    this->status = LIMIT_TRIGGERED;
                     // disables heaters and motors, ignores incoming Gcode and flushes block queue
                     THEKERNEL->call_event(ON_HALT, nullptr);
                     return;
@@ -313,22 +313,22 @@ void Endstops::on_idle(void *argument)
 // checks if triggered and only backs off if triggered
 void Endstops::back_off_home(char axes_to_move)
 {
-    std::vector<std::pair<char,float>> params;
+    std::vector<std::pair<char, float>> params;
     this->status = BACK_OFF_HOME;
 
     // these are handled differently
     if(is_delta || is_scara) {
         // Move off of the endstop using a regular relative move in Z only
-         params.push_back({'Z', this->retract_mm[Z_AXIS]*(this->home_direction[Z_AXIS]?1:-1)});
+        params.push_back({'Z', this->retract_mm[Z_AXIS] * (this->home_direction[Z_AXIS] ? 1 : -1)});
 
-    }else{
+    } else {
         // cartesians, concatenate all the moves we need to do into one gcode
         for( int c = X_AXIS; c <= Z_AXIS; c++ ) {
             if( ((axes_to_move >> c ) & 1) == 0) continue; // only for axes we asked to move
 
             // if not triggered no need to move off
             if(this->limit_enable[c] && debounced_get(c + (this->home_direction[c] ? 0 : 3)) ) {
-                params.push_back({c+'X', this->retract_mm[c]*(this->home_direction[c]?1:-1)});
+                params.push_back({c + 'X', this->retract_mm[c] * (this->home_direction[c] ? 1 : -1)});
             }
         }
     }
@@ -337,14 +337,14 @@ void Endstops::back_off_home(char axes_to_move)
         // Move off of the endstop using a regular relative move
         params.insert(params.begin(), {'G', 0});
         // use X slow rate to move, Z should have a max speed set anyway
-        params.push_back({'F', this->slow_rates[X_AXIS]*60.0F});
+        params.push_back({'F', this->slow_rates[X_AXIS] * 60.0F});
         char gcode_buf[64];
         append_parameters(gcode_buf, params, sizeof(gcode_buf));
         Gcode gc(gcode_buf, &(StreamOutput::NullStream));
-        bool oldmode= THEKERNEL->robot->absolute_mode;
-        THEKERNEL->robot->absolute_mode= false; // needs to be relative mode
+        bool oldmode = THEKERNEL->robot->absolute_mode;
+        THEKERNEL->robot->absolute_mode = false; // needs to be relative mode
         THEKERNEL->robot->on_gcode_received(&gc); // send to robot directly
-        THEKERNEL->robot->absolute_mode= oldmode; // restore mode
+        THEKERNEL->robot->absolute_mode = oldmode; // restore mode
         // Wait for above to finish
         THEKERNEL->conveyor->wait_for_empty_queue();
     }
@@ -355,14 +355,14 @@ void Endstops::back_off_home(char axes_to_move)
 // If enabled will move the head to 0,0 after homing, but only if X and Y were set to home
 void Endstops::move_to_origin(char axes_to_move)
 {
-    if( (axes_to_move&0x03) != 3 ) return; // ignore if X and Y not homing
+    if( (axes_to_move & 0x03) != 3 ) return; // ignore if X and Y not homing
 
     // Do we need to check if we are already at 0,0? probably not as the G0 will not do anything if we are
     // float pos[3]; THEKERNEL->robot->get_axis_position(pos); if(pos[0] == 0 && pos[1] == 0) return;
 
     this->status = MOVE_TO_ORIGIN;
     // Move to center using a regular move, use slower of X and Y fast rate
-    float rate= std::min(this->fast_rates[0], this->fast_rates[1])*60.0F;
+    float rate = std::min(this->fast_rates[0], this->fast_rates[1]) * 60.0F;
     char buf[32];
     snprintf(buf, sizeof(buf), "G53 G0 X0 Y0 F%1.4f", rate); // must use machine coordinates in case G92 or WCS is in effect
     struct SerialMessage message;
@@ -393,7 +393,7 @@ bool Endstops::wait_for_homed(char axes_to_move)
                         running = true;
                     } else if ( STEPPER[c]->is_moving() ) {
                         STEPPER[c]->move(0, 0);
-                        axes_to_move &= ~(1<<c); // no need to check it again
+                        axes_to_move &= ~(1 << c); // no need to check it again
                     }
                 } else {
                     // The endstop was not hit yet
@@ -416,7 +416,7 @@ void Endstops::do_homing_cartesian(char axes_to_move)
     this->status = MOVING_TO_ENDSTOP_FAST;
     for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
         if ( ( axes_to_move >> c) & 1 ) {
-            this->feed_rate[c]= this->fast_rates[c];
+            this->feed_rate[c] = this->fast_rates[c];
             STEPPER[c]->move(this->home_direction[c], 10000000, 0);
         }
     }
@@ -430,7 +430,7 @@ void Endstops::do_homing_cartesian(char axes_to_move)
     for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
         if ( ( axes_to_move >> c ) & 1 ) {
             inverted_dir = !this->home_direction[c];
-            this->feed_rate[c]= this->slow_rates[c];
+            this->feed_rate[c] = this->slow_rates[c];
             STEPPER[c]->move(inverted_dir, this->retract_mm[c]*STEPS_PER_MM(c), 0);
         }
     }
@@ -449,7 +449,7 @@ void Endstops::do_homing_cartesian(char axes_to_move)
     this->status = MOVING_TO_ENDSTOP_SLOW;
     for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
         if ( ( axes_to_move >> c ) & 1 ) {
-            this->feed_rate[c]= this->slow_rates[c];
+            this->feed_rate[c] = this->slow_rates[c];
             STEPPER[c]->move(this->home_direction[c], 10000000, 0);
         }
     }
@@ -493,9 +493,9 @@ void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate,
     if(THEKERNEL->is_halted()) return;
 
     this->status = MOVING_TO_ENDSTOP_FAST;
-    this->feed_rate[X_AXIS]= fast_rate;
+    this->feed_rate[X_AXIS] = fast_rate;
     STEPPER[X_AXIS]->move(dirx, 10000000, 0);
-    this->feed_rate[Y_AXIS]= fast_rate;
+    this->feed_rate[Y_AXIS] = fast_rate;
     STEPPER[Y_AXIS]->move(diry, 10000000, 0);
 
     // wait for primary axis
@@ -503,9 +503,9 @@ void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate,
 
     // Move back a small distance
     this->status = MOVING_BACK;
-    this->feed_rate[X_AXIS]= slow_rate;
+    this->feed_rate[X_AXIS] = slow_rate;
     STEPPER[X_AXIS]->move(!dirx, retract_steps, 0);
-    this->feed_rate[Y_AXIS]= slow_rate;
+    this->feed_rate[Y_AXIS] = slow_rate;
     STEPPER[Y_AXIS]->move(!diry, retract_steps, 0);
 
     // wait until done
@@ -516,9 +516,9 @@ void Endstops::corexy_home(int home_axis, bool dirx, bool diry, float fast_rate,
 
     // Start moving the axes to the origin slowly
     this->status = MOVING_TO_ENDSTOP_SLOW;
-    this->feed_rate[X_AXIS]= slow_rate;
+    this->feed_rate[X_AXIS] = slow_rate;
     STEPPER[X_AXIS]->move(dirx, 10000000, 0);
-    this->feed_rate[Y_AXIS]= slow_rate;
+    this->feed_rate[Y_AXIS] = slow_rate;
     STEPPER[Y_AXIS]->move(diry, 10000000, 0);
 
     // wait for primary axis
@@ -535,39 +535,39 @@ void Endstops::do_homing_corexy(char axes_to_move)
 
     if((axes_to_move & 0x03) == 0x03) { // both X and Y need Homing
         // determine which motor to turn and which way
-        bool dirx= this->home_direction[X_AXIS];
-        bool diry= this->home_direction[Y_AXIS];
+        bool dirx = this->home_direction[X_AXIS];
+        bool diry = this->home_direction[Y_AXIS];
         int motor;
         bool dir;
         if(dirx && diry) { // min/min
-            motor= X_AXIS;
-            dir= true;
-        }else if(dirx && !diry) { // min/max
-            motor= Y_AXIS;
-            dir= true;
-        }else if(!dirx && diry) { // max/min
-            motor= Y_AXIS;
-            dir= false;
-        }else if(!dirx && !diry) { // max/max
-            motor= X_AXIS;
-            dir= false;
+            motor = X_AXIS;
+            dir = true;
+        } else if(dirx && !diry) { // min/max
+            motor = Y_AXIS;
+            dir = true;
+        } else if(!dirx && diry) { // max/min
+            motor = Y_AXIS;
+            dir = false;
+        } else if(!dirx && !diry) { // max/max
+            motor = X_AXIS;
+            dir = false;
         }
 
         // then move both X and Y until one hits the endstop
         this->status = MOVING_TO_ENDSTOP_FAST;
-         // need to allow for more ground covered when moving diagonally
-        this->feed_rate[motor]= this->fast_rates[motor]*1.4142;
+        // need to allow for more ground covered when moving diagonally
+        this->feed_rate[motor] = this->fast_rates[motor] * 1.4142;
         STEPPER[motor]->move(dir, 10000000, 0);
         // wait until either X or Y hits the endstop
-        bool running= true;
+        bool running = true;
         while (running) {
             THEKERNEL->call_event(ON_IDLE);
             if(THEKERNEL->is_halted()) return;
-            for(int m=X_AXIS;m<=Y_AXIS;m++) {
+            for(int m = X_AXIS; m <= Y_AXIS; m++) {
                 if(this->pins[m + (this->home_direction[m] ? 0 : 3)].get()) {
                     // turn off motor
                     if(STEPPER[motor]->is_moving()) STEPPER[motor]->move(0, 0);
-                    running= false;
+                    running = false;
                     break;
                 }
             }
@@ -576,12 +576,12 @@ void Endstops::do_homing_corexy(char axes_to_move)
 
     // move individual axis
     if (axes_to_move & 0x01) { // Home X, which means both X and Y in same direction
-        bool dir= this->home_direction[X_AXIS];
+        bool dir = this->home_direction[X_AXIS];
         corexy_home(X_AXIS, dir, dir, this->fast_rates[X_AXIS], this->slow_rates[X_AXIS], this->retract_mm[X_AXIS]*STEPS_PER_MM(X_AXIS));
     }
 
     if (axes_to_move & 0x02) { // Home Y, which means both X and Y in different directions
-        bool dir= this->home_direction[Y_AXIS];
+        bool dir = this->home_direction[Y_AXIS];
         corexy_home(Y_AXIS, dir, !dir, this->fast_rates[Y_AXIS], this->slow_rates[Y_AXIS], this->retract_mm[Y_AXIS]*STEPS_PER_MM(Y_AXIS));
     }
 
@@ -597,10 +597,10 @@ void Endstops::home(char axes_to_move)
         STEPPER[c]->set_moved_last_block(false);
     }
 
-    if (is_corexy){
+    if (is_corexy) {
         // corexy/HBot homing
         do_homing_corexy(axes_to_move);
-    }else{
+    } else {
         // cartesian/delta homing
         do_homing_cartesian(axes_to_move);
     }
@@ -616,142 +616,147 @@ void Endstops::home(char axes_to_move)
 void Endstops::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode *>(argument);
-    if ( gcode->has_g) {
-        if ( gcode->g == 28 ) {
-            if(THEKERNEL->is_grbl_mode()) {
-                if(gcode->subcode == 0) { // G28 goto pre defined position
-                    // TODO
+    if ( gcode->has_g && gcode->g == 28) {
+        if( (gcode->subcode == 0 && THEKERNEL->is_grbl_mode()) || (gcode->subcode == 2 && !THEKERNEL->is_grbl_mode()) ) {
+            // G28 in grbl mode or G28.2 in normal mode will do a rapid to the predefined position
+            // TODO spec says if XYZ specified move to them first then move to MCS of specifed axis
+            char buf[32];
+            snprintf(buf, sizeof(buf), "G53 G0 X%f Y%f", saved_position[X_AXIS], saved_position[Y_AXIS]); // must use machine coordinates in case G92 or WCS is in effect
+            struct SerialMessage message;
+            message.message = buf;
+            message.stream = &(StreamOutput::NullStream);
+            THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message ); // as it is a multi G code command
+            return;
 
-                }else if(gcode->subcode == 1) { // G28.1 set pre defined position
-                    // TODO
+        } else if(THEKERNEL->is_grbl_mode() && gcode->subcode == 2) { // G28.2 in grbl mode forces homing (triggered by $H)
+            // fall through so it does homing cycle
 
-                }else if(gcode->subcode == 2) { // G28.2 force homing cycle
-                    // fall through to do this
+        } else if(gcode->subcode == 1) { // G28.1 set pre defined position
+            // saves current position in absolute machine coordinates
+            THEKERNEL->robot->get_axis_position(saved_position);
+            return;
 
-                }else{
-                    gcode->stream->printf("error:Unsupported command\n");
-                    return;
-                }
-
-            }else{
-                if(gcode->subcode == 1) { // G28.1
-                    if(gcode->get_num_args() == 0) {
-                        THEKERNEL->robot->reset_axis_position(0, 0, 0);
-                    }else{
-                        // do a manual homing based on current position, no endstops required
-                        if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
-                        if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
-                        if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
-                    }
-                    return;
-                }
-            }
-
-            // G28 is received, we have homing to do
-
-            // First wait for the queue to be empty
-            THEKERNEL->conveyor->wait_for_empty_queue();
-
-            // Do we move select axes or all of them
-            char axes_to_move = 0;
-            // only enable homing if the endstop is defined, deltas, scaras always home all axis
-            bool home_all = this->is_delta || this->is_scara || !( gcode->has_letter('X') || gcode->has_letter('Y') || gcode->has_letter('Z') );
-
-            for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
-                if ( (home_all || gcode->has_letter(c+'X')) && this->pins[c + (this->home_direction[c] ? 0 : 3)].connected() ) {
-                    axes_to_move += ( 1 << c );
-                }
-            }
-
-            // Enable the motors
-            THEKERNEL->stepper->turn_enable_pins_on();
-
-            // do the actual homing
-            if(homing_order != 0){
-                // if an order has been specified do it in the specified order
-                // homing order is 0b00ccbbaa where aa is 0,1,2 to specify the first axis, bb is the second and cc is the third
-                // eg 0b00100001 would be Y X Z, 0b00100100 would be X Y Z
-                for (uint8_t m = homing_order; m != 0; m >>= 2) {
-                    int a= (1 << (m & 0x03)); // axis to move
-                    if((a & axes_to_move) != 0){
-                        home(a);
-                    }
-                    // check if on_halt (eg kill)
-                    if(THEKERNEL->is_halted()) break;
-                }
-
-            }else {
-                // they all home at the same time
-                home(axes_to_move);
-            }
-
-            // check if on_halt (eg kill)
-            if(THEKERNEL->is_halted()){
-                THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
-                return;
-            }
-
-            if(home_all) {
-                // Here's where we would have been if the endstops were perfectly trimmed
-                float ideal_position[3] = {
-                    this->homing_position[X_AXIS] + this->home_offset[X_AXIS],
-                    this->homing_position[Y_AXIS] + this->home_offset[Y_AXIS],
-                    this->homing_position[Z_AXIS] + this->home_offset[Z_AXIS]
-                };
-
-                bool has_endstop_trim = this->is_delta || this->is_scara;
-                if (has_endstop_trim) {
-                    ActuatorCoordinates ideal_actuator_position;
-                    THEKERNEL->robot->arm_solution->cartesian_to_actuator(ideal_position, ideal_actuator_position);
-
-                    // We are actually not at the ideal position, but a trim away
-                    ActuatorCoordinates real_actuator_position = {
-                        ideal_actuator_position[X_AXIS] - this->trim_mm[X_AXIS],
-                        ideal_actuator_position[Y_AXIS] - this->trim_mm[Y_AXIS],
-                        ideal_actuator_position[Z_AXIS] - this->trim_mm[Z_AXIS]
-                    };
-
-                    float real_position[3];
-                    THEKERNEL->robot->arm_solution->actuator_to_cartesian(real_actuator_position, real_position);
-                    // Reset the actuator positions to correspond our real position
-                    THEKERNEL->robot->reset_axis_position(real_position[0], real_position[1], real_position[2]);
-                } else {
-                    // without endstop trim, real_position == ideal_position
-                    // Reset the actuator positions to correspond our real position
-                    THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
-                }
+        } else if(gcode->subcode == 3) { // G28.3 is a smoothie special it sets manual homing
+            if(gcode->get_num_args() == 0) {
+                THEKERNEL->robot->reset_axis_position(0, 0, 0);
             } else {
-                // Zero the ax(i/e)s position, add in the home offset
-                for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
-                    if ( (axes_to_move >> c)  & 1 ) {
-                        THEKERNEL->robot->reset_axis_position(this->homing_position[c] + this->home_offset[c], c);
-                    }
-                }
+                // do a manual homing based on current position, no endstops required
+                if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
+                if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
+                if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
             }
+            return;
 
-            // on some systems where 0,0 is bed center it is nice to have home goto 0,0 after homing
-            // default is off for cartesian on for deltas
-            if(!is_delta) {
-                if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
-                // if limit switches are enabled we must back off endstop after setting home
-                back_off_home(axes_to_move);
+        } else if(THEKERNEL->is_grbl_mode()) {
+            gcode->stream->printf("error:Unsupported command\n");
+            return;
+        }
 
-            }else if(this->move_to_origin_after_home || this->limit_enable[X_AXIS]) {
-                // deltas are not left at 0,0 because of the trim settings, so move to 0,0 if requested, but we need to back off endstops first
-                // also need to back off endstops if limits are enabled
-                back_off_home(axes_to_move);
-                if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
+        // G28 is received, we have homing to do
+
+        // First wait for the queue to be empty
+        THEKERNEL->conveyor->wait_for_empty_queue();
+
+        // Do we move select axes or all of them
+        char axes_to_move = 0;
+        // only enable homing if the endstop is defined, deltas, scaras always home all axis
+        bool home_all = this->is_delta || this->is_scara || !( gcode->has_letter('X') || gcode->has_letter('Y') || gcode->has_letter('Z') );
+
+        for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
+            if ( (home_all || gcode->has_letter(c + 'X')) && this->pins[c + (this->home_direction[c] ? 0 : 3)].connected() ) {
+                axes_to_move += ( 1 << c );
             }
         }
 
-    } else if (gcode->has_m) {
+        // Enable the motors
+        THEKERNEL->stepper->turn_enable_pins_on();
+
+        // do the actual homing
+        if(homing_order != 0) {
+            // if an order has been specified do it in the specified order
+            // homing order is 0b00ccbbaa where aa is 0,1,2 to specify the first axis, bb is the second and cc is the third
+            // eg 0b00100001 would be Y X Z, 0b00100100 would be X Y Z
+            for (uint8_t m = homing_order; m != 0; m >>= 2) {
+                int a = (1 << (m & 0x03)); // axis to move
+                if((a & axes_to_move) != 0) {
+                    home(a);
+                }
+                // check if on_halt (eg kill)
+                if(THEKERNEL->is_halted()) break;
+            }
+
+        } else {
+            // they all home at the same time
+            home(axes_to_move);
+        }
+
+        // check if on_halt (eg kill)
+        if(THEKERNEL->is_halted()) {
+            THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
+            return;
+        }
+
+        if(home_all) {
+            // Here's where we would have been if the endstops were perfectly trimmed
+            float ideal_position[3] = {
+                this->homing_position[X_AXIS] + this->home_offset[X_AXIS],
+                this->homing_position[Y_AXIS] + this->home_offset[Y_AXIS],
+                this->homing_position[Z_AXIS] + this->home_offset[Z_AXIS]
+            };
+
+            bool has_endstop_trim = this->is_delta || this->is_scara;
+            if (has_endstop_trim) {
+                ActuatorCoordinates ideal_actuator_position;
+                THEKERNEL->robot->arm_solution->cartesian_to_actuator(ideal_position, ideal_actuator_position);
+
+                // We are actually not at the ideal position, but a trim away
+                ActuatorCoordinates real_actuator_position = {
+                    ideal_actuator_position[X_AXIS] - this->trim_mm[X_AXIS],
+                    ideal_actuator_position[Y_AXIS] - this->trim_mm[Y_AXIS],
+                    ideal_actuator_position[Z_AXIS] - this->trim_mm[Z_AXIS]
+                };
+
+                float real_position[3];
+                THEKERNEL->robot->arm_solution->actuator_to_cartesian(real_actuator_position, real_position);
+                // Reset the actuator positions to correspond our real position
+                THEKERNEL->robot->reset_axis_position(real_position[0], real_position[1], real_position[2]);
+            } else {
+                // without endstop trim, real_position == ideal_position
+                // Reset the actuator positions to correspond our real position
+                THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
+            }
+        } else {
+            // Zero the ax(i/e)s position, add in the home offset
+            for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
+                if ( (axes_to_move >> c)  & 1 ) {
+                    THEKERNEL->robot->reset_axis_position(this->homing_position[c] + this->home_offset[c], c);
+                }
+            }
+        }
+
+        // on some systems where 0,0 is bed center it is nice to have home goto 0,0 after homing
+        // default is off for cartesian on for deltas
+        if(!is_delta) {
+            if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
+            // if limit switches are enabled we must back off endstop after setting home
+            back_off_home(axes_to_move);
+
+        } else if(this->move_to_origin_after_home || this->limit_enable[X_AXIS]) {
+            // deltas are not left at 0,0 because of the trim settings, so move to 0,0 if requested, but we need to back off endstops first
+            // also need to back off endstops if limits are enabled
+            back_off_home(axes_to_move);
+            if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
+        }
+    }
+
+    if (gcode->has_m) {
         switch (gcode->m) {
             case 119: {
                 for (int i = 0; i < 6; ++i) {
                     if(this->pins[i].connected())
                         gcode->stream->printf("%s:%d ", endstop_names[i], this->pins[i].get());
                 }
-                gcode->add_nl= true;
+                gcode->add_nl = true;
 
             }
             break;
@@ -764,27 +769,26 @@ void Endstops::on_gcode_received(void *argument)
 
                 break;
 
-            case 306: // Similar to M206 and G92 but sets Homing offsets based on current position
-                {
-                    float cartesian[3];
-                    THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
-                    if (gcode->has_letter('X')){
-                        home_offset[0] -= (cartesian[X_AXIS] - gcode->get_value('X'));
-                        THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
-                    }
-                    if (gcode->has_letter('Y')) {
-                        home_offset[1] -= (cartesian[Y_AXIS] - gcode->get_value('Y'));
-                        THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
-                    }
-                    if (gcode->has_letter('Z')) {
-                        home_offset[2] -= (cartesian[Z_AXIS] - gcode->get_value('Z'));
-                        THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
-                    }
-
-                    gcode->stream->printf("Homing Offset: X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
-
+            case 306: { // Similar to M206 and G92 but sets Homing offsets based on current position
+                float cartesian[3];
+                THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
+                if (gcode->has_letter('X')) {
+                    home_offset[0] -= (cartesian[X_AXIS] - gcode->get_value('X'));
+                    THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
                 }
-                break;
+                if (gcode->has_letter('Y')) {
+                    home_offset[1] -= (cartesian[Y_AXIS] - gcode->get_value('Y'));
+                    THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
+                }
+                if (gcode->has_letter('Z')) {
+                    home_offset[2] -= (cartesian[Z_AXIS] - gcode->get_value('Z'));
+                    THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
+                }
+
+                gcode->stream->printf("Homing Offset: X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
+
+            }
+            break;
 
             case 500: // save settings
             case 503: // print settings
@@ -792,6 +796,9 @@ void Endstops::on_gcode_received(void *argument)
                 if (this->is_delta || this->is_scara) {
                     gcode->stream->printf(";Trim (mm):\nM666 X%1.3f Y%1.3f Z%1.3f\n", trim_mm[0], trim_mm[1], trim_mm[2]);
                     gcode->stream->printf(";Max Z\nM665 Z%1.3f\n", this->homing_position[2]);
+                }
+                if(saved_position[X_AXIS] != 0 || saved_position[Y_AXIS] != 0) {
+                    gcode->stream->printf(";predefined position:\nG28.1 X%1.4f Y%1.4f Z%1.4f\n", saved_position[X_AXIS], saved_position[Y_AXIS], saved_position[Z_AXIS]);
                 }
                 break;
 
@@ -817,7 +824,7 @@ void Endstops::on_gcode_received(void *argument)
                     gcode->stream->printf("X: %5.3f Y: %5.3f Z: %5.3f\n", trim_mm[0], trim_mm[1], trim_mm[2]);
 
                 }
-            break;
+                break;
 
             // NOTE this is to test accuracy of lead screws etc.
             case 1910: { // M1910 - move specific number of raw steps
@@ -825,27 +832,27 @@ void Endstops::on_gcode_received(void *argument)
                     // Enable the motors
                     THEKERNEL->stepper->turn_enable_pins_on();
 
-                    int x= 0, y=0 , z= 0, f= 200*16;
+                    int x = 0, y = 0 , z = 0, f = 200 * 16;
                     if (gcode->has_letter('F')) f = gcode->get_value('F');
                     if (gcode->has_letter('X')) {
                         x = gcode->get_value('X');
-                        STEPPER[X_AXIS]->move(x<0, abs(x), f);
+                        STEPPER[X_AXIS]->move(x < 0, abs(x), f);
                     }
                     if (gcode->has_letter('Y')) {
                         y = gcode->get_value('Y');
-                        STEPPER[Y_AXIS]->move(y<0, abs(y), f);
+                        STEPPER[Y_AXIS]->move(y < 0, abs(y), f);
                     }
                     if (gcode->has_letter('Z')) {
                         z = gcode->get_value('Z');
-                        STEPPER[Z_AXIS]->move(z<0, abs(z), f);
+                        STEPPER[Z_AXIS]->move(z < 0, abs(z), f);
                     }
                     gcode->stream->printf("Moving X %d Y %d Z %d steps at F %d steps/sec\n", x, y, z, f);
 
-                }else if(gcode->subcode == 1) {
+                } else if(gcode->subcode == 1) {
                     // stop any that are moving
                     for (int i = 0; i < 3; ++i) {
-                         if(STEPPER[i]->is_moving()) STEPPER[i]->move(0, 0);
-                     }
+                        if(STEPPER[i]->is_moving()) STEPPER[i]->move(0, 0);
+                    }
                 }
                 break;
             }
@@ -863,13 +870,13 @@ void Endstops::acceleration_tick(void)
         if( !STEPPER[c]->is_moving() ) continue;
 
         uint32_t current_rate = STEPPER[c]->get_steps_per_second();
-        uint32_t target_rate = floorf(this->feed_rate[c]*STEPS_PER_MM(c));
-        float acc= (c==Z_AXIS) ? THEKERNEL->planner->get_z_acceleration() : THEKERNEL->planner->get_acceleration();
-        if( current_rate < target_rate ){
-            uint32_t rate_increase = floorf((acc/THEKERNEL->acceleration_ticks_per_second)*STEPS_PER_MM(c));
+        uint32_t target_rate = floorf(this->feed_rate[c] * STEPS_PER_MM(c));
+        float acc = (c == Z_AXIS) ? THEKERNEL->planner->get_z_acceleration() : THEKERNEL->planner->get_acceleration();
+        if( current_rate < target_rate ) {
+            uint32_t rate_increase = floorf((acc / THEKERNEL->acceleration_ticks_per_second) * STEPS_PER_MM(c));
             current_rate = min( target_rate, current_rate + rate_increase );
         }
-        if( current_rate > target_rate ){ current_rate = target_rate; }
+        if( current_rate > target_rate ) { current_rate = target_rate; }
 
         // steps per second
         STEPPER[c]->set_speed(current_rate);
@@ -878,7 +885,8 @@ void Endstops::acceleration_tick(void)
     return;
 }
 
-void Endstops::on_get_public_data(void* argument){
+void Endstops::on_get_public_data(void* argument)
+{
     PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
 
     if(!pdr->starts_with(endstops_checksum)) return;
@@ -887,28 +895,33 @@ void Endstops::on_get_public_data(void* argument){
         pdr->set_data_ptr(&this->trim_mm);
         pdr->set_taken();
 
-    }else if(pdr->second_element_is(home_offset_checksum)) {
+    } else if(pdr->second_element_is(home_offset_checksum)) {
         pdr->set_data_ptr(&this->home_offset);
+        pdr->set_taken();
+
+    } else if(pdr->second_element_is(saved_position_checksum)) {
+        pdr->set_data_ptr(&this->saved_position);
         pdr->set_taken();
     }
 }
 
-void Endstops::on_set_public_data(void* argument){
+void Endstops::on_set_public_data(void* argument)
+{
     PublicDataRequest* pdr = static_cast<PublicDataRequest*>(argument);
 
     if(!pdr->starts_with(endstops_checksum)) return;
 
     if(pdr->second_element_is(trim_checksum)) {
-        float *t= static_cast<float*>(pdr->get_data_ptr());
-        this->trim_mm[0]= t[0];
-        this->trim_mm[1]= t[1];
-        this->trim_mm[2]= t[2];
+        float *t = static_cast<float*>(pdr->get_data_ptr());
+        this->trim_mm[0] = t[0];
+        this->trim_mm[1] = t[1];
+        this->trim_mm[2] = t[2];
         pdr->set_taken();
 
-    }else if(pdr->second_element_is(home_offset_checksum)) {
-        float *t= static_cast<float*>(pdr->get_data_ptr());
-        if(!isnan(t[0])) this->home_offset[0]= t[0];
-        if(!isnan(t[1])) this->home_offset[1]= t[1];
-        if(!isnan(t[2])) this->home_offset[2]= t[2];
+    } else if(pdr->second_element_is(home_offset_checksum)) {
+        float *t = static_cast<float*>(pdr->get_data_ptr());
+        if(!isnan(t[0])) this->home_offset[0] = t[0];
+        if(!isnan(t[1])) this->home_offset[1] = t[1];
+        if(!isnan(t[2])) this->home_offset[2] = t[2];
     }
 }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -618,16 +618,33 @@ void Endstops::on_gcode_received(void *argument)
     Gcode *gcode = static_cast<Gcode *>(argument);
     if ( gcode->has_g) {
         if ( gcode->g == 28 ) {
-            if(gcode->subcode == 1) { // G28.1
-                if(gcode->get_num_args() == 0) {
-                    THEKERNEL->robot->reset_axis_position(0, 0, 0);
+            if(THEKERNEL->is_grbl_mode()) {
+                if(gcode->subcode == 0) { // G28 goto pre defined position
+                    // TODO
+
+                }else if(gcode->subcode == 1) { // G28.1 set pre defined position
+                    // TODO
+
+                }else if(gcode->subcode == 2) { // G28.2 force homing cycle
+                    // fall through to do this
+
                 }else{
-                    // do a manual homing based on current position, no endstops required
-                    if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
-                    if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
-                    if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
+                    gcode->stream->printf("error:Unsupported command\n");
+                    return;
                 }
-                return;
+
+            }else{
+                if(gcode->subcode == 1) { // G28.1
+                    if(gcode->get_num_args() == 0) {
+                        THEKERNEL->robot->reset_axis_position(0, 0, 0);
+                    }else{
+                        // do a manual homing based on current position, no endstops required
+                        if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
+                        if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
+                        if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
+                    }
+                    return;
+                }
             }
 
             // G28 is received, we have homing to do

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -692,7 +692,9 @@ void Endstops::on_gcode_received(void *argument)
 
         // check if on_halt (eg kill)
         if(THEKERNEL->is_halted()) {
-            THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
+            if(!THEKERNEL->is_grbl_mode()) {
+                THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
+            }
             return;
         }
 
@@ -901,6 +903,11 @@ void Endstops::on_get_public_data(void* argument)
 
     } else if(pdr->second_element_is(saved_position_checksum)) {
         pdr->set_data_ptr(&this->saved_position);
+        pdr->set_taken();
+
+    } else if(pdr->second_element_is(get_homing_status_checksum)) {
+        bool *homing= static_cast<bool *>(pdr->get_data_ptr());
+        *homing= this->status != NOT_HOMING;
         pdr->set_taken();
     }
 }

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -42,6 +42,7 @@ class Endstops : public Module{
         uint8_t homing_order;
         std::bitset<3> home_direction;
         std::bitset<3> limit_enable;
+        float saved_position[3]{0}; // save G28 (in grbl mode)
 
         unsigned int  debounce_count;
         float  retract_mm[3];

--- a/src/modules/tools/endstops/EndstopsPublicAccess.h
+++ b/src/modules/tools/endstops/EndstopsPublicAccess.h
@@ -6,5 +6,6 @@
 #define trim_checksum        CHECKSUM("trim")
 #define home_offset_checksum CHECKSUM("home_offset")
 #define saved_position_checksum CHECKSUM("saved_position")
+#define get_homing_status_checksum CHECKSUM("homing_status")
 
 #endif

--- a/src/modules/tools/endstops/EndstopsPublicAccess.h
+++ b/src/modules/tools/endstops/EndstopsPublicAccess.h
@@ -5,5 +5,6 @@
 #define endstops_checksum    CHECKSUM("endstop")
 #define trim_checksum        CHECKSUM("trim")
 #define home_offset_checksum CHECKSUM("home_offset")
+#define saved_position_checksum CHECKSUM("saved_position")
 
 #endif

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -352,11 +352,11 @@ void ZProbe::on_gcode_received(void *argument)
 
         // make sure the probe is defined and not already triggered before moving motors
         if(!this->pin.connected()) {
-            gcode->stream->printf("ZProbe not connected.\n");
+            gcode->stream->printf("error:ZProbe not connected.\n");
             return;
         }
         if(this->pin.get()) {
-            gcode->stream->printf("ZProbe triggered before move, aborting command.\n");
+            gcode->stream->printf("error:ZProbe triggered before move, aborting command.\n");
             return;
         }
 
@@ -365,11 +365,11 @@ void ZProbe::on_gcode_received(void *argument)
 
         if(gcode->has_letter('X')) {
             // probe in the X axis
-            gcode->stream->printf("error: Not currently supported.\n");
+            gcode->stream->printf("error:Not currently supported.\n");
 
         }else if(gcode->has_letter('Y')) {
             // probe in the Y axis
-            gcode->stream->printf("error: Not currently supported.\n");
+            gcode->stream->printf("error:Not currently supported.\n");
 
         }else if(gcode->has_letter('Z')) {
             // we need to know where we started the probe from
@@ -402,12 +402,12 @@ void ZProbe::on_gcode_received(void *argument)
                     gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:0]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS]);
 
                 }else{
-                    gcode->stream->printf("error: ZProbe not triggered\n");
+                    gcode->stream->printf("error:ZProbe not triggered\n");
                 }
             }
 
         }else{
-            gcode->stream->printf("error: at least one of X Y or Z must be specified\n");
+            gcode->stream->printf("error:at least one of X Y or Z must be specified\n");
 
         }
         return;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -343,10 +343,10 @@ void ZProbe::on_gcode_received(void *argument)
             }
         }
 
-    } else if(gcode->has_g && gcode->g == 38 ) { // G38.2 Straight Probe
+    } else if(gcode->has_g && gcode->g == 38 ) { // G38.2 Straight Probe with error, G38.3 straight probe without error
         // linuxcnc/grbl style probe http://www.linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe
         if(gcode->subcode != 2 && gcode->subcode != 3) {
-            gcode->stream->printf("ERROR: Only G38.2 and G38.3 are supported\n");
+            gcode->stream->printf("error: Only G38.2 and G38.3 are supported\n");
             return;
         }
 
@@ -365,11 +365,11 @@ void ZProbe::on_gcode_received(void *argument)
 
         if(gcode->has_letter('X')) {
             // probe in the X axis
-            gcode->stream->printf("Not currently supported.\n");
+            gcode->stream->printf("error: Not currently supported.\n");
 
         }else if(gcode->has_letter('Y')) {
             // probe in the Y axis
-            gcode->stream->printf("Not currently supported.\n");
+            gcode->stream->printf("error: Not currently supported.\n");
 
         }else if(gcode->has_letter('Z')) {
             // we need to know where we started the probe from
@@ -382,17 +382,32 @@ void ZProbe::on_gcode_received(void *argument)
             bool probe_result = run_probe_feed(steps, rate, gcode->get_value('Z'));
 
             if(probe_result) {
-                gcode->stream->printf("INFO: delta Z %1.4f (Steps %d)\n", steps / Z_STEPS_PER_MM, steps);
+                float z= current_machine_pos[Z_AXIS] - zsteps_to_mm(steps);
+                if(THEKERNEL->is_grbl_mode()) {
+                    gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:1]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], z);
+
+                }else{
+                    gcode->stream->printf("INFO: delta Z %1.4f (Steps %d)\n", steps / Z_STEPS_PER_MM, steps);
+                }
 
                 // set position to where it stopped
-                THEKERNEL->robot->reset_axis_position(current_machine_pos[Z_AXIS] - zsteps_to_mm(steps), Z_AXIS);
+                THEKERNEL->robot->reset_axis_position(z, Z_AXIS);
 
             } else {
-                gcode->stream->printf("ERROR: ZProbe not triggered\n");
+                if(THEKERNEL->is_grbl_mode()) {
+                    if(gcode->subcode == 2) {
+                        gcode->stream->printf("ALARM: Probe fail\n");
+                        THEKERNEL->call_event(ON_HALT, nullptr);
+                    }
+                    gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:0]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS]);
+
+                }else{
+                    gcode->stream->printf("error: ZProbe not triggered\n");
+                }
             }
 
         }else{
-            gcode->stream->printf("ERROR: at least one of X Y or Z must be specified\n");
+            gcode->stream->printf("error: at least one of X Y or Z must be specified\n");
 
         }
         return;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -346,7 +346,7 @@ void ZProbe::on_gcode_received(void *argument)
     } else if(gcode->has_g && gcode->g == 38 ) { // G38.2 Straight Probe with error, G38.3 straight probe without error
         // linuxcnc/grbl style probe http://www.linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe
         if(gcode->subcode != 2 && gcode->subcode != 3) {
-            gcode->stream->printf("error: Only G38.2 and G38.3 are supported\n");
+            gcode->stream->printf("error:Only G38.2 and G38.3 are supported\n");
             return;
         }
 
@@ -396,7 +396,7 @@ void ZProbe::on_gcode_received(void *argument)
             } else {
                 if(THEKERNEL->is_grbl_mode()) {
                     if(gcode->subcode == 2) {
-                        gcode->stream->printf("ALARM: Probe fail\n");
+                        gcode->stream->printf("ALARM:get_homing_status_checksumProbe fail\n");
                         THEKERNEL->call_event(ON_HALT, nullptr);
                     }
                     gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:0]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS]);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -231,7 +231,7 @@ void SimpleShell::on_console_line_received( void *argument )
 
             case 'H':
                 {
-                    // issue G28.3 which is force homing cycle
+                    // issue G28.2 which is force homing cycle
                     Gcode gcode("G28.2", new_message.stream);
                     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
                 }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -27,6 +27,7 @@
 #include "GcodeDispatch.h"
 
 #include "TemperatureControlPublicAccess.h"
+#include "EndstopsPublicAccess.h"
 #include "NetworkPublicAccess.h"
 #include "platform_memory.h"
 #include "SwitchPublicAccess.h"
@@ -654,8 +655,11 @@ void SimpleShell::grblDP_command( string parameters, StreamOutput *stream)
         stream->printf("[%s:%1.3f,%1.3f,%1.3f]\n", wcs2gcode(i-1).c_str(), std::get<0>(v[i]), std::get<1>(v[i]), std::get<2>(v[i]));
     }
 
-    stream->printf("[G28:%1.3f,%1.3f,%1.3f]\n",  0.0F, 0.0F, 0.0F);
-    stream->printf("[G30:%1.3f,%1.3f,%1.3f]\n",  0.0F, 0.0F, 0.0F);
+    float *rd;
+    PublicData::get_value( endstops_checksum, saved_position_checksum, &rd );
+    stream->printf("[G28:%1.3f,%1.3f,%1.3f]\n",  rd[0], rd[1], rd[2]);
+    stream->printf("[G30:%1.3f,%1.3f,%1.3f]\n",  0.0F, 0.0F, 0.0F); // not implemented
+
     stream->printf("[G92:%1.3f,%1.3f,%1.3f]\n", std::get<0>(v[n+1]), std::get<1>(v[n+1]), std::get<2>(v[n+1]));
     stream->printf("[TL0:%1.3f]\n", std::get<2>(v[n+2]));
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -659,7 +659,7 @@ void SimpleShell::grblDP_command( string parameters, StreamOutput *stream)
     stream->printf("[G92:%1.3f,%1.3f,%1.3f]\n", std::get<0>(v[n+1]), std::get<1>(v[n+1]), std::get<2>(v[n+1]));
     stream->printf("[TL0:%1.3f]\n", std::get<2>(v[n+2]));
 
-    // TODO this shoul dbe the last probe position, which will be this if probe was the last thing done
+    // TODO this should be the last probe position, which will be this if probe was the last thing done
     float current_machine_pos[3];
     THEKERNEL->robot->get_axis_position(current_machine_pos);
     stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS], 0);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -231,15 +231,17 @@ void SimpleShell::on_console_line_received( void *argument )
                 break;
 
             case 'H':
-                {
+                if(THEKERNEL->is_grbl_mode()) {
                     // issue G28.2 which is force homing cycle
                     Gcode gcode("G28.2", new_message.stream);
                     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+                }else{
+                    new_message.stream->printf("error:only supported in GRBL mode\n");
                 }
                 break;
 
             default:
-                new_message.stream->printf("error: Invalid statement\n");
+                new_message.stream->printf("error:Invalid statement\n");
                 break;
         }
 
@@ -250,7 +252,7 @@ void SimpleShell::on_console_line_received( void *argument )
 
         // find command and execute it
         if(!parse_command(cmd.c_str(), possible_command, new_message.stream)) {
-            new_message.stream->printf("error: Unsupported command\n");
+            new_message.stream->printf("error:Unsupported command\n");
         }
     }
 }
@@ -738,7 +740,7 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
             THEKERNEL->robot->get_feed_rate());
 
     } else {
-        stream->printf("error: unknown option %s\n", what.c_str());
+        stream->printf("error:unknown option %s\n", what.c_str());
     }
 }
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -232,7 +232,7 @@ void SimpleShell::on_console_line_received( void *argument )
             case 'H':
                 {
                     // issue G28.3 which is force homing cycle
-                    Gcode gcode("G28.3", new_message.stream);
+                    Gcode gcode("G28.2", new_message.stream);
                     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
                 }
                 break;

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -205,18 +205,53 @@ bool SimpleShell::parse_command(const char *cmd, string args, StreamOutput *stre
 void SimpleShell::on_console_line_received( void *argument )
 {
     SerialMessage new_message = *static_cast<SerialMessage *>(argument);
-
-    // ignore comments and blank lines and if this is a G code then also ignore it
-    char first_char = new_message.message[0];
-    if(strchr(";( \n\rGMTN", first_char) != NULL) return;
-
     string possible_command = new_message.message;
 
-    //new_message.stream->printf("Received %s\r\n", possible_command.c_str());
-    string cmd = shift_parameter(possible_command);
+    // ignore anything that is not lowercase or a $ as it is not a command
+    if(possible_command.size() == 0 || (!islower(possible_command[0]) && possible_command[0] != '$')) {
+        return;
+    }
 
-    // find command and execute it
-    parse_command(cmd.c_str(), possible_command, new_message.stream);
+    // it is a grbl compatible command
+    if(possible_command[0] == '$' && possible_command.size() >= 2) {
+        switch(possible_command[1]) {
+            case 'G':
+                // issue get state
+                get_command("state", new_message.stream);
+                break;
+
+            case 'X':
+                THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
+                new_message.stream->printf("[Caution: Unlocked]\n");
+                break;
+
+            case '#':
+                grblDP_command("", new_message.stream);
+                break;
+
+            case 'H':
+                {
+                    // issue G28.3 which is force homing cycle
+                    Gcode gcode("G28.3", new_message.stream);
+                    THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+                }
+                break;
+
+            default:
+                new_message.stream->printf("error: Invalid statement\n");
+                break;
+        }
+
+    }else{
+
+        //new_message.stream->printf("Received %s\r\n", possible_command.c_str());
+        string cmd = shift_parameter(possible_command);
+
+        // find command and execute it
+        if(!parse_command(cmd.c_str(), possible_command, new_message.stream)) {
+            new_message.stream->printf("error: Unsupported command\n");
+        }
+    }
 }
 
 // Act upon an ls command
@@ -598,6 +633,38 @@ static int get_active_tool()
     }
 }
 
+void SimpleShell::grblDP_command( string parameters, StreamOutput *stream)
+{
+    /*
+    [G54:95.000,40.000,-23.600]
+    [G55:0.000,0.000,0.000]
+    [G56:0.000,0.000,0.000]
+    [G57:0.000,0.000,0.000]
+    [G58:0.000,0.000,0.000]
+    [G59:0.000,0.000,0.000]
+    [G28:0.000,0.000,0.000]
+    [G30:0.000,0.000,0.000]
+    [G92:0.000,0.000,0.000]
+    [TLO:0.000]
+    [PRB:0.000,0.000,0.000:0]
+    */
+    std::vector<Robot::wcs_t> v= THEKERNEL->robot->get_wcs_state();
+    int n= std::get<1>(v[0]);
+    for (int i = 1; i <= n; ++i) {
+        stream->printf("[%s:%1.3f,%1.3f,%1.3f]\n", wcs2gcode(i-1).c_str(), std::get<0>(v[i]), std::get<1>(v[i]), std::get<2>(v[i]));
+    }
+
+    stream->printf("[G28:%1.3f,%1.3f,%1.3f]\n",  0.0F, 0.0F, 0.0F);
+    stream->printf("[G30:%1.3f,%1.3f,%1.3f]\n",  0.0F, 0.0F, 0.0F);
+    stream->printf("[G92:%1.3f,%1.3f,%1.3f]\n", std::get<0>(v[n+1]), std::get<1>(v[n+1]), std::get<2>(v[n+1]));
+    stream->printf("[TL0:%1.3f]\n", std::get<2>(v[n+2]));
+
+    // TODO this shoul dbe the last probe position, which will be this if probe was the last thing done
+    float current_machine_pos[3];
+    THEKERNEL->robot->get_axis_position(current_machine_pos);
+    stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS], 0);
+}
+
 // used to test out the get public data events
 void SimpleShell::get_command( string parameters, StreamOutput *stream)
 {
@@ -653,8 +720,9 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
         stream->printf("ToolOffset: %1.4f, %1.4f, %1.4f\n", std::get<0>(v[n+2]), std::get<1>(v[n+2]), std::get<2>(v[n+2]));
 
     } else if (what == "state") {
+        // also $G
         // [G0 G54 G17 G21 G90 G94 M0 M5 M9 T0 F0.]
-        stream->printf("[G%d %s G%d G%d G%d G94 T%d F%1.1f]\n",
+        stream->printf("[G%d %s G%d G%d G%d G94 M0 M5 M9 T%d F%1.1f]\n",
             THEKERNEL->gcode_dispatch->get_modal_command(),
             wcs2gcode(THEKERNEL->robot->get_current_wcs()).c_str(),
             THEKERNEL->robot->plane_axis_0 == X_AXIS && THEKERNEL->robot->plane_axis_1 == Y_AXIS && THEKERNEL->robot->plane_axis_2 == Z_AXIS ? 17 :
@@ -664,6 +732,9 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
             THEKERNEL->robot->absolute_mode ? 90 : 91,
             get_active_tool(),
             THEKERNEL->robot->get_feed_rate());
+
+    } else {
+        stream->printf("error: unknown option %s\n", what.c_str());
     }
 }
 
@@ -773,7 +844,7 @@ void SimpleShell::help_command( string parameters, StreamOutput *stream )
     stream->printf("ls [-s] [folder]\r\n");
     stream->printf("cd folder\r\n");
     stream->printf("pwd\r\n");
-    stream->printf("cat file [limit]\r\n");
+    stream->printf("cat file [limit] [-d 10]\r\n");
     stream->printf("rm file\r\n");
     stream->printf("mv file newfile\r\n");
     stream->printf("remount\r\n");
@@ -788,6 +859,8 @@ void SimpleShell::help_command( string parameters, StreamOutput *stream )
     stream->printf("get temp [bed|hotend]\r\n");
     stream->printf("set_temp bed|hotend 185\r\n");
     stream->printf("get pos\r\n");
+    stream->printf("get wcs\r\n");
+    stream->printf("get state\r\n");
     stream->printf("net\r\n");
     stream->printf("load [file] - loads a configuration override file from soecified name or config-override\r\n");
     stream->printf("save [file] - saves a configuration override file as specified filename or as config-override\r\n");

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -47,6 +47,7 @@ private:
     static void calc_thermistor_command( string parameters, StreamOutput *stream);
     static void print_thermistors_command( string parameters, StreamOutput *stream);
     static void md5sum_command( string parameters, StreamOutput *stream);
+    static void grblDP_command( string parameters, StreamOutput *stream);
 
     static void switch_command(string parameters, StreamOutput *stream );
     static void mem_command(string parameters, StreamOutput *stream );


### PR DESCRIPTION
added grbl_mode to config
implemented grbl queries and commands when in grbl mode:

$X unlock
$H home
$G get gcode status
$# view parameters
! feed hold
~ cycle start
^X immediate halt
? print current status

Implemented G28 moves to predefined position as per G code spec and grbl when in grbl mode or G28.2 when in smoothie mode . (G28 Still homes in smoothie mode).

implemented G28.1 to save predefined position (saved with M500).
G28.3 does a manual set home.

Optimize simple_shell by only handling any command in lowercase, and return error if unknown lowercase command.
Optimize gcodedispatch by ignoring any command that is lowercase.
