### PR TITLE
Zgrid homing

### DIFF
--- a/ConfigSamples/Snippets/ZprobeGrid.config
+++ b/ConfigSamples/Snippets/ZprobeGrid.config
@@ -8,7 +8,7 @@ leveling-strategy.ZGrid-leveling.bed_z           20
 # Manual probe attachment point (Defaults to the calculated values above)
 # leveling-strategy.ZGrid-leveling.bed_x          100
 # leveling-strategy.ZGrid-leveling.bed_y          100
-# leveling-strategy.ZGrid-leveling.bed_y          50
+# leveling-strategy.ZGrid-leveling.bed_z          50
 
 leveling-strategy.ZGrid-leveling.rows           7          # X divisions (Default 5)
 leveling-strategy.ZGrid-leveling.cols           9          # Y divisions (Default 5)

--- a/ConfigSamples/Snippets/ZprobeGrid.config
+++ b/ConfigSamples/Snippets/ZprobeGrid.config
@@ -5,6 +5,11 @@ leveling-strategy.ZGrid-leveling.bed_y          200        # Bed Size
 # Machine height, used to determine probe attachment point (bed_z / 2)
 leveling-strategy.ZGrid-leveling.bed_z           20
 
+# Manual probe attachment point (Defaults to the calculated values above)
+# leveling-strategy.ZGrid-leveling.bed_x          100
+# leveling-strategy.ZGrid-leveling.bed_y          100
+# leveling-strategy.ZGrid-leveling.bed_y          50
+
 leveling-strategy.ZGrid-leveling.rows           7          # X divisions (Default 5)
 leveling-strategy.ZGrid-leveling.cols           9          # Y divisions (Default 5)
 

--- a/src/modules/tools/zprobe/ZGridStrategy.cpp
+++ b/src/modules/tools/zprobe/ZGridStrategy.cpp
@@ -308,7 +308,6 @@ bool ZGridStrategy::handleGcode(Gcode *gcode)
             // M373: finalize calibration
             case 373: {
                  // normalize the grid
-                 //this->normalize_grid();
                  this->normalize_grid_2home();
 
                  this->in_cal = false;
@@ -353,7 +352,7 @@ bool ZGridStrategy::handleGcode(Gcode *gcode)
             }
             return true;
 
-          case 376: { // Check grid value calculations: For debug only.
+/*          case 376: { // Check grid value calculations: For debug only.
                 float target[3];
 
                 for(char letter = 'X'; letter <= 'Z'; letter++) {
@@ -365,7 +364,7 @@ bool ZGridStrategy::handleGcode(Gcode *gcode)
 
             }
             return true;
-
+*/
             case 565: { // M565: Set Z probe offsets
                 float x= 0, y= 0, z= 0;
                 if(gcode->has_letter('X')) x = gcode->get_value('X');
@@ -552,29 +551,6 @@ bool ZGridStrategy::doProbing(StreamOutput *stream)  // probed calibration
     this->in_cal = false;
 
     return true;
-}
-
-//TODO: normalize to set home position zero - this required to prevent the large z movement bug when home position is off print area
-void ZGridStrategy::normalize_grid()
-{
-    float min = 100.0F,    // set large start value
-          norm_offset = 0;
-
-    // find minimum value in offset grid
-    for (int i = 0; i < probe_points; i++)
-        if (this->pData[i] < min)
-          min = this->pData[i];
-
-    // creates addition offset to set minimum value to zero.
-    norm_offset = -min;
-
-    // adds the offset to create a table of deltas, normalzed to minimum zero
-    for (int i = 0; i < probe_points; i++)
-        this->pData[i] += norm_offset;
-
-   // add the offset to the current Z homing offset to preserve full probed offset.
-   this->setZoffset(this->getZhomeoffset() - norm_offset);
-
 }
 
 

--- a/src/modules/tools/zprobe/ZGridStrategy.h
+++ b/src/modules/tools/zprobe/ZGridStrategy.h
@@ -31,6 +31,7 @@ private:
     void setAdjustFunction(bool);
     bool doProbing(StreamOutput *stream);
     void normalize_grid();
+    void normalize_grid_2home();
 
     bool loadGrid(std::string args);
     bool saveGrid(std::string args);
@@ -46,6 +47,9 @@ private:
     float bed_x;
     float bed_y;
     float bed_z;
+    float probe_x;
+    float probe_y;
+    float probe_z;
     float cal_offset_x;
     float cal_offset_y;
     float bed_div_x;

--- a/src/modules/tools/zprobe/ZGridStrategy.h
+++ b/src/modules/tools/zprobe/ZGridStrategy.h
@@ -30,7 +30,6 @@ private:
 
     void setAdjustFunction(bool);
     bool doProbing(StreamOutput *stream);
-    void normalize_grid();
     void normalize_grid_2home();
 
     bool loadGrid(std::string args);


### PR DESCRIPTION
This pull request does the following:
1) repair Z offset after running routine with a well adjusted probe
2) Adds an optional manual probe attachment point
3) changes the normalisation method to zero the home position, preventing jerky movements on the first move after homing.