### PR TITLE
Feature/laser ttl

### DIFF
--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -23,6 +23,7 @@
 
 #define laser_module_enable_checksum        CHECKSUM("laser_module_enable")
 #define laser_module_pin_checksum           CHECKSUM("laser_module_pin")
+#define laser_module_pwm_pin_checksum       CHECKSUM("laser_module_pwm_pin")
 #define laser_module_ttl_pin_checksum    	CHECKSUM("laser_module_ttl_pin")
 #define laser_module_pwm_period_checksum    CHECKSUM("laser_module_pwm_period")
 #define laser_module_maximum_power_checksum CHECKSUM("laser_module_maximum_power")
@@ -44,6 +45,10 @@ void Laser::on_module_loaded() {
     // Get smoothie-style pin from config
     Pin* dummy_pin = new Pin();
     dummy_pin->from_string(THEKERNEL->config->value(laser_module_pin_checksum)->by_default("nc")->as_string())->as_output();
+
+    // Alternative less ambiguous name for pwm_pin
+    if (!dummy_pin->connected())
+        dummy_pin->from_string(THEKERNEL->config->value(laser_module_pwm_pin_checksum)->by_default("nc")->as_string())->as_output();
 
     pwm_pin = dummy_pin->hardware_pwm();
 

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -23,6 +23,7 @@
 
 #define laser_module_enable_checksum        CHECKSUM("laser_module_enable")
 #define laser_module_pin_checksum           CHECKSUM("laser_module_pin")
+#define laser_module_ttl_pin_checksum    	CHECKSUM("laser_module_ttl_pin")
 #define laser_module_pwm_period_checksum    CHECKSUM("laser_module_pwm_period")
 #define laser_module_maximum_power_checksum CHECKSUM("laser_module_maximum_power")
 #define laser_module_minimum_power_checksum CHECKSUM("laser_module_minimum_power")
@@ -44,9 +45,9 @@ void Laser::on_module_loaded() {
     Pin* dummy_pin = new Pin();
     dummy_pin->from_string(THEKERNEL->config->value(laser_module_pin_checksum)->by_default("nc")->as_string())->as_output();
 
-    laser_pin = dummy_pin->hardware_pwm();
+    pwm_pin = dummy_pin->hardware_pwm();
 
-    if (laser_pin == NULL)
+    if (pwm_pin == NULL)
     {
         THEKERNEL->streams->printf("Error: Laser cannot use P%d.%d (P2.0 - P2.5, P1.18, P1.20, P1.21, P1.23, P1.24, P1.26, P3.25, P3.26 only). Laser module disabled.\n", dummy_pin->port_number, dummy_pin->pin);
         delete dummy_pin;
@@ -54,13 +55,22 @@ void Laser::on_module_loaded() {
         return;
     }
 
-    this->laser_inverting = dummy_pin->inverting;
+
+    this->pwm_inverting = dummy_pin->inverting;
 
     delete dummy_pin;
     dummy_pin = NULL;
 
-    this->laser_pin->period_us(THEKERNEL->config->value(laser_module_pwm_period_checksum)->by_default(20)->as_number());
-    this->laser_pin->write(this->laser_inverting ? 1 : 0);
+    // TTL settings
+    this->ttl_pin = new Pin();
+    ttl_pin->from_string( THEKERNEL->config->value(laser_module_ttl_pin_checksum)->by_default("nc" )->as_string())->as_output();
+    this->ttl_used = ttl_pin->connected();
+    this->ttl_inverting = ttl_pin->inverting;
+    if (ttl_used)
+    	ttl_pin->set(0);
+
+    this->pwm_pin->period_us(THEKERNEL->config->value(laser_module_pwm_period_checksum)->by_default(20)->as_number());
+    this->pwm_pin->write(this->pwm_inverting ? 1 : 0);
     this->laser_maximum_power = THEKERNEL->config->value(laser_module_maximum_power_checksum   )->by_default(1.0f)->as_number() ;
 
     // These config variables are deprecated, they have been replaced with laser_module_default_power and laser_module_minimum_power
@@ -80,7 +90,10 @@ void Laser::on_module_loaded() {
 
 // Turn laser off laser at the end of a move
 void  Laser::on_block_end(void* argument){
-    this->laser_pin->write(this->laser_inverting ? 1 : 0);
+    this->pwm_pin->write(this->pwm_inverting ? 1 : 0);
+
+    if (this->ttl_used)
+        this->ttl_pin->set(0);
 }
 
 // Set laser power at the beginning of a block
@@ -95,7 +108,7 @@ void Laser::on_gcode_execute(void* argument){
     if( gcode->has_g){
         int code = gcode->g;
         if( code == 0 ){                    // G0
-            this->laser_pin->write(this->laser_inverting ? 1 - this->laser_minimum_power : this->laser_minimum_power);
+            this->pwm_pin->write(this->pwm_inverting ? 1 - this->laser_minimum_power : this->laser_minimum_power);
             this->laser_on =  false;
         }else if( code >= 1 && code <= 3 ){ // G1, G2, G3
             this->laser_on =  true;
@@ -104,6 +117,9 @@ void Laser::on_gcode_execute(void* argument){
     if ( gcode->has_letter('S' )){
         this->laser_power = gcode->get_value('S');
     }
+
+    if (this->ttl_used)
+        this->ttl_pin->set(this->laser_on);
 
 }
 
@@ -118,6 +134,6 @@ void Laser::set_proportional_power(){
     if( this->laser_on && THEKERNEL->stepper->get_current_block() ){
         // adjust power to maximum power and actual velocity
         float proportional_power = (((this->laser_maximum_power-this->laser_minimum_power)*(this->laser_power * THEKERNEL->stepper->get_trapezoid_adjusted_rate() / THEKERNEL->stepper->get_current_block()->nominal_rate))+this->laser_minimum_power);
-        this->laser_pin->write(this->laser_inverting ? 1 - proportional_power : proportional_power);
+        this->pwm_pin->write(this->pwm_inverting ? 1 - proportional_power : proportional_power);
     }
 }

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -71,8 +71,13 @@ void Laser::on_module_loaded() {
     ttl_pin->from_string( THEKERNEL->config->value(laser_module_ttl_pin_checksum)->by_default("nc" )->as_string())->as_output();
     this->ttl_used = ttl_pin->connected();
     this->ttl_inverting = ttl_pin->inverting;
-    if (ttl_used)
+    if (ttl_used) {
     	ttl_pin->set(0);
+    } else {
+    	delete ttl_pin;
+    	ttl_pin = NULL;
+    }
+
 
     this->pwm_pin->period_us(THEKERNEL->config->value(laser_module_pwm_period_checksum)->by_default(20)->as_number());
     this->pwm_pin->write(this->pwm_inverting ? 1 : 0);

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -13,6 +13,7 @@
 namespace mbed {
     class PwmOut;
 }
+class Pin;
 
 class Laser : public Module{
     public:
@@ -26,10 +27,13 @@ class Laser : public Module{
 
     private:
         void set_proportional_power();
-        mbed::PwmOut *laser_pin;    // PWM output to regulate the laser power
+        mbed::PwmOut *pwm_pin;    // PWM output to regulate the laser power
+        Pin *ttl_pin;				// TTL output to fire laser
         struct {
-            bool laser_on:1;     // Laser status
-            bool laser_inverting:1; // stores whether the pwm period should be inverted
+            bool laser_on:1;        // Laser status
+            bool pwm_inverting:1; // stores whether the PWM period should be inverted
+            bool ttl_used:1;		// stores whether we have a TTL output
+            bool ttl_inverting:1;   // stores whether the TTL output should be inverted
         };
         float            laser_maximum_power; // maximum allowed laser power to be output on the pwm pin
         float            laser_minimum_power; // value used to tickle the laser on moves.  Also minimum value for auto-scaling


### PR DESCRIPTION
Hi. This is my first ever contribution to an open source project and first ever pull request, so I kept it simple.I hope I've got it right.

The first commit (4287ba0) adds an optional _laser_module_ttl_pin _output. It's set when the laser is fired on G1/2/3 moves. Existing PWM functionality is not affected, whether the TTL pin is used or not.

The second commit (39b0a65) optionally allows the PWM pin to be referred to as _laser_module_pwm_pin_ so it's not confused with the TTL pin. The existing _laser_module_pin_ name is retained for backward compatibility.

Tested using a logic analyzer and also on my DC-K40 CO2 laser.