### PR TITLE
add utility functions for manually controlling and setting odd arm solutions

### DIFF
--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -197,19 +197,19 @@ StepperMotor* StepperMotor::set_speed( float speed )
 void StepperMotor::change_steps_per_mm(float new_steps)
 {
     steps_per_mm = new_steps;
-    last_milestone_steps = lround(last_milestone_mm * steps_per_mm);
+    last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
 }
 
 void StepperMotor::change_last_milestone(float new_milestone)
 {
     last_milestone_mm = new_milestone;
-    last_milestone_steps = lround(last_milestone_mm * steps_per_mm);
+    last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
 }
 
 int  StepperMotor::steps_to_target(float target)
 {
-    int target_steps = lround(target * steps_per_mm);
+    int target_steps = lroundf(target * steps_per_mm);
     return target_steps - last_milestone_steps;
 }

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -33,6 +33,7 @@ class Robot : public Module {
 
         void reset_axis_position(float position, int axis);
         void reset_axis_position(float x, float y, float z);
+        void reset_actuator_position(float a, float b, float c);
         void reset_position_from_current_actuator_position();
         float get_seconds_per_minute() const { return seconds_per_minute; }
         float get_z_maxfeedrate() const { return this->max_speeds[2]; }

--- a/src/modules/tools/temperaturecontrol/max31855.cpp
+++ b/src/modules/tools/temperaturecontrol/max31855.cpp
@@ -36,7 +36,7 @@ void Max31855::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
     this->spi_cs_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, chip_select_checksum)->by_default("0.16")->as_string());
     this->spi_cs_pin.set(true);
     this->spi_cs_pin.as_output();
-    
+
     // select which SPI channel to use
     int spi_channel = THEKERNEL->config->value(module_checksum, name_checksum, spi_channel_checksum)->by_default(0)->as_number();
     PinName miso;
@@ -48,7 +48,7 @@ void Max31855::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
     } else {
         // Channel 1
         mosi=P0_9; miso=P0_8; sclk=P0_7;
-    } 
+    }
 
     delete spi;
     spi = new mbed::SPI(mosi, miso, sclk);
@@ -92,7 +92,7 @@ float Max31855::read_temp()
 //	uint16_t data2 = spi->write(0);
 
     this->spi_cs_pin.set(true);
-    
+
     float temperature;
 
     //Process temp
@@ -113,5 +113,5 @@ float Max31855::read_temp()
             temperature = ((data & 0x1FFF) + 1) / -4.f;
         }
     }
-    return temperature; 
+    return temperature;
 }

--- a/src/modules/utils/panel/panels/UniversalAdapter.cpp
+++ b/src/modules/utils/panel/panels/UniversalAdapter.cpp
@@ -12,6 +12,7 @@
 #include "ConfigValue.h"
 #include "libs/Pin.h"
 #include "StreamOutputPool.h"
+#include "utils.h"
 
 // config settings
 #define panel_checksum             CHECKSUM("panel")
@@ -101,7 +102,7 @@ void UniversalAdapter::wait_until_ready()
 {
     while(this->busy_pin->get() != 0) {
         // poll adapter for more room
-        wait_ms(100);
+        safe_delay(100);
         writeSPI(POLL);
     }
 }
@@ -211,5 +212,5 @@ void UniversalAdapter::init()
         writeSPI(INIT_ADAPTER);
     }
     // give adapter time to init
-    wait_ms(100);
+    safe_delay(100);
 }

--- a/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.cpp
+++ b/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.cpp
@@ -183,11 +183,11 @@ void RrdGlcd::initDisplay() {
     if(fb == NULL) return;
     ST7920_CS();
     clearScreen();  // clear framebuffer
-    wait_ms(90);                 //initial delay for boot up
+    safe_delay(90);                 //initial delay for boot up
     ST7920_SET_CMD();
     ST7920_WRITE_BYTE(0x08);       //display off, cursor+blink off
     ST7920_WRITE_BYTE(0x01);       //clear CGRAM ram
-    wait_ms(10);                 //delay for cgram clear
+    safe_delay(10);                 //delay for cgram clear
     ST7920_WRITE_BYTE(0x3E);       //extended mode + gdram active
     for(int y=0;y<HEIGHT/2;y++)        //clear GDRAM
     {

--- a/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.cpp
+++ b/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.cpp
@@ -183,11 +183,11 @@ void RrdGlcd::initDisplay() {
     if(fb == NULL) return;
     ST7920_CS();
     clearScreen();  // clear framebuffer
-    safe_delay(90);                 //initial delay for boot up
+    wait_ms(90);                 //initial delay for boot up
     ST7920_SET_CMD();
     ST7920_WRITE_BYTE(0x08);       //display off, cursor+blink off
     ST7920_WRITE_BYTE(0x01);       //clear CGRAM ram
-    safe_delay(10);                 //delay for cgram clear
+    wait_ms(10);                 //delay for cgram clear
     ST7920_WRITE_BYTE(0x3E);       //extended mode + gdram active
     for(int y=0;y<HEIGHT/2;y++)        //clear GDRAM
     {

--- a/src/modules/utils/panel/screens/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/WatchScreen.cpp
@@ -65,7 +65,7 @@ void WatchScreen::on_enter()
     get_current_status();
     get_current_pos(this->pos);
     get_sd_play_info();
-    this->current_speed = lround(get_current_speed());
+    this->current_speed = lroundf(get_current_speed());
     this->refresh_screen(false);
     THEPANEL->enter_control_mode(1, 0.5);
     THEPANEL->set_control_value(this->current_speed);
@@ -122,7 +122,7 @@ void WatchScreen::on_refresh()
             this->speed_changed = false;
         } else if (!this->issue_change_speed) { // change still queued
             // read it in case it was changed via M220
-            this->current_speed = lround(get_current_speed());
+            this->current_speed = lroundf(get_current_speed());
             THEPANEL->set_control_value(this->current_speed);
             THEPANEL->reset_counter();
         }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -26,6 +26,7 @@
 #include "ToolManagerPublicAccess.h"
 #include "GcodeDispatch.h"
 #include "BaseSolution.h"
+#include "StepperMotor.h"
 
 #include "TemperatureControlPublicAccess.h"
 #include "EndstopsPublicAccess.h"
@@ -710,21 +711,25 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
         }
 
         std::vector<float> v= parse_number_list(p.c_str());
-        if(p.empty() || v.size() != 3) {
-            stream->printf("error:usage: get [fk|ik] [-m] x,y,z\n");
+        if(p.empty() || v.size() < 1) {
+            stream->printf("error:usage: get [fk|ik] [-m] x[,y,z]\n");
             return;
         }
 
         float x= v[0];
-        float y= v[1];
-        float z= v[2];
+        float y= (v.size() > 1) ? v[1] : x;
+        float z= (v.size() > 2) ? v[2] : y;
 
         if(what == "fk") {
             // do forward kinematics on the given actuator position and display the cartesian coordinates
             ActuatorCoordinates apos{x, y, z};
             float pos[3];
             THEKERNEL->robot->arm_solution->actuator_to_cartesian(apos, pos);
-            stream->printf("cartesian= X %f, Y %f, Z %f\n", pos[0], pos[1], pos[2]);
+            stream->printf("cartesian= X %f, Y %f, Z %f, Steps= A %lu, B %lu, C %lu\n",
+                pos[0], pos[1], pos[2],
+                lroundf(x*THEKERNEL->robot->actuators[0]->get_steps_per_mm()),
+                lroundf(y*THEKERNEL->robot->actuators[1]->get_steps_per_mm()),
+                lroundf(z*THEKERNEL->robot->actuators[2]->get_steps_per_mm()));
             x= pos[0];
             y= pos[1];
             z= pos[2];

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -35,6 +35,7 @@
 #include "SDFAT.h"
 #include "Thermistor.h"
 #include "md5.h"
+#include "utils.h"
 
 #include "system_LPC17xx.h"
 #include "LPC17xx.h"
@@ -373,11 +374,8 @@ void SimpleShell::cat_command( string parameters, StreamOutput *stream )
     }
 
     // we have been asked to delay before cat, probably to allow time to issue upload command
-    while(delay-- > 0) {
-        for (int i = 0; i < 10; ++i) {
-            wait_ms(100);
-            THEKERNEL->call_event(ON_IDLE);
-        }
+    if(delay > 0) {
+        safe_delay(delay*1000);
     }
 
     // Open file


### PR DESCRIPTION
add reset_actuator_position() to allow manual homing and setting actuator specific positions
add G28.4 to allow manual setting of homing to actuator units (as opposed to cartesian coordinates)
add M1910.2 to move by the specified number of actuator units (as opposed to steps)