### PR TITLE
Changes for rotary delta homing...

### DIFF
--- a/src/libs/Config.cpp
+++ b/src/libs/Config.cpp
@@ -62,10 +62,6 @@ Config::~Config()
     }
 }
 
-void Config::on_module_loaded() {}
-
-void Config::on_console_line_received( void *argument ) {}
-
 // Get a list of modules, used by module "pools" that look for the "enable" keyboard to find things like "moduletype.modulename.enable" as the marker of a new instance of a module
 void Config::get_module_list(vector<uint16_t> *list, uint16_t family)
 {

--- a/src/libs/Config.h
+++ b/src/libs/Config.h
@@ -17,7 +17,7 @@ class ConfigValue;
 class ConfigSource;
 class ConfigCache;
 
-class Config : public Module {
+class Config  {
     public:
         Config();
         Config(ConfigSource*);

--- a/src/libs/Config.h
+++ b/src/libs/Config.h
@@ -23,8 +23,6 @@ class Config : public Module {
         Config(ConfigSource*);
         ~Config();
 
-        void on_module_loaded();
-        void on_console_line_received( void* argument );
         void config_cache_load(bool parse= true);
         void config_cache_clear();
         void set_string( string setting , string value);

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -27,6 +27,8 @@
 #include "StepperMotor.h"
 #include "BaseSolution.h"
 #include "EndstopsPublicAccess.h"
+#include "Configurator.h"
+#include "SimpleShell.h"
 
 #include <malloc.h>
 #include <array>
@@ -147,6 +149,8 @@ Kernel::Kernel(){
     this->add_module( this->robot          = new Robot()         );
     this->add_module( this->stepper        = new Stepper()       );
     this->add_module( this->conveyor       = new Conveyor()      );
+    this->add_module( this->configurator   = new Configurator()  );
+    this->add_module( this->simpleshell    = new SimpleShell()   );
 
     this->planner = new Planner();
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -101,7 +101,6 @@ Kernel::Kernel(){
     this->grbl_mode= this->config->value( grbl_mode_checksum )->by_default(false)->as_bool();
     this->ok_per_line= this->config->value( ok_per_line_checksum )->by_default(true)->as_bool();
 
-    this->add_module( this->config );
     this->add_module( this->serial );
 
     // HAL stuff
@@ -151,11 +150,10 @@ Kernel::Kernel(){
     this->add_module( this->robot          = new Robot()         );
     this->add_module( this->stepper        = new Stepper()       );
     this->add_module( this->conveyor       = new Conveyor()      );
-    this->add_module( this->configurator   = new Configurator()  );
     this->add_module( this->simpleshell    = new SimpleShell()   );
 
     this->planner = new Planner();
-
+    this->configurator   = new Configurator();
 }
 
 // return a GRBL-like query string for serial ?

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -42,6 +42,7 @@
 #define acceleration_ticks_per_second_checksum      CHECKSUM("acceleration_ticks_per_second")
 #define disable_leds_checksum                       CHECKSUM("leds_disable")
 #define grbl_mode_checksum                          CHECKSUM("grbl_mode")
+#define ok_per_line_checksum                        CHECKSUM("ok_per_line")
 
 Kernel* Kernel::instance;
 
@@ -98,6 +99,7 @@ Kernel::Kernel(){
     //some boards don't have leds.. TOO BAD!
     this->use_leds= !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
     this->grbl_mode= this->config->value( grbl_mode_checksum )->by_default(false)->as_bool();
+    this->ok_per_line= this->config->value( ok_per_line_checksum )->by_default(true)->as_bool();
 
     this->add_module( this->config );
     this->add_module( this->serial );

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -29,6 +29,8 @@ class Planner;
 class StepTicker;
 class Adc;
 class PublicData;
+class SimpleShell;
+class Configurator;
 
 class Kernel {
     public:
@@ -61,6 +63,8 @@ class Kernel {
         Planner*          planner;
         Config*           config;
         Conveyor*         conveyor;
+        Configurator*     configurator;
+        SimpleShell*      simpleshell;
 
         int debug;
         SlowTicker*       slow_ticker;

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -48,6 +48,7 @@ class Kernel {
         bool is_using_leds() const { return use_leds; }
         bool is_halted() const { return halted; }
         bool is_grbl_mode() const { return grbl_mode; }
+        bool is_ok_per_line() const { return ok_per_line; }
 
         void set_feed_hold(bool f) { feed_hold= f; }
         bool get_feed_hold() const { return feed_hold; }
@@ -82,6 +83,7 @@ class Kernel {
             bool halted:1;
             bool grbl_mode:1;
             bool feed_hold:1;
+            bool ok_per_line:1;
         };
 
 };

--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -63,7 +63,7 @@ StepTicker::StepTicker(){
     this->num_motors= 0;
     this->active_motor.reset();
     this->tick_cnt= 0;
-    probe_fnc= nullptr;
+    this->probe_fnc= nullptr;
 }
 
 StepTicker::~StepTicker() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,11 +133,11 @@ void init() {
 
 
     // Create and add main modules
-    kernel->add_module( new CurrentControl() );
-    kernel->add_module( new KillButton() );
-    kernel->add_module( new PlayLed() );
-    kernel->add_module( new Endstops() );
-    kernel->add_module( new Player() );
+    kernel->add_module( new(AHB0) CurrentControl() );
+    kernel->add_module( new(AHB0) KillButton() );
+    kernel->add_module( new(AHB0) PlayLed() );
+    kernel->add_module( new(AHB0) Endstops() );
+    kernel->add_module( new(AHB0) Player() );
 
 
     // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
@@ -165,13 +165,10 @@ void init() {
     kernel->add_module( new Spindle() );
     #endif
     #ifndef NO_UTILS_PANEL
-    kernel->add_module( new Panel() );
-    #endif
-    #ifndef NO_TOOLS_TOUCHPROBE
-    kernel->add_module( new Touchprobe() );
+    kernel->add_module( new(AHB0) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new ZProbe() );
+    kernel->add_module( new(AHB0) ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
     kernel->add_module( new SCARAcal() );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,8 +133,6 @@ void init() {
 
 
     // Create and add main modules
-    kernel->add_module( new SimpleShell() );
-    kernel->add_module( new Configurator() );
     kernel->add_module( new CurrentControl() );
     kernel->add_module( new KillButton() );
     kernel->add_module( new PlayLed() );

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -324,12 +324,12 @@ try_again:
                         gcode->txt_after_ok.clear();
 
                     } else {
-                        if(THEKERNEL->is_grbl_mode()) {
+                        if(THEKERNEL->is_ok_per_line() || THEKERNEL->is_grbl_mode()) {
                             // only send ok once per line if this is a multi g code line send ok on the last one
                             if(possible_command.empty())
                                 new_message.stream->printf("ok\r\n");
                         } else {
-                            // TODO maybe should do the above for all hosts?
+                            // maybe should do the above for all hosts?
                             new_message.stream->printf("ok\r\n");
                         }
                     }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -767,8 +767,8 @@ void Robot::reset_axis_position(float position, int axis)
     reset_axis_position(last_milestone[X_AXIS], last_milestone[Y_AXIS], last_milestone[Z_AXIS]);
 }
 
-// similar to reset_actuator_position but directly sets the actuator positions in actuators units (eg mm for cartesian, degrees for rotary delta)
-// then sets the axis postions to match. currently only called from G28.4 in Endstops.cpp
+// similar to reset_axis_position but directly sets the actuator positions in actuators units (eg mm for cartesian, degrees for rotary delta)
+// then sets the axis postions to match. currently only called from G28.4 and M306 in Endstops.cpp
 void Robot::reset_actuator_position(float a, float b, float c)
 {
     // NOTE this does NOT support the multiple actuator HACK. so if there are more than 3 actuators this will probably not work
@@ -796,7 +796,7 @@ void Robot::reset_position_from_current_actuator_position()
 
     // now reset actuator::last_milestone, NOTE this may lose a little precision as FK is not always entirely accurate.
     // NOTE This is required to sync the machine position with the actuator position, we do a somewhat redundant cartesian_to_actuator() call
-    // to get everything in perfect sync. **This IS required as there is rounding to the next step as steps are integer**
+    // to get everything in perfect sync.
     arm_solution->cartesian_to_actuator(last_machine_position, actuator_pos);
     for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -48,8 +48,9 @@ class Robot : public Module {
         wcs_t get_axis_position() const { return wcs_t(last_milestone[0], last_milestone[1], last_milestone[2]); }
         int print_position(uint8_t subcode, char *buf, size_t bufsize) const;
         uint8_t get_current_wcs() const { return current_wcs; }
-
         std::vector<wcs_t> get_wcs_state() const;
+        std::tuple<float, float, float, uint8_t> get_last_probe_position() const { return last_probe_position; }
+        void set_last_probe_position(std::tuple<float, float, float, uint8_t> p) { last_probe_position = p; }
 
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 
@@ -89,6 +90,7 @@ class Robot : public Module {
         uint8_t current_wcs{0}; // 0 means G54 is enabled this is persistent once saved with M500
         wcs_t g92_offset;
         wcs_t tool_offset; // used for multiple extruders, sets the tool offset for the current extruder applied first
+        std::tuple<float, float, float, uint8_t> last_probe_position;
 
         using saved_state_t= std::tuple<float, float, bool, bool, uint8_t>; // save current feedrate and absolute mode, inch mode, current_wcs
         std::stack<saved_state_t> state_stack;               // saves state from M120

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -680,6 +680,13 @@ void Endstops::on_gcode_received(void *argument)
             }
         }
 
+        // save current actuator position so we can report how far we moved
+        ActuatorCoordinates start_pos{
+            THEKERNEL->robot->actuators[X_AXIS]->get_current_position(),
+            THEKERNEL->robot->actuators[Y_AXIS]->get_current_position(),
+            THEKERNEL->robot->actuators[Z_AXIS]->get_current_position()
+        };
+
         // Enable the motors
         THEKERNEL->stepper->turn_enable_pins_on();
 
@@ -711,7 +718,12 @@ void Endstops::on_gcode_received(void *argument)
         }
 
         // set the last probe position to the actuator units moved during this home
-        THEKERNEL->robot->set_last_probe_position(std::make_tuple(STEPPER[0]->get_stepped()/STEPS_PER_MM(0), STEPPER[1]->get_stepped()/STEPS_PER_MM(1), STEPPER[2]->get_stepped()/STEPS_PER_MM(2), 0));
+        THEKERNEL->robot->set_last_probe_position(
+            std::make_tuple(
+                start_pos[0]-THEKERNEL->robot->actuators[0]->get_current_position(),
+                start_pos[1]-THEKERNEL->robot->actuators[1]->get_current_position(),
+                start_pos[2]-THEKERNEL->robot->actuators[2]->get_current_position(),
+                0));
 
         if(home_all) {
             // Here's where we would have been if the endstops were perfectly trimmed

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -615,181 +615,186 @@ void Endstops::home(char axes_to_move)
     this->status = NOT_HOMING;
 }
 
+void Endstops::process_home_command(Gcode* gcode)
+{
+    if( (gcode->subcode == 0 && THEKERNEL->is_grbl_mode()) || (gcode->subcode == 2 && !THEKERNEL->is_grbl_mode()) ) {
+        // G28 in grbl mode or G28.2 in normal mode will do a rapid to the predefined position
+        // TODO spec says if XYZ specified move to them first then move to MCS of specifed axis
+        char buf[32];
+        snprintf(buf, sizeof(buf), "G53 G0 X%f Y%f", saved_position[X_AXIS], saved_position[Y_AXIS]); // must use machine coordinates in case G92 or WCS is in effect
+        struct SerialMessage message;
+        message.message = buf;
+        message.stream = &(StreamOutput::NullStream);
+        THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message ); // as it is a multi G code command
+        return;
+
+    } else if(THEKERNEL->is_grbl_mode() && gcode->subcode == 2) { // G28.2 in grbl mode forces homing (triggered by $H)
+        // fall through so it does homing cycle
+
+    } else if(gcode->subcode == 1) { // G28.1 set pre defined position
+        // saves current position in absolute machine coordinates
+        THEKERNEL->robot->get_axis_position(saved_position);
+        return;
+
+    } else if(gcode->subcode == 3) { // G28.3 is a smoothie special it sets manual homing
+        if(gcode->get_num_args() == 0) {
+            THEKERNEL->robot->reset_axis_position(0, 0, 0);
+        } else {
+            // do a manual homing based on given coordinates, no endstops required
+            if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
+            if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
+            if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
+        }
+        return;
+
+    } else if(gcode->subcode == 4) { // G28.4 is a smoothie special it sets manual homing based on the actuator position (used for rotary delta)
+        // do a manual homing based on given coordinates, no endstops required
+        float a = NAN, b = NAN, c = NAN;
+        if(gcode->has_letter('A')) a =  gcode->get_value('A');
+        if(gcode->has_letter('B')) b =  gcode->get_value('B');
+        if(gcode->has_letter('C')) c =  gcode->get_value('C');
+        THEKERNEL->robot->reset_actuator_position(a, b, c);
+        return;
+
+    } else if(THEKERNEL->is_grbl_mode()) {
+        gcode->stream->printf("error:Unsupported command\n");
+        return;
+    }
+
+    // G28 is received, we have homing to do
+
+    // First wait for the queue to be empty
+    THEKERNEL->conveyor->wait_for_empty_queue();
+
+    // Do we move select axes or all of them
+    char axes_to_move = 0;
+    // only enable homing if the endstop is defined, deltas, scaras always home all axis
+    bool home_all = this->is_delta || this->is_rdelta || this->is_scara || !( gcode->has_letter('X') || gcode->has_letter('Y') || gcode->has_letter('Z') );
+
+    for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
+        if ( (home_all || gcode->has_letter(c + 'X')) && this->pins[c + (this->home_direction[c] ? 0 : 3)].connected() ) {
+            axes_to_move += ( 1 << c );
+        }
+    }
+
+    // save current actuator position so we can report how far we moved
+    ActuatorCoordinates start_pos{
+        THEKERNEL->robot->actuators[X_AXIS]->get_current_position(),
+        THEKERNEL->robot->actuators[Y_AXIS]->get_current_position(),
+        THEKERNEL->robot->actuators[Z_AXIS]->get_current_position()
+    };
+
+    // Enable the motors
+    THEKERNEL->stepper->turn_enable_pins_on();
+
+    // do the actual homing
+    if(homing_order != 0) {
+        // if an order has been specified do it in the specified order
+        // homing order is 0b00ccbbaa where aa is 0,1,2 to specify the first axis, bb is the second and cc is the third
+        // eg 0b00100001 would be Y X Z, 0b00100100 would be X Y Z
+        for (uint8_t m = homing_order; m != 0; m >>= 2) {
+            int a = (1 << (m & 0x03)); // axis to move
+            if((a & axes_to_move) != 0) {
+                home(a);
+            }
+            // check if on_halt (eg kill)
+            if(THEKERNEL->is_halted()) break;
+        }
+
+    } else {
+        // they all home at the same time
+        home(axes_to_move);
+    }
+
+    // check if on_halt (eg kill)
+    if(THEKERNEL->is_halted()) {
+        if(!THEKERNEL->is_grbl_mode()) {
+            THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
+        }
+        return;
+    }
+
+    // set the last probe position to the actuator units moved during this home
+    THEKERNEL->robot->set_last_probe_position(
+        std::make_tuple(
+            start_pos[0] - THEKERNEL->robot->actuators[0]->get_current_position(),
+            start_pos[1] - THEKERNEL->robot->actuators[1]->get_current_position(),
+            start_pos[2] - THEKERNEL->robot->actuators[2]->get_current_position(),
+            0));
+
+    if(home_all) {
+        // Here's where we would have been if the endstops were perfectly trimmed
+        // NOTE on a rotary delta home_offset is actuator position in degrees when homed and
+        // home_offset is the theta offset for each actuator, so M206 is used to set theta offset for each actuator in degrees
+        float ideal_position[3] = {
+            this->homing_position[X_AXIS] + this->home_offset[X_AXIS],
+            this->homing_position[Y_AXIS] + this->home_offset[Y_AXIS],
+            this->homing_position[Z_AXIS] + this->home_offset[Z_AXIS]
+        };
+
+        bool has_endstop_trim = this->is_delta || this->is_scara;
+        if (has_endstop_trim) {
+            ActuatorCoordinates ideal_actuator_position;
+            THEKERNEL->robot->arm_solution->cartesian_to_actuator(ideal_position, ideal_actuator_position);
+
+            // We are actually not at the ideal position, but a trim away
+            ActuatorCoordinates real_actuator_position = {
+                ideal_actuator_position[X_AXIS] - this->trim_mm[X_AXIS],
+                ideal_actuator_position[Y_AXIS] - this->trim_mm[Y_AXIS],
+                ideal_actuator_position[Z_AXIS] - this->trim_mm[Z_AXIS]
+            };
+
+            float real_position[3];
+            THEKERNEL->robot->arm_solution->actuator_to_cartesian(real_actuator_position, real_position);
+            // Reset the actuator positions to correspond our real position
+            THEKERNEL->robot->reset_axis_position(real_position[0], real_position[1], real_position[2]);
+
+        } else {
+            // without endstop trim, real_position == ideal_position
+            if(is_rdelta) {
+                // with a rotary delta we set the actuators angle then use the FK to calculate the resulting cartesian coordinates
+                THEKERNEL->robot->reset_actuator_position(ideal_position[0], ideal_position[1], ideal_position[2]);
+
+            } else {
+                // Reset the actuator positions to correspond our real position
+                THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
+            }
+        }
+
+    } else {
+        // Zero the ax(i/e)s position, add in the home offset
+        for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
+            if ( (axes_to_move >> c)  & 1 ) {
+                THEKERNEL->robot->reset_axis_position(this->homing_position[c] + this->home_offset[c], c);
+            }
+        }
+    }
+
+    // on some systems where 0,0 is bed center it is nice to have home goto 0,0 after homing
+    // default is off for cartesian on for deltas
+    if(!is_delta) {
+        // NOTE a rotary delta usually has optical or hall-effect endstops so it is safe to go past them a little bit
+        if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
+        // if limit switches are enabled we must back off endstop after setting home
+        back_off_home(axes_to_move);
+
+    } else if(this->move_to_origin_after_home || this->limit_enable[X_AXIS]) {
+        // deltas are not left at 0,0 because of the trim settings, so move to 0,0 if requested, but we need to back off endstops first
+        // also need to back off endstops if limits are enabled
+        back_off_home(axes_to_move);
+        if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
+    }
+}
+
 // Start homing sequences by response to GCode commands
 void Endstops::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode *>(argument);
     if ( gcode->has_g && gcode->g == 28) {
-        if( (gcode->subcode == 0 && THEKERNEL->is_grbl_mode()) || (gcode->subcode == 2 && !THEKERNEL->is_grbl_mode()) ) {
-            // G28 in grbl mode or G28.2 in normal mode will do a rapid to the predefined position
-            // TODO spec says if XYZ specified move to them first then move to MCS of specifed axis
-            char buf[32];
-            snprintf(buf, sizeof(buf), "G53 G0 X%f Y%f", saved_position[X_AXIS], saved_position[Y_AXIS]); // must use machine coordinates in case G92 or WCS is in effect
-            struct SerialMessage message;
-            message.message = buf;
-            message.stream = &(StreamOutput::NullStream);
-            THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message ); // as it is a multi G code command
-            return;
+        process_home_command(gcode);
 
-        } else if(THEKERNEL->is_grbl_mode() && gcode->subcode == 2) { // G28.2 in grbl mode forces homing (triggered by $H)
-            // fall through so it does homing cycle
+    }else if (gcode->has_m) {
 
-        } else if(gcode->subcode == 1) { // G28.1 set pre defined position
-            // saves current position in absolute machine coordinates
-            THEKERNEL->robot->get_axis_position(saved_position);
-            return;
-
-        } else if(gcode->subcode == 3) { // G28.3 is a smoothie special it sets manual homing
-            if(gcode->get_num_args() == 0) {
-                THEKERNEL->robot->reset_axis_position(0, 0, 0);
-            } else {
-                // do a manual homing based on given coordinates, no endstops required
-                if(gcode->has_letter('X')) THEKERNEL->robot->reset_axis_position(gcode->get_value('X'), X_AXIS);
-                if(gcode->has_letter('Y')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Y'), Y_AXIS);
-                if(gcode->has_letter('Z')) THEKERNEL->robot->reset_axis_position(gcode->get_value('Z'), Z_AXIS);
-            }
-            return;
-
-       } else if(gcode->subcode == 4) { // G28.4 is a smoothie special it sets manual homing based on the actuator position (used for rotary delta)
-            // do a manual homing based on given coordinates, no endstops required
-            float a=NAN, b=NAN, c=NAN;
-            if(gcode->has_letter('A')) a=  gcode->get_value('A');
-            if(gcode->has_letter('B')) b=  gcode->get_value('B');
-            if(gcode->has_letter('C')) c=  gcode->get_value('C');
-            THEKERNEL->robot->reset_actuator_position(a, b, c);
-            return;
-
-        } else if(THEKERNEL->is_grbl_mode()) {
-            gcode->stream->printf("error:Unsupported command\n");
-            return;
-        }
-
-        // G28 is received, we have homing to do
-
-        // First wait for the queue to be empty
-        THEKERNEL->conveyor->wait_for_empty_queue();
-
-        // Do we move select axes or all of them
-        char axes_to_move = 0;
-        // only enable homing if the endstop is defined, deltas, scaras always home all axis
-        bool home_all = this->is_delta || this->is_rdelta || this->is_scara || !( gcode->has_letter('X') || gcode->has_letter('Y') || gcode->has_letter('Z') );
-
-        for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
-            if ( (home_all || gcode->has_letter(c + 'X')) && this->pins[c + (this->home_direction[c] ? 0 : 3)].connected() ) {
-                axes_to_move += ( 1 << c );
-            }
-        }
-
-        // save current actuator position so we can report how far we moved
-        ActuatorCoordinates start_pos{
-            THEKERNEL->robot->actuators[X_AXIS]->get_current_position(),
-            THEKERNEL->robot->actuators[Y_AXIS]->get_current_position(),
-            THEKERNEL->robot->actuators[Z_AXIS]->get_current_position()
-        };
-
-        // Enable the motors
-        THEKERNEL->stepper->turn_enable_pins_on();
-
-        // do the actual homing
-        if(homing_order != 0) {
-            // if an order has been specified do it in the specified order
-            // homing order is 0b00ccbbaa where aa is 0,1,2 to specify the first axis, bb is the second and cc is the third
-            // eg 0b00100001 would be Y X Z, 0b00100100 would be X Y Z
-            for (uint8_t m = homing_order; m != 0; m >>= 2) {
-                int a = (1 << (m & 0x03)); // axis to move
-                if((a & axes_to_move) != 0) {
-                    home(a);
-                }
-                // check if on_halt (eg kill)
-                if(THEKERNEL->is_halted()) break;
-            }
-
-        } else {
-            // they all home at the same time
-            home(axes_to_move);
-        }
-
-        // check if on_halt (eg kill)
-        if(THEKERNEL->is_halted()) {
-            if(!THEKERNEL->is_grbl_mode()) {
-                THEKERNEL->streams->printf("Homing cycle aborted by kill\n");
-            }
-            return;
-        }
-
-        // set the last probe position to the actuator units moved during this home
-        THEKERNEL->robot->set_last_probe_position(
-            std::make_tuple(
-                start_pos[0]-THEKERNEL->robot->actuators[0]->get_current_position(),
-                start_pos[1]-THEKERNEL->robot->actuators[1]->get_current_position(),
-                start_pos[2]-THEKERNEL->robot->actuators[2]->get_current_position(),
-                0));
-
-        if(home_all) {
-            // Here's where we would have been if the endstops were perfectly trimmed
-            // NOTE on a rotary delta home_offset is actuator position in degrees when homed and
-            // home_offset is the theta offset for each actuator, so M206 is used to set theta offset for each actuator in degrees
-            float ideal_position[3] = {
-                this->homing_position[X_AXIS] + this->home_offset[X_AXIS],
-                this->homing_position[Y_AXIS] + this->home_offset[Y_AXIS],
-                this->homing_position[Z_AXIS] + this->home_offset[Z_AXIS]
-            };
-
-            bool has_endstop_trim = this->is_delta || this->is_scara;
-            if (has_endstop_trim) {
-                ActuatorCoordinates ideal_actuator_position;
-                THEKERNEL->robot->arm_solution->cartesian_to_actuator(ideal_position, ideal_actuator_position);
-
-                // We are actually not at the ideal position, but a trim away
-                ActuatorCoordinates real_actuator_position = {
-                    ideal_actuator_position[X_AXIS] - this->trim_mm[X_AXIS],
-                    ideal_actuator_position[Y_AXIS] - this->trim_mm[Y_AXIS],
-                    ideal_actuator_position[Z_AXIS] - this->trim_mm[Z_AXIS]
-                };
-
-                float real_position[3];
-                THEKERNEL->robot->arm_solution->actuator_to_cartesian(real_actuator_position, real_position);
-                // Reset the actuator positions to correspond our real position
-                THEKERNEL->robot->reset_axis_position(real_position[0], real_position[1], real_position[2]);
-
-            } else {
-                // without endstop trim, real_position == ideal_position
-                if(is_rdelta) {
-                    // with a rotary delta we set the actuators angle then use the FK to calculate the resulting cartesian coordinates
-                    THEKERNEL->robot->reset_actuator_position(ideal_position[0], ideal_position[1], ideal_position[2]);
-
-                }else{
-                    // Reset the actuator positions to correspond our real position
-                    THEKERNEL->robot->reset_axis_position(ideal_position[0], ideal_position[1], ideal_position[2]);
-                }
-            }
-
-        } else {
-            // Zero the ax(i/e)s position, add in the home offset
-            for ( int c = X_AXIS; c <= Z_AXIS; c++ ) {
-                if ( (axes_to_move >> c)  & 1 ) {
-                    THEKERNEL->robot->reset_axis_position(this->homing_position[c] + this->home_offset[c], c);
-                }
-            }
-        }
-
-        // on some systems where 0,0 is bed center it is nice to have home goto 0,0 after homing
-        // default is off for cartesian on for deltas
-        if(!is_delta) {
-            // NOTE a rotary delta usually has optical or hall-effect endstops so it is safe to go past them a little bit
-            if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
-            // if limit switches are enabled we must back off endstop after setting home
-            back_off_home(axes_to_move);
-
-        } else if(this->move_to_origin_after_home || this->limit_enable[X_AXIS]) {
-            // deltas are not left at 0,0 because of the trim settings, so move to 0,0 if requested, but we need to back off endstops first
-            // also need to back off endstops if limits are enabled
-            back_off_home(axes_to_move);
-            if(this->move_to_origin_after_home) move_to_origin(axes_to_move);
-        }
-    }
-
-    if (gcode->has_m) {
         switch (gcode->m) {
             case 119: {
                 for (int i = 0; i < 6; ++i) {
@@ -808,7 +813,7 @@ void Endstops::on_gcode_received(void *argument)
                     if (gcode->has_letter('Z')) home_offset[2] = gcode->get_value('Z');
                     gcode->stream->printf("X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
 
-                }else{
+                } else {
                     // set theta offset
                     if (gcode->has_letter('A')) home_offset[0] = gcode->get_value('A');
                     if (gcode->has_letter('B')) home_offset[1] = gcode->get_value('B');
@@ -836,7 +841,7 @@ void Endstops::on_gcode_received(void *argument)
 
                     gcode->stream->printf("Homing Offset: X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
 
-                }else{
+                } else {
                     // for a rotary delta M306 calibrates the homing angle
                     // by doing M306 A-56.17 it will calculate the M206 A value (the theta offset for actuator A) based on the difference
                     // between what it thinks is the current angle and what the current angle actually is specified by A (ditto for B and C)
@@ -850,18 +855,18 @@ void Endstops::on_gcode_received(void *argument)
 
                     //figure out what home_offset needs to be to correct the homing_position
                     if (gcode->has_letter('A')) {
-                        float a= gcode->get_value('A'); // what actual angle is
-                        home_offset[0]= (a - current_angle[0]);
+                        float a = gcode->get_value('A'); // what actual angle is
+                        home_offset[0] = (a - current_angle[0]);
                         THEKERNEL->robot->reset_actuator_position(a, NAN, NAN);
                     }
                     if (gcode->has_letter('B')) {
-                        float b= gcode->get_value('B');
-                        home_offset[1]= (b - current_angle[1]);
+                        float b = gcode->get_value('B');
+                        home_offset[1] = (b - current_angle[1]);
                         THEKERNEL->robot->reset_actuator_position(NAN, b, NAN);
                     }
                     if (gcode->has_letter('C')) {
-                        float c= gcode->get_value('C');
-                        home_offset[2]= (c - current_angle[2]);
+                        float c = gcode->get_value('C');
+                        home_offset[2] = (c - current_angle[2]);
                         THEKERNEL->robot->reset_actuator_position(NAN, NAN, c);
                     }
 
@@ -922,20 +927,20 @@ void Endstops::on_gcode_received(void *argument)
 
                     if (gcode->has_letter('X')) {
                         float v = gcode->get_value('X');
-                        if(gcode->subcode == 2) x= lroundf(v * STEPS_PER_MM(X_AXIS));
-                        else x= roundf(v);
+                        if(gcode->subcode == 2) x = lroundf(v * STEPS_PER_MM(X_AXIS));
+                        else x = roundf(v);
                         STEPPER[X_AXIS]->move(x < 0, abs(x), f);
                     }
                     if (gcode->has_letter('Y')) {
                         float v = gcode->get_value('Y');
-                        if(gcode->subcode == 2) y= lroundf(v * STEPS_PER_MM(Y_AXIS));
-                        else y= roundf(v);
+                        if(gcode->subcode == 2) y = lroundf(v * STEPS_PER_MM(Y_AXIS));
+                        else y = roundf(v);
                         STEPPER[Y_AXIS]->move(y < 0, abs(y), f);
                     }
                     if (gcode->has_letter('Z')) {
                         float v = gcode->get_value('Z');
-                        if(gcode->subcode == 2) z= lroundf(v * STEPS_PER_MM(Z_AXIS));
-                        else z= roundf(v);
+                        if(gcode->subcode == 2) z = lroundf(v * STEPS_PER_MM(Z_AXIS));
+                        else z = roundf(v);
                         STEPPER[Z_AXIS]->move(z < 0, abs(z), f);
                     }
                     gcode->stream->printf("Moving X %ld Y %ld Z %ld steps at F %ld steps/sec\n", x, y, z, f);
@@ -996,8 +1001,8 @@ void Endstops::on_get_public_data(void* argument)
         pdr->set_taken();
 
     } else if(pdr->second_element_is(get_homing_status_checksum)) {
-        bool *homing= static_cast<bool *>(pdr->get_data_ptr());
-        *homing= this->status != NOT_HOMING;
+        bool *homing = static_cast<bool *>(pdr->get_data_ptr());
+        *homing = this->status != NOT_HOMING;
         pdr->set_taken();
     }
 }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -710,6 +710,9 @@ void Endstops::on_gcode_received(void *argument)
             return;
         }
 
+        // set the last probe position to the actuator units moved during this home
+        THEKERNEL->robot->set_last_probe_position(std::make_tuple(STEPPER[0]->get_stepped()/STEPS_PER_MM(0), STEPPER[1]->get_stepped()/STEPS_PER_MM(1), STEPPER[2]->get_stepped()/STEPS_PER_MM(2), 0));
+
         if(home_all) {
             // Here's where we would have been if the endstops were perfectly trimmed
             // NOTE on a rotary delta home_offset is actuator position in degrees when homed and

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -833,19 +833,20 @@ void Endstops::on_gcode_received(void *argument)
                         THEKERNEL->robot->actuators[Z_AXIS]->get_current_position()
                     };
 
+                    //figure out what home_offset needs to be to correct the homing_position
                     if (gcode->has_letter('A')) {
-                        float a= gcode->get_value('A');
-                        home_offset[0] -= (current_angle[0] - a);
+                        float a= gcode->get_value('A'); // what actual angle is
+                        home_offset[0]= (a - current_angle[0]);
                         THEKERNEL->robot->reset_actuator_position(a, NAN, NAN);
                     }
                     if (gcode->has_letter('B')) {
                         float b= gcode->get_value('B');
-                        home_offset[1] -= (current_angle[1] - b);
+                        home_offset[1]= (b - current_angle[1]);
                         THEKERNEL->robot->reset_actuator_position(NAN, b, NAN);
                     }
                     if (gcode->has_letter('C')) {
                         float c= gcode->get_value('C');
-                        home_offset[2] -= (current_angle[2] - c);
+                        home_offset[2]= (c - current_angle[2]);
                         THEKERNEL->robot->reset_actuator_position(NAN, NAN, c);
                     }
 
@@ -901,22 +902,25 @@ void Endstops::on_gcode_received(void *argument)
                     // Enable the motors
                     THEKERNEL->stepper->turn_enable_pins_on();
 
-                    int32_t x = 0, y = 0 , z = 0, f = 200 * 16;
+                    int32_t x = 0, y = 0, z = 0, f = 200 * 16;
                     if (gcode->has_letter('F')) f = gcode->get_value('F');
 
                     if (gcode->has_letter('X')) {
-                        x = gcode->get_value('X');
-                        if(gcode->subcode == 2) x= lroundf(x * STEPS_PER_MM(X_AXIS));
+                        float v = gcode->get_value('X');
+                        if(gcode->subcode == 2) x= lroundf(v * STEPS_PER_MM(X_AXIS));
+                        else x= roundf(v);
                         STEPPER[X_AXIS]->move(x < 0, abs(x), f);
                     }
                     if (gcode->has_letter('Y')) {
-                        y = gcode->get_value('Y');
-                        if(gcode->subcode == 2) y= lroundf(y * STEPS_PER_MM(Y_AXIS));
+                        float v = gcode->get_value('Y');
+                        if(gcode->subcode == 2) y= lroundf(v * STEPS_PER_MM(Y_AXIS));
+                        else y= roundf(v);
                         STEPPER[Y_AXIS]->move(y < 0, abs(y), f);
                     }
                     if (gcode->has_letter('Z')) {
-                        z = gcode->get_value('Z');
-                        if(gcode->subcode == 2) z= lroundf(z * STEPS_PER_MM(Z_AXIS));
+                        float v = gcode->get_value('Z');
+                        if(gcode->subcode == 2) z= lroundf(v * STEPS_PER_MM(Z_AXIS));
+                        else z= roundf(v);
                         STEPPER[Z_AXIS]->move(z < 0, abs(z), f);
                     }
                     gcode->stream->printf("Moving X %ld Y %ld Z %ld steps at F %ld steps/sec\n", x, y, z, f);

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -14,6 +14,7 @@
 #include <bitset>
 
 class StepperMotor;
+class Gcode;
 
 class Endstops : public Module{
     public:
@@ -36,6 +37,7 @@ class Endstops : public Module{
         void on_set_public_data(void* argument);
         void on_idle(void *argument);
         bool debounced_get(int pin);
+        void process_home_command(Gcode* gcode);
 
         float homing_position[3];
         float home_offset[3];

--- a/src/modules/tools/filamentdetector/FilamentDetector.cpp
+++ b/src/modules/tools/filamentdetector/FilamentDetector.cpp
@@ -90,9 +90,9 @@ void FilamentDetector::on_module_loaded()
     // register event-handlers
     if (this->encoder_pin != nullptr) {
         //This event is only valid if we are using the encodeer.
-        register_for_event(ON_SECOND_TICK); 
+        register_for_event(ON_SECOND_TICK);
     }
-    
+
     register_for_event(ON_MAIN_LOOP);
     register_for_event(ON_CONSOLE_LINE_RECEIVED);
     this->register_for_event(ON_GCODE_RECEIVED);
@@ -115,7 +115,7 @@ void FilamentDetector::on_console_line_received( void *argument )
     SerialMessage new_message = *static_cast<SerialMessage *>(argument);
     string possible_command = new_message.message;
     string cmd = shift_parameter(possible_command);
-    if(cmd == "resume") {
+    if(cmd == "resume" || cmd == "M601") {
         this->pulses= 0;
         e_last_moved= NAN;
         suspended= false;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -370,53 +370,18 @@ void ZProbe::on_gcode_received(void *argument)
 
         if(gcode->has_letter('X')) {
             // probe in the X axis
-            probe_XY(gcode, X_AXIS);
+            probe_XYZ(gcode, X_AXIS);
 
         }else if(gcode->has_letter('Y')) {
             // probe in the Y axis
-            probe_XY(gcode, Y_AXIS);
+            probe_XYZ(gcode, Y_AXIS);
 
         }else if(gcode->has_letter('Z')) {
-            // we need to know where we started the probe from
-            float current_machine_pos[3];
-            THEKERNEL->robot->get_axis_position(current_machine_pos);
-
-            // probe down in the Z axis no more than the Z value in mm
-            float rate = (gcode->has_letter('F')) ? gcode->get_value('F') / 60 : this->slow_feedrate;
-            int steps;
-            bool probe_result = run_probe_feed(steps, rate, gcode->get_value('Z'));
-
-            if(probe_result) {
-                float z= current_machine_pos[Z_AXIS] - zsteps_to_mm(steps);
-                THEKERNEL->robot->set_last_probe_position(std::make_tuple(current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], z, 1));
-
-                if(THEKERNEL->is_grbl_mode()) {
-                    gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:1]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], z);
-
-                }else{
-                    gcode->stream->printf("INFO: delta Z %1.4f (Steps %d)\n", steps / Z_STEPS_PER_MM, steps);
-                }
-
-                // set position to where it stopped
-                THEKERNEL->robot->reset_axis_position(z, Z_AXIS);
-
-            } else {
-                THEKERNEL->robot->set_last_probe_position(std::make_tuple(current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS], 0));
-                if(THEKERNEL->is_grbl_mode()) {
-                    if(gcode->subcode == 2) {
-                        gcode->stream->printf("ALARM:Probe fail\n");
-                        THEKERNEL->call_event(ON_HALT, nullptr);
-                    }
-                    gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:0]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS]);
-
-                }else{
-                    gcode->stream->printf("error:ZProbe not triggered\n");
-                }
-            }
+            // probe in the Z axis
+            probe_XYZ(gcode, Z_AXIS);
 
         }else{
             gcode->stream->printf("error:at least one of X Y or Z must be specified\n");
-
         }
 
         // restore compensationTransform
@@ -459,8 +424,8 @@ void ZProbe::on_gcode_received(void *argument)
     }
 }
 
-// special way to probe in the X or Y direction
-void ZProbe::probe_XY(Gcode *gcode, int axis)
+// special way to probe in the X or Y or Z direction using planned moves
+void ZProbe::probe_XYZ(Gcode *gcode, int axis)
 {
     // enable the probe checking in the stepticker
     THEKERNEL->step_ticker->probe_fnc= [this]() { return this->pin.get(); };
@@ -474,6 +439,9 @@ void ZProbe::probe_XY(Gcode *gcode, int axis)
 
     }else if(axis == Y_AXIS) {
         coordinated_move(0, gcode->get_value('Y'), 0, rate, true);
+
+    }else if(axis == Z_AXIS) {
+        coordinated_move(0, 0, gcode->get_value('Z'), rate, true);
 
     }else{
         // this is an error

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -63,7 +63,6 @@ void ZProbe::on_module_loaded()
         delete this;
         return;
     }
-    this->running = false;
 
     // load settings
     this->on_config_reload(this);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -364,6 +364,10 @@ void ZProbe::on_gcode_received(void *argument)
         // first wait for an empty queue i.e. no moves left
         THEKERNEL->conveyor->wait_for_empty_queue();
 
+        // turn off any compensation transform
+        auto savect= THEKERNEL->robot->compensationTransform;
+        THEKERNEL->robot->compensationTransform= nullptr;
+
         if(gcode->has_letter('X')) {
             // probe in the X axis
             probe_XY(gcode, X_AXIS);
@@ -414,6 +418,10 @@ void ZProbe::on_gcode_received(void *argument)
             gcode->stream->printf("error:at least one of X Y or Z must be specified\n");
 
         }
+
+        // restore compensationTransform
+        THEKERNEL->robot->compensationTransform= savect;
+
         return;
 
     } else if(gcode->has_m) {

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -294,6 +294,7 @@ void ZProbe::on_gcode_received(void *argument)
         }
 
         if( gcode->g == 30 ) { // simple Z probe
+            // NOTE currently this will not work for rotary deltas, use G38.2/3 Z instead
             // first wait for an empty queue i.e. no moves left
             THEKERNEL->conveyor->wait_for_empty_queue();
 
@@ -356,6 +357,7 @@ void ZProbe::on_gcode_received(void *argument)
             gcode->stream->printf("error:ZProbe not connected.\n");
             return;
         }
+
         if(this->pin.get()) {
             gcode->stream->printf("error:ZProbe triggered before move, aborting command.\n");
             return;
@@ -424,7 +426,7 @@ void ZProbe::on_gcode_received(void *argument)
     }
 }
 
-// special way to probe in the X or Y or Z direction using planned moves
+// special way to probe in the X or Y or Z direction using planned moves, shoul dwork with any kinematics
 void ZProbe::probe_XYZ(Gcode *gcode, int axis)
 {
     // enable the probe checking in the stepticker
@@ -466,11 +468,11 @@ void ZProbe::probe_XYZ(Gcode *gcode, int axis)
     }
 
     // see if probe was triggered
-    // handle debounce here, 200ms should be enough
+    // handle debounce here, 200ms should be enough Note this won't filter noise just handles real debounce after hit
     safe_delay(200);
     uint8_t probeok= this->pin.get() ? 1 : 0;
 
-    // print results
+    // print results using the GRBL format
     gcode->stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS], probeok);
     THEKERNEL->robot->set_last_probe_position(std::make_tuple(pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS], probeok));
 

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -50,7 +50,7 @@ public:
 
 private:
     void accelerate(int c);
-    void probe_XY(Gcode *gc, int axis);
+    void probe_XYZ(Gcode *gc, int axis);
 
     volatile float current_feedrate;
     float slow_feedrate;

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -26,8 +26,9 @@ class ZProbe: public Module
 {
 
 public:
+    ZProbe() : running(false){};
+
     void on_module_loaded();
-    void on_config_reload(void *argument);
     void on_gcode_received(void *argument);
     void acceleration_tick(void);
 
@@ -49,6 +50,7 @@ public:
     float zsteps_to_mm(float steps);
 
 private:
+    void on_config_reload(void *argument);
     void accelerate(int c);
     void probe_XYZ(Gcode *gc, int axis);
 

--- a/src/modules/utils/configurator/Configurator.cpp
+++ b/src/modules/utils/configurator/Configurator.cpp
@@ -25,36 +25,6 @@
 #define CONF_SD         2
 #define CONF_EEPROM     3
 
-void Configurator::on_module_loaded()
-{
-    this->register_for_event(ON_CONSOLE_LINE_RECEIVED);
-    //    this->register_for_event(ON_GCODE_RECEIVED);
-    //    this->register_for_event(ON_MAIN_LOOP);
-}
-
-// When a new line is received, check if it is a command, and if it is, act upon it
-void Configurator::on_console_line_received( void *argument )
-{
-    SerialMessage new_message = *static_cast<SerialMessage *>(argument);
-
-    // ignore comments and blank lines and if this is a G code then also ignore it
-    char first_char = new_message.message[0];
-    if(strchr(";( \n\rGMTN", first_char) != NULL) return;
-
-    string possible_command = new_message.message;
-    string cmd = shift_parameter(possible_command);
-
-    // Act depending on command
-    if (cmd == "config-get"){
-        this->config_get_command(  possible_command, new_message.stream );
-    } else if (cmd == "config-set"){
-        this->config_set_command(  possible_command, new_message.stream );
-    } else if (cmd == "config-load"){
-        this->config_load_command(  possible_command, new_message.stream );
-    }
-}
-
-void Configurator::on_main_loop(void *argument) {}
 
 // Output a ConfigValue from the specified ConfigSource to the stream
 void Configurator::config_get_command( string parameters, StreamOutput *stream )

--- a/src/modules/utils/configurator/Configurator.h
+++ b/src/modules/utils/configurator/Configurator.h
@@ -9,14 +9,12 @@
 #ifndef configurator_h
 #define configurator_h
 
-#include "Module.h"
-
 #include <string>
 using std::string;
 
 class StreamOutput;
 
-class Configurator : public Module
+class Configurator
 {
 public:
     Configurator() {}

--- a/src/modules/utils/configurator/Configurator.h
+++ b/src/modules/utils/configurator/Configurator.h
@@ -21,10 +21,6 @@ class Configurator : public Module
 public:
     Configurator() {}
 
-    void on_module_loaded();
-    void on_console_line_received( void *argument );
-    void on_main_loop( void *argument );
-
     void config_get_command( string parameters, StreamOutput *stream );
     void config_set_command( string parameters, StreamOutput *stream );
     void config_load_command(string parameters, StreamOutput *stream );

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -685,7 +685,6 @@ void SimpleShell::grblDP_command( string parameters, StreamOutput *stream)
     stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", px, py, pz, ps);
 }
 
-// used to test out the get public data events
 void SimpleShell::get_command( string parameters, StreamOutput *stream)
 {
     string what = shift_parameter( parameters );

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -255,7 +255,7 @@ void SimpleShell::on_console_line_received( void *argument )
 
         // find command and execute it
         if(!parse_command(cmd.c_str(), possible_command, new_message.stream)) {
-            new_message.stream->printf("error:Unsupported command\n");
+            new_message.stream->printf("error:Unsupported command - %s\n", cmd.c_str());
         }
     }
 }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -27,6 +27,7 @@
 #include "GcodeDispatch.h"
 #include "BaseSolution.h"
 #include "StepperMotor.h"
+#include "Configurator.h"
 
 #include "TemperatureControlPublicAccess.h"
 #include "EndstopsPublicAccess.h"
@@ -253,8 +254,20 @@ void SimpleShell::on_console_line_received( void *argument )
         //new_message.stream->printf("Received %s\r\n", possible_command.c_str());
         string cmd = shift_parameter(possible_command);
 
-        // find command and execute it
-        if(!parse_command(cmd.c_str(), possible_command, new_message.stream)) {
+        // Configurator commands
+        if (cmd == "config-get"){
+            THEKERNEL->configurator->config_get_command(  possible_command, new_message.stream );
+
+        } else if (cmd == "config-set"){
+            THEKERNEL->configurator->config_set_command(  possible_command, new_message.stream );
+
+        } else if (cmd == "config-load"){
+            THEKERNEL->configurator->config_load_command(  possible_command, new_message.stream );
+
+        } else if (cmd == "play" || cmd == "progress" || cmd == "abort" || cmd == "suspend" || cmd == "resume") {
+            // handled in the Player.cpp module
+
+        }else if(!parse_command(cmd.c_str(), possible_command, new_message.stream)) {
             new_message.stream->printf("error:Unsupported command - %s\n", cmd.c_str());
         }
     }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -678,10 +678,11 @@ void SimpleShell::grblDP_command( string parameters, StreamOutput *stream)
     stream->printf("[G92:%1.3f,%1.3f,%1.3f]\n", std::get<0>(v[n+1]), std::get<1>(v[n+1]), std::get<2>(v[n+1]));
     stream->printf("[TL0:%1.3f]\n", std::get<2>(v[n+2]));
 
-    // TODO this should be the last probe position, which will be this if probe was the last thing done
-    float current_machine_pos[3];
-    THEKERNEL->robot->get_axis_position(current_machine_pos);
-    stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", current_machine_pos[X_AXIS], current_machine_pos[Y_AXIS], current_machine_pos[Z_AXIS], 0);
+    // this is the last probe position, updated when a probe completes, also stores the number of steps moved after a homing cycle
+    float px, py, pz;
+    uint8_t ps;
+    std::tie(px, py, pz, ps) = THEKERNEL->robot->get_last_probe_position();
+    stream->printf("[PRB:%1.3f,%1.3f,%1.3f:%d]\n", px, py, pz, ps);
 }
 
 // used to test out the get public data events


### PR DESCRIPTION
The alpha_max, beta_max, gamma_max are the angle that the actuators are at when homed.

home_offsets (set with M206) are the theta offsets for the homing angle.
M306 is used to set the theta angle offsets for the rotary delta.

When a rotary delta homes it uses the angle given in the alpha_max+home_offset[0] and uses the FK
(actuator_to_cartesian) to input the angles and get the cartesian XYZ for those angles, (added a
new call Robot::reset_actuator_position(a, b, c) where a b c are the theta angles for each actuator).

trim (M666) is disabled for rotary delta. (unless someone can explain to me how trim would
actually work in this case).

Cleaned up some modules that did not need to be modules. Config, Configurator. (saves some memory)

Smoothie now sends ok per line sent to it, not an ok per gcode as it used to, this is what most hosts expect. (it can be disabled with the config option ```ok_per_line false```)

Moved many modules to AHB0 as memory was running out during config if the config file was large, and/or many modules were enabled. Overall saves about 1k of main RAM, and moves it to AHB0.

The G38.x probe results are now remembered and returned with the $# query.

Some minor refactors.