### PR TITLE
Change the initial MR0 value which otherwise generates a large number…

### DIFF
--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -27,7 +27,6 @@ SlowTicker::SlowTicker(){
     max_frequency = 0;
     global_slow_ticker = this;
 
-
     // ISP button FIXME: WHy is this here?
     ispbtn.from_string("2.10")->as_input()->pull_up();
 
@@ -37,7 +36,7 @@ SlowTicker::SlowTicker(){
 
     // Configure the actual timer after setup to avoid race conditions
     LPC_SC->PCONP |= (1 << 22);     // Power Ticker ON
-    LPC_TIM2->MR0 = 10000;          // Initial dummy value for Match Register
+    LPC_TIM2->MR0 = 1000000;        // Initial dummy value for Match Register
     LPC_TIM2->MCR = 3;              // Match on MR0, reset on MR0
     LPC_TIM2->TCR = 1;              // Enable interrupt
     NVIC_EnableIRQ(TIMER2_IRQn);    // Enable interrupt handler
@@ -84,7 +83,6 @@ void SlowTicker::tick(){
     // TODO: This should have it's own module
     if (ispbtn.get() == 0)
         __debugbreak();
-
 }
 
 bool SlowTicker::flag_1s(){


### PR DESCRIPTION
The initial value of the Match Register 0 (MR0) for Timer 2 which is used for the SlowTicker is set to 10000. A large number of interrupts are fired during Smoothie initialization, before MR0 is correctly configured. This generates a large useless (or worse) number of calls (eg. second tick events and SlowTicker attached hooks).

This simple edit sets the initial value to 1000000 instead, removing this large number of useless spurious interrupts/timer based events.

NB: I noticed this as I was extending the SimpleShell module so that it feeds an ESP8266 module connected to the (non USB) UART every second, using the ON_SECOND_TICK event.  When Smoothieware boots, it initially emits the ON_SECOND_TICK event a large number of times, in less than one seconds. This is fixed with the commit above.

The "wifi module" code is in commit 35740cb434c7aeb1a63804a3a51c4d4c2d8053cd on my edge branch if you are interested.