### PR TITLE
remove the fnc from stepticker used for probe checking.

### DIFF
--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -63,7 +63,6 @@ StepTicker::StepTicker(){
     this->num_motors= 0;
     this->active_motor.reset();
     this->tick_cnt= 0;
-    this->probe_fnc= nullptr;
 }
 
 StepTicker::~StepTicker() {
@@ -192,24 +191,12 @@ void StepTicker::TIMER0_IRQHandler (void){
     LPC_TIM0->IR |= 1 << 0;
     tick_cnt++; // count number of ticks
 
-    // check if we are probing and if so check the probe status and force an end of move if it is triggered
-    if(probe_fnc && probe_fnc()) {
-        // we do exactly what we would do if stepping had finished
-        for (uint32_t motor = 0; motor < num_motors; motor++){
-            if(this->active_motor[motor]){
-                 this->motor[motor]->force_finish_move();
-             }
-        }
-
-    }else{
-
-        // Step pins NOTE takes 1.2us when nothing to step, 1.8-2us for one motor stepped and 2.6us when two motors stepped, 3.167us when three motors stepped
-        for (uint32_t motor = 0; motor < num_motors; motor++){
-            // send tick to all active motors
-            if(this->active_motor[motor] && this->motor[motor]->tick()){
-                // we stepped so schedule an unstep
-                this->unstep[motor]= 1;
-            }
+    // Step pins NOTE takes 1.2us when nothing to step, 1.8-2us for one motor stepped and 2.6us when two motors stepped, 3.167us when three motors stepped
+    for (uint32_t motor = 0; motor < num_motors; motor++){
+        // send tick to all active motors
+        if(this->active_motor[motor] && this->motor[motor]->tick()){
+            // we stepped so schedule an unstep
+            this->unstep[motor]= 1;
         }
     }
 

--- a/src/libs/StepTicker.h
+++ b/src/libs/StepTicker.h
@@ -46,8 +46,6 @@ class StepTicker{
 
         void start();
 
-        std::function<bool(void)> probe_fnc;
-
         friend class StepperMotor;
 
     private:

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -50,7 +50,7 @@ class StepperMotor {
         int  steps_to_target(float);
         uint32_t get_steps_to_move() const { return steps_to_move; }
         uint32_t get_stepped() const { return stepped; }
-        void force_finish_move();
+        void force_finish_move() { force_finish= true; }
 
         template<typename T> void attach( T *optr, uint32_t ( T::*fptr )( uint32_t ) ){
             Hook* hook = new Hook();
@@ -94,10 +94,11 @@ class StepperMotor {
         uint32_t fx_counter;
         uint32_t fx_ticks_per_step;
 
-        struct {
-            bool direction:1;
+        volatile struct {
             volatile bool is_move_finished:1; // Whether the move just finished
             volatile bool moving:1;
+            volatile bool force_finish:1; // set to force a move to finish early
+            bool direction:1;
             bool last_step_tick_valid:1; // set if the last step tick time is valid (ie the motor moved last block)
         };
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -120,6 +120,7 @@ Robot::Robot()
     this->wcs_offsets.fill(wcs_t(0.0F, 0.0F, 0.0F));
     this->g92_offset = wcs_t(0.0F, 0.0F, 0.0F);
     this->next_command_is_MCS = false;
+    this->disable_segmentation= false;
 }
 
 //Called when the module has just been loaded
@@ -904,7 +905,10 @@ bool Robot::append_line(Gcode *gcode, const float target[], float rate_mm_s )
     // The latter is more efficient and avoids splitting fast long lines into very small segments, like initial z move to 0, it is what Johanns Marlin delta port does
     uint16_t segments;
 
-    if(this->delta_segments_per_second > 1.0F) {
+    if(this->disable_segmentation) {
+        segments= 1;
+
+    } else if(this->delta_segments_per_second > 1.0F) {
         // enabled if set to something > 1, it is set to 0.0 by default
         // segment based on current speed and requested segments per second
         // the faster the travel speed the fewer segments needed

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -67,6 +67,7 @@ class Robot : public Module {
             bool inch_mode:1;                                 // true for inch mode, false for millimeter mode ( default )
             bool absolute_mode:1;                             // true for absolute mode ( default ), false for relative mode
             bool next_command_is_MCS:1;                       // set by G53
+            bool disable_segmentation:1;                      // set to disable segmentation
             uint8_t plane_axis_0:2;                           // Current plane ( XY, XZ, YZ )
             uint8_t plane_axis_1:2;
             uint8_t plane_axis_2:2;

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -53,21 +53,24 @@ private:
     void on_config_reload(void *argument);
     void accelerate(int c);
     void probe_XYZ(Gcode *gc, int axis);
-
+    uint32_t read_probe(uint32_t dummy);
     volatile float current_feedrate;
     float slow_feedrate;
     float fast_feedrate;
     float return_feedrate;
     float probe_height;
     float max_z;
+
+    Pin pin;
+    std::vector<LevelingStrategy*> strategies;
+    uint8_t debounce_count;
+
     volatile struct {
         volatile bool running:1;
         bool is_delta:1;
+        bool probing:1;
+        volatile bool probe_detected:1;
     };
-
-    Pin pin;
-    uint8_t debounce_count;
-    std::vector<LevelingStrategy*> strategies;
 };
 
 #endif /* ZPROBE_H_ */


### PR DESCRIPTION
use a timer to check for probe and tell steppers to stop moving with a flag.
allow disabling of segmentation which is required to allow G38.x to work this way.
G38.x now works on deltas.
Check if probe was hit or miss more reliably in G38.x