### PR TITLE
make module.h include platform_memory.h so if any module is allcoated…

### DIFF
--- a/src/libs/Module.h
+++ b/src/libs/Module.h
@@ -8,6 +8,8 @@
 #ifndef MODULE_H
 #define MODULE_H
 
+#include "platform_memory.h" // needed in case the mdouke is loaded in AHB0 so it can delete itself properly
+
 // See : http://smoothieware.org/listofevents
 // When adding a new event the virtual method needs to be defined in class Module and the method pointer need to be defined in
 // Module.cpp:16 in the same order

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@
 
 #include "version.h"
 #include "system_LPC17xx.h"
+#include "platform_memory.h"
 
 #include "mbed.h"
 
@@ -136,10 +137,10 @@ void init() {
     // Create and add main modules
     kernel->add_module( new(AHB0) Player() );
 
-    kernel->add_module( new CurrentControl() );
-    kernel->add_module( new KillButton() );
-    kernel->add_module( new PlayLed() );
-    kernel->add_module( new Endstops() );
+    kernel->add_module( new(AHB0) CurrentControl() );
+    kernel->add_module( new(AHB0) KillButton() );
+    kernel->add_module( new(AHB0) PlayLed() );
+    kernel->add_module( new(AHB0) Endstops() );
 
 
     // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
@@ -167,13 +168,13 @@ void init() {
     kernel->add_module( new Spindle() );
     #endif
     #ifndef NO_UTILS_PANEL
-    kernel->add_module( new Panel() );
+    kernel->add_module( new(AHB0) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new ZProbe() );
+    kernel->add_module( new(AHB0) ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
-    kernel->add_module( new SCARAcal() );
+    kernel->add_module( new(AHB0) SCARAcal() );
     #endif
     #ifndef NONETWORK
     kernel->add_module( new Network() );
@@ -223,6 +224,9 @@ void init() {
 
 
     kernel->add_module( &u );
+
+    // memory before cache is cleared
+    //SimpleShell::print_mem(kernel->streams);
 
     // clear up the config cache to save some memory
     kernel->config->config_cache_clear();

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -795,7 +795,7 @@ void Endstops::on_gcode_received(void *argument)
     if ( gcode->has_g && gcode->g == 28) {
         process_home_command(gcode);
 
-    }else if (gcode->has_m) {
+    } else if (gcode->has_m) {
 
         switch (gcode->m) {
             case 119: {

--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -602,7 +602,7 @@ void Extruder::on_block_begin(void *argument)
     this->current_position += this->travel_distance ;
 
     // round down, we take care of the fractional part next time
-    int steps_to_step = abs(floorf(this->steps_per_millimeter * (this->travel_distance + this->unstepped_distance) ));
+    int steps_to_step = abs((int)floorf(this->steps_per_millimeter * (this->travel_distance + this->unstepped_distance) ));
 
     // accumulate the fractional part
     if ( this->travel_distance > 0 ) {

--- a/src/modules/tools/temperaturecontrol/PID_Autotuner.cpp
+++ b/src/modules/tools/temperaturecontrol/PID_Autotuner.cpp
@@ -235,7 +235,7 @@ void PID_Autotuner::on_idle(void *)
 
     if (justchanged && peakCount >= 4) {
         // we've transitioned. check if we can autotune based on the last peaks
-        float avgSeparation = (std::abs(peaks[peakCount - 1] - peaks[peakCount - 2]) + std::abs(peaks[peakCount - 2] - peaks[peakCount - 3])) / 2;
+        float avgSeparation = (fabsf(peaks[peakCount - 1] - peaks[peakCount - 2]) + fabsf(peaks[peakCount - 2] - peaks[peakCount - 3])) / 2;
         THEKERNEL->streams->printf("// Cycle %d: max: %g, min: %g, avg separation: %g\n", peakCount, absMax, absMin, avgSeparation);
         if (peakCount > 3 && avgSeparation < (0.05 * (absMax - absMin))) {
             DEBUG_PRINTF("Stabilized\n");

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -344,7 +344,7 @@ bool DeltaCalibrationStrategy::calibrate_delta_radius(Gcode *gcode)
         float d = cmm - m;
         gcode->stream->printf("C-%d Z-ave:%1.4f delta: %1.3f\n", i, m, d);
 
-        if(abs(d) <= target){
+        if(fabsf(d) <= target){
             good= true;
             break; // resolution of success
         }

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -300,8 +300,8 @@ bool ThreePointStrategy::doProbing(StreamOutput *stream)
     }
 
     // if first point is not within tolerance report it, it should ideally be 0
-    if(abs(v[0][2]) > this->tolerance) {
-        stream->printf("WARNING: probe is not within tolerance: %f > %f\n", abs(v[0][2]), this->tolerance);
+    if(fabsf(v[0][2]) > this->tolerance) {
+        stream->printf("WARNING: probe is not within tolerance: %f > %f\n", fabsf(v[0][2]), this->tolerance);
     }
 
     // define the plane

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -27,6 +27,7 @@ public:
     void on_gcode_received(void *argument);
     void on_second_tick(void *);
     static bool parse_command(const char *cmd, string args, StreamOutput *stream);
+    static void print_mem(StreamOutput *stream) { mem_command("", stream); }
 
 private:
     static void ls_command(string parameters, StreamOutput *stream );


### PR DESCRIPTION
… in AHB0 and releases itself it dosn't crash as it will use the correct delete

allocate some more modules into AHB0 so as to reduce the chances of out of memory crash while config is setting up.
Still have very little memory left after all config, especially if there is a big config file.

use fabsf() for floats due to stdclib issues with abs() (using int version instead of float)