### PR TITLE
Make the operator delete in MemoryPool.cpp global so it catches all d…

### DIFF
--- a/src/libs/MemoryPool.h
+++ b/src/libs/MemoryPool.h
@@ -55,24 +55,4 @@ inline void  operator delete(void* p, MemoryPool& pool)
     pool.dealloc(p);
 }
 
-// this catches all usages of delete blah. The object's destructor is called before we get here
-// it first checks if the deleted object is part of a pool, and uses free otherwise.
-inline void  operator delete(void* p)
-{
-    MemoryPool* m = MemoryPool::first;
-    while (m)
-    {
-        if (m->has(p))
-        {
-            MDEBUG("Pool %p has %p, using dealloc()\n", m, p);
-            m->dealloc(p);
-            return;
-        }
-        m = m->next;
-    }
-
-    MDEBUG("no pool has %p, using free()\n", p);
-    free(p);
-}
-
 #endif /* _MEMORYPOOL_H */

--- a/src/libs/Module.h
+++ b/src/libs/Module.h
@@ -8,8 +8,6 @@
 #ifndef MODULE_H
 #define MODULE_H
 
-#include "platform_memory.h" // needed in case the mdouke is loaded in AHB0 so it can delete itself properly
-
 // See : http://smoothieware.org/listofevents
 // When adding a new event the virtual method needs to be defined in class Module and the method pointer need to be defined in
 // Module.cpp:16 in the same order


### PR DESCRIPTION
…elete calls regardless of MemoryPool.h being included.

This fixes cases where a Module is laoded into AHB0 and deletes itself as it is not enabled.
No longer needed to include paltform_memory.h in Module.h