### PR TITLE
Feature/delta grid strategy

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -272,7 +272,7 @@ int Robot::print_position(uint8_t subcode, char *buf, size_t bufsize) const
         n = snprintf(buf, bufsize, "LMS: X:%1.4f Y:%1.4f Z:%1.4f", last_milestone[X_AXIS], last_milestone[Y_AXIS], last_milestone[Z_AXIS]);
 
     } else if(subcode == 5) { // M114.4 print last machine position (which should be the same as M114.1 if axis are not moving and no level compensation)
-        n = snprintf(buf, bufsize, "LMCS: X:%1.4f Y:%1.4f Z:%1.4f", last_machine_position[X_AXIS], last_machine_position[Y_AXIS], last_machine_position[Z_AXIS]);
+        n = snprintf(buf, bufsize, "LMP: X:%1.4f Y:%1.4f Z:%1.4f", last_machine_position[X_AXIS], last_machine_position[Y_AXIS], last_machine_position[Z_AXIS]);
 
     } else {
         // get real time positions

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -603,15 +603,12 @@ void Robot::on_gcode_received(void *argument)
                     }
                     ++n;
                 }
-            }
-
-            if(gcode->m == 503) {
-                // just print the G92 setting as it is not saved
-                // TODO linuxcnc does seem to save G92, so maybe we should here too
+                // linuxcnc does seem to save G92, so we do too
+                // also it needs to be used to set Z0 on rotary deltas as M206/306 can't be used
                 if(g92_offset != wcs_t(0, 0, 0)) {
                     float x, y, z;
                     std::tie(x, y, z) = g92_offset;
-                    gcode->stream->printf("G92 X%f Y%f Z%f ; NOT SAVED\n", x, y, z);
+                    gcode->stream->printf("G92 X%f Y%f Z%f\n", x, y, z);
                 }
             }
             break;

--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -47,6 +47,9 @@ bool DeltaCalibrationStrategy::handleGcode(Gcode *gcode)
             // first wait for an empty queue i.e. no moves left
             THEKERNEL->conveyor->wait_for_empty_queue();
 
+            // turn off any compensation transform as it will be invalidated anyway by this
+            THEKERNEL->robot->compensationTransform= nullptr;
+
             if(!gcode->has_letter('R')) {
                 if(!calibrate_delta_endstops(gcode)) {
                     gcode->stream->printf("Calibration failed to complete, probe not triggered\n");

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -1,5 +1,63 @@
-// This code is derived from (and mostly copied from) Johann Rocholls code at https://github.com/jcrocholl/Marlin/blob/deltabot/Marlin/Marlin_main.cpp
-// license is the same as his code.
+/*
+ This code is derived from (and mostly copied from) Johann Rocholls code at https://github.com/jcrocholl/Marlin/blob/deltabot/Marlin/Marlin_main.cpp
+ license is the same as his code.
+
+    Summary
+    -------
+    Probes grid_size points in X and Y (total probes grid_size * grid_size) and stores the relative offsets from the 0,0 Z height
+    When enabled everymove will calcualte the Z offset based on interpolating the height offset within the grids nearest 4 points.
+
+    Configuration
+    -------------
+    The strategy must be enabled in the config as well as zprobe.
+
+      leveling-strategy.delta-grid.enable         true
+
+    The radius of the bed must be specified with...
+
+      leveling-strategy.delta-grid.radius        50
+
+      this needs to be at least as big as the maximum printing radius as moves outside of this will not be compensated for correctly
+
+    The size of the grid can be set with...
+
+      leveling-strategy.delta-grid.size        7
+
+      this is the X and Y size of the grid, it must be an odd number, the default is 7 which is 49 probe points
+
+   Optionally probe offsets from the nozzle or tool head can be defined with...
+
+      leveling-strategy.delta-grid.probe_offsets  0,0,0  # probe offsetrs x,y,z
+
+      they may also be set with M565 X0 Y0 Z0
+
+    If the saved grid is to be loaded on boot then this must be set in the config...
+
+      leveling-strategy.delta-grid.save        true
+
+      Then when M500 is issued it will save M375 which will cause the grid to be loaded on boot. The default is to not autoload the grid on boot
+
+    Optionally an initial_height can be set that tell the intial probe where to stop the fast decent before it probes, this should be around 5-10mm above the bed
+      leveling-strategy.delta-grid.initial_height  10
+
+
+    Usage
+    -----
+    G29 test probes in a spiral pattern within the radius producing a map of offsets, this can be imported into a graphing program to visualize the bed heights
+    G31 probes the grid and turns the compensation on, this will remain in effect until reset or M561/M370
+
+    M370 clears the grid and turns off compensation
+    M374 Save grid to /sd/delta.grid
+    M374.1 delete /sd/delta.grid
+    M375 Load the grid from /sd/delta.grid and enable compensation
+    M375.1 display the current grid
+    M561 clears the grid and turns off compensation
+    M565 defines the probe offsets from the nozzle or tool head
+
+
+    M500 saves the probe points
+    M503 displays the current settings
+*/
 
 #include "DeltaGridStrategy.h"
 

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -29,6 +29,8 @@
 #define probe_offsets_checksum       CHECKSUM("probe_offsets")
 #define initial_height_checksum      CHECKSUM("initial_height")
 
+#define GRIDFILE "/sd/delta.grid"
+
 DeltaGridStrategy::DeltaGridStrategy(ZProbe *zprobe) : LevelingStrategy(zprobe)
 {
     // TODO allocate grid in AHB0 or AHB1
@@ -65,7 +67,7 @@ bool DeltaGridStrategy::handleConfig()
 
 void DeltaGridStrategy::save_grid(StreamOutput *stream)
 {
-    FILE *fp= fopen("/sd/delta.grid", "w");
+    FILE *fp= fopen(GRIDFILE, "w");
     if(fp == NULL) {
         stream->printf("error:Failed to open grid\n");
         return;
@@ -85,7 +87,7 @@ void DeltaGridStrategy::save_grid(StreamOutput *stream)
 
 void DeltaGridStrategy::load_grid(StreamOutput *stream)
 {
-    FILE *fp= fopen("/sd/delta.grid", "r");
+    FILE *fp= fopen(GRIDFILE, "r");
     if(fp == NULL) {
         stream->printf("error:Failed to open grid\n");
         return;
@@ -123,11 +125,15 @@ bool DeltaGridStrategy::handleGcode(Gcode *gcode)
             // delete the compensationTransform in robot
             setAdjustFunction(false);
             reset_bed_level();
-            remove("delta.grid");
             return true;
 
-        } else if(gcode->m == 374) { // M374: Save grid
-            save_grid(gcode->stream);
+        } else if(gcode->m == 374) { // M374: Save grid, M374.1: delete saved grid
+            if(subcode == 1) {
+                remove(GRIDFILE);
+            }else{
+                save_grid(gcode->stream);
+            }
+
             return true;
 
         } else if(gcode->m == 375) { // M375: load grid, M375.1 display grid

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -66,6 +66,7 @@ bool DeltaGridStrategy::handleConfig()
     grid= (float *)AHB0.alloc(grid_size * grid_size * sizeof(float));
 
     reset_bed_level();
+
     // load the saved grid file
     if(save) load_grid(nullptr);
 
@@ -110,7 +111,7 @@ bool DeltaGridStrategy::load_grid(StreamOutput *stream)
             }
         }
     }
-    stream->printf("grid loaded from %s\n", GRIDFILE);
+    if(stream != nullptr) stream->printf("grid loaded from %s\n", GRIDFILE);
     fclose(fp);
     return true;
 }

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -1,0 +1,290 @@
+// This code is derived from (and mostly copied from) Johann Rocholls code at https://github.com/jcrocholl/Marlin/blob/deltabot/Marlin/Marlin_main.cpp
+// license is the same as his code.
+
+#include "DeltaGridStrategy.h"
+
+#include "Kernel.h"
+#include "Config.h"
+#include "Robot.h"
+#include "StreamOutputPool.h"
+#include "Gcode.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "PublicDataRequest.h"
+#include "PublicData.h"
+#include "Conveyor.h"
+#include "ZProbe.h"
+#include "nuts_bolts.h"
+#include "utils.h"
+
+#include <string>
+#include <algorithm>
+#include <cstdlib>
+#include <cmath>
+
+#define grid_radius_checksum CHECKSUM("radius")
+#define grid_resolution_checksum CHECKSUM("resolution")
+#define tolerance_checksum CHECKSUM("tolerance")
+#define save_checksum CHECKSUM("save")
+#define probe_offsets_checksum       CHECKSUM("probe_offsets")
+#define initial_height_checksum CHECKSUM("initial_height")
+
+DeltaGridStrategy::DeltaGridStrategy(ZProbe *zprobe) : LevelingStrategy(zprobe)
+{
+    //grid = nullptr;
+}
+
+DeltaGridStrategy::~DeltaGridStrategy()
+{
+    //delete[] grid;
+}
+
+bool DeltaGridStrategy::handleConfig()
+{
+    grid_radius = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_radius_checksum)->by_default(50.0F)->as_number();
+    //grid_resolution = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, grid_radius_checksum)->by_default(7)->as_number();
+    tolerance = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, tolerance_checksum)->by_default(0.03F)->as_number();
+    save = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, save_checksum)->by_default(false)->as_bool();
+    // the initial height above the bed we stop the intial move down after home to find the bed
+    // this should be a height that is enough that the probe will not hit the bed and is an offset from max_z (can be set to 0 if max_z takes into account the probe offset)
+    this->initial_height= THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, initial_height_checksum)->by_default(10)->as_number();
+
+    // Probe offsets xxx,yyy,zzz
+    {
+        std::string po = THEKERNEL->config->value(leveling_strategy_checksum, delta_grid_leveling_strategy_checksum, probe_offsets_checksum)->by_default("0,0,0")->as_string();
+        std::vector<float> v = parse_number_list(po.c_str());
+        if(v.size() >= 3) {
+            this->probe_offsets = std::make_tuple(v[0], v[1], v[2]);
+        }
+    }
+
+    return true;
+}
+
+
+bool DeltaGridStrategy::handleGcode(Gcode *gcode)
+{
+    if(gcode->has_g) {
+        if( gcode->g == 31 ) { // do probe (shol dbe 32 but use 31 as deltacalibration will usually also be enabled)
+             // first wait for an empty queue i.e. no moves left
+            THEKERNEL->conveyor->wait_for_empty_queue();
+
+            if(!doProbe(gcode)) {
+                gcode->stream->printf("Probe failed to complete, probe not triggered or other error\n");
+            } else {
+                gcode->stream->printf("Probe completed\n");
+            }
+            return true;
+        }
+
+    } else if(gcode->has_m) {
+        if(gcode->m == 561) { // M561: Set Identity Transform
+            // delete the compensationTransform in robot
+            setAdjustFunction(false);
+            reset_bed_level();
+            return true;
+
+        } else if(gcode->m == 565) { // M565: Set Z probe offsets
+            float x= 0, y= 0, z= 0;
+            if(gcode->has_letter('X')) x = gcode->get_value('X');
+            if(gcode->has_letter('Y')) y = gcode->get_value('Y');
+            if(gcode->has_letter('Z')) z = gcode->get_value('Z');
+            probe_offsets = std::make_tuple(x, y, z);
+            return true;
+
+        } else if(gcode->m == 500 || gcode->m == 503) { // M500 save, M503 display
+            float x, y, z;
+            gcode->stream->printf(";Probe offsets:\n");
+            std::tie(x, y, z) = probe_offsets;
+            gcode->stream->printf("M565 X%1.5f Y%1.5f Z%1.5f\n", x, y, z);
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// set the rectangle in which to probe
+#define DELTA_PROBABLE_RADIUS (grid_radius)
+#define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+#define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+#define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+#define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+
+// probe at the points of a lattice grid
+//#define AUTO_BED_LEVELING_GRID_POINTS (grid_resolution)
+#define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS - 1))
+#define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS - 1))
+
+#define X_PROBE_OFFSET_FROM_EXTRUDER std::get<0>(probe_offsets)
+#define Y_PROBE_OFFSET_FROM_EXTRUDER std::get<1>(probe_offsets)
+#define Z_PROBE_OFFSET_FROM_EXTRUDER std::get<2>(probe_offsets)
+
+void DeltaGridStrategy::setAdjustFunction(bool on)
+{
+    if(on) {
+        // set the compensationTransform in robot
+        THEKERNEL->robot->compensationTransform= [this](float target[3]) { doCompensation(target); };
+    }else{
+        // clear it
+        THEKERNEL->robot->compensationTransform= nullptr;
+    }
+}
+
+float DeltaGridStrategy::findBed()
+{
+    // home
+    zprobe->home();
+
+    // move to an initial position fast so as to not take all day, we move down max_z - initial_height, which is set in config, default 10mm
+    float deltaz= zprobe->getMaxZ() - initial_height;
+    zprobe->coordinated_move(NAN, NAN, -deltaz, zprobe->getFastFeedrate(), true); // relative move
+    zprobe->coordinated_move(0, 0, NAN, zprobe->getFastFeedrate()); // move to 0,0
+
+    // find bed at 0,0 run at slow rate so as to not hit bed hard
+    int s;
+    if(!zprobe->run_probe(s, false)) return NAN;
+
+    return zprobe->zsteps_to_mm(s) + deltaz - zprobe->getProbeHeight(); // distance to move from home to 5mm above bed
+}
+
+bool DeltaGridStrategy::doProbe(Gcode *gc)
+{
+    reset_bed_level();
+    setAdjustFunction(false);
+
+    float initial_z= findBed();
+    if(isnan(initial_z)) return false;
+    gc->stream->printf("initial Bed ht is %f mm\n", initial_z);
+
+    // we start the probe zprobe->getProbeHeight() above the bed
+    zprobe->home();
+    zprobe->coordinated_move(NAN, NAN, -initial_z, zprobe->getFastFeedrate(), true); // do a relative move from home to the point above the bed
+
+    for (int yCount = 0; yCount < AUTO_BED_LEVELING_GRID_POINTS; yCount++) {
+        float yProbe = FRONT_PROBE_BED_POSITION + AUTO_BED_LEVELING_GRID_Y * yCount;
+        int xStart, xStop, xInc;
+        if (yCount % 2) {
+            xStart = 0;
+            xStop = AUTO_BED_LEVELING_GRID_POINTS;
+            xInc = 1;
+        } else {
+            xStart = AUTO_BED_LEVELING_GRID_POINTS - 1;
+            xStop = -1;
+            xInc = -1;
+        }
+
+        for (int xCount = xStart; xCount != xStop; xCount += xInc) {
+            float xProbe = LEFT_PROBE_BED_POSITION + AUTO_BED_LEVELING_GRID_X * xCount;
+
+            // Avoid probing the corners (outside the round or hexagon print surface) on a delta printer.
+            float distance_from_center = sqrtf(xProbe * xProbe + yProbe * yProbe);
+            if (distance_from_center > DELTA_PROBABLE_RADIUS) continue;
+
+            int s;
+            if(!zprobe->doProbeAt(s, xProbe-X_PROBE_OFFSET_FROM_EXTRUDER, yProbe-Y_PROBE_OFFSET_FROM_EXTRUDER)) return false;
+            float measured_z = zprobe->getProbeHeight() - zprobe->zsteps_to_mm(s); // this is the delta z from bed at 0,0
+            grid[xCount][yCount] = measured_z;
+        }
+    }
+
+    extrapolate_unprobed_bed_level();
+    print_bed_level(gc->stream);
+
+    return true;
+}
+
+void DeltaGridStrategy::extrapolate_one_point(int x, int y, int xdir, int ydir)
+{
+    if (!isnan(grid[x][y])) {
+        return;  // Don't overwrite good values.
+    }
+    float a = 2 * grid[x + xdir][y] - grid[x + xdir * 2][y]; // Left to right.
+    float b = 2 * grid[x][y + ydir] - grid[x][y + ydir * 2]; // Front to back.
+    float c = 2 * grid[x + xdir][y + ydir] - grid[x + xdir * 2][y + ydir * 2]; // Diagonal.
+    float median = c;  // Median is robust (ignores outliers).
+    if (a < b) {
+        if (b < c) median = b;
+        if (c < a) median = a;
+    } else {  // b <= a
+        if (c < b) median = b;
+        if (a < c) median = a;
+    }
+    grid[x][y] = median;
+}
+
+// Fill in the unprobed points (corners of circular print surface)
+// using linear extrapolation, away from the center.
+void DeltaGridStrategy::extrapolate_unprobed_bed_level()
+{
+    int half = (AUTO_BED_LEVELING_GRID_POINTS - 1) / 2;
+    for (int y = 0; y <= half; y++) {
+        for (int x = 0; x <= half; x++) {
+            if (x + y < 3) continue;
+            extrapolate_one_point(half - x, half - y, x > 1 ? +1 : 0, y > 1 ? +1 : 0);
+            extrapolate_one_point(half + x, half - y, x > 1 ? -1 : 0, y > 1 ? +1 : 0);
+            extrapolate_one_point(half - x, half + y, x > 1 ? +1 : 0, y > 1 ? -1 : 0);
+            extrapolate_one_point(half + x, half + y, x > 1 ? -1 : 0, y > 1 ? -1 : 0);
+        }
+    }
+}
+
+void DeltaGridStrategy::doCompensation(float target[3])
+{
+    // Adjust print surface height by linear interpolation over the bed_level array.
+    int half = (AUTO_BED_LEVELING_GRID_POINTS - 1) / 2;
+    float grid_x = std::max(0.001F - half, std::min(half - 0.001F, target[X_AXIS] / AUTO_BED_LEVELING_GRID_X));
+    float grid_y = std::max(0.001F - half, std::min(half - 0.001F, target[Y_AXIS] / AUTO_BED_LEVELING_GRID_Y));
+    int floor_x = floorf(grid_x);
+    int floor_y = floorf(grid_y);
+    float ratio_x = grid_x - floor_x;
+    float ratio_y = grid_y - floor_y;
+    float z1 = grid[floor_x + half][floor_y + half];
+    float z2 = grid[floor_x + half][floor_y + half + 1];
+    float z3 = grid[floor_x + half + 1][floor_y + half];
+    float z4 = grid[floor_x + half + 1][floor_y + half + 1];
+    float left = (1 - ratio_y) * z1 + ratio_y * z2;
+    float right = (1 - ratio_y) * z3 + ratio_y * z4;
+    float offset = (1 - ratio_x) * left + ratio_x * right;
+
+    target[2] += offset;
+
+    /*
+    SERIAL_ECHOPGM("grid_x="); SERIAL_ECHO(grid_x);
+    SERIAL_ECHOPGM(" grid_y="); SERIAL_ECHO(grid_y);
+    SERIAL_ECHOPGM(" floor_x="); SERIAL_ECHO(floor_x);
+    SERIAL_ECHOPGM(" floor_y="); SERIAL_ECHO(floor_y);
+    SERIAL_ECHOPGM(" ratio_x="); SERIAL_ECHO(ratio_x);
+    SERIAL_ECHOPGM(" ratio_y="); SERIAL_ECHO(ratio_y);
+    SERIAL_ECHOPGM(" z1="); SERIAL_ECHO(z1);
+    SERIAL_ECHOPGM(" z2="); SERIAL_ECHO(z2);
+    SERIAL_ECHOPGM(" z3="); SERIAL_ECHO(z3);
+    SERIAL_ECHOPGM(" z4="); SERIAL_ECHO(z4);
+    SERIAL_ECHOPGM(" left="); SERIAL_ECHO(left);
+    SERIAL_ECHOPGM(" right="); SERIAL_ECHO(right);
+    SERIAL_ECHOPGM(" offset="); SERIAL_ECHOLN(offset);
+    */
+}
+
+
+// Print calibration results for plotting or manual frame adjustment.
+void DeltaGridStrategy::print_bed_level(StreamOutput *stream)
+{
+    for (int y = 0; y < AUTO_BED_LEVELING_GRID_POINTS; y++) {
+        for (int x = 0; x < AUTO_BED_LEVELING_GRID_POINTS; x++) {
+            stream->printf("%1.4f ", grid[x][y]);
+        }
+        stream->printf("\n");
+    }
+}
+
+// Reset calibration results to zero.
+void DeltaGridStrategy::reset_bed_level()
+{
+    for (int y = 0; y < AUTO_BED_LEVELING_GRID_POINTS; y++) {
+        for (int x = 0; x < AUTO_BED_LEVELING_GRID_POINTS; x++) {
+            grid[x][y] = NAN;
+        }
+    }
+}

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -67,9 +67,6 @@ bool DeltaGridStrategy::handleConfig()
 
     reset_bed_level();
 
-    // load the saved grid file
-    if(save) load_grid(nullptr);
-
     return true;
 }
 
@@ -203,7 +200,7 @@ bool DeltaGridStrategy::handleGcode(Gcode *gcode)
             float x, y, z;
             std::tie(x, y, z) = probe_offsets;
             gcode->stream->printf(";Probe offsets:\nM565 X%1.5f Y%1.5f Z%1.5f\n", x, y, z);
-            if(save && gcode->m == 500) gcode->stream->printf(";Load saved grid\nM375\n");
+            if(save && !isnan(grid[0])) gcode->stream->printf(";Load saved grid\nM375\n");
             return true;
         }
     }

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -35,12 +35,10 @@ private:
     float initial_height;
     float tolerance;
 
-    // TODO make this configurable once it all works
-    #define AUTO_BED_LEVELING_GRID_POINTS 7
-    float grid[AUTO_BED_LEVELING_GRID_POINTS][AUTO_BED_LEVELING_GRID_POINTS];
-    //uint8_t grid_resolution;
+    float *grid;
     float grid_radius;
     std::tuple<float, float, float> probe_offsets;
+    uint8_t grid_size;
 
     struct {
         bool save:1;

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -33,6 +33,8 @@ private:
 
     float initial_height;
     float tolerance;
+
+    // TODO make this configurable once it all works
     #define AUTO_BED_LEVELING_GRID_POINTS 7
     float grid[AUTO_BED_LEVELING_GRID_POINTS][AUTO_BED_LEVELING_GRID_POINTS];
     //uint8_t grid_resolution;

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -29,7 +29,7 @@ private:
     void doCompensation(float target[3]);
     void reset_bed_level();
     void save_grid(StreamOutput *stream);
-    void load_grid(StreamOutput *stream);
+    bool load_grid(StreamOutput *stream);
 
     float initial_height;
     float tolerance;

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "LevelingStrategy.h"
+
+#include <string.h>
+#include <tuple>
+
+#define delta_grid_leveling_strategy_checksum CHECKSUM("delta-grid-leveling")
+
+class StreamOutput;
+class Gcode;
+
+class DeltaGridStrategy : public LevelingStrategy
+{
+public:
+    DeltaGridStrategy(ZProbe *zprobe);
+    ~DeltaGridStrategy();
+    bool handleGcode(Gcode* gcode);
+    bool handleConfig();
+
+private:
+
+    void extrapolate_one_point(int x, int y, int xdir, int ydir);
+    void extrapolate_unprobed_bed_level();
+    bool doProbe(Gcode *gc);
+    float findBed();
+    void setAdjustFunction(bool on);
+    void print_bed_level(StreamOutput *stream);
+    void doCompensation(float target[3]);
+    void reset_bed_level();
+
+    float initial_height;
+    float tolerance;
+    #define AUTO_BED_LEVELING_GRID_POINTS 7
+    float grid[AUTO_BED_LEVELING_GRID_POINTS][AUTO_BED_LEVELING_GRID_POINTS];
+    //uint8_t grid_resolution;
+    float grid_radius;
+    std::tuple<float, float, float> probe_offsets;
+
+    struct {
+        bool save:1;
+    };
+};

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -30,6 +30,7 @@ private:
     void reset_bed_level();
     void save_grid(StreamOutput *stream);
     bool load_grid(StreamOutput *stream);
+    bool probe_spiral(int n, StreamOutput *stream);
 
     float initial_height;
     float tolerance;

--- a/src/modules/tools/zprobe/DeltaGridStrategy.h
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.h
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <tuple>
 
-#define delta_grid_leveling_strategy_checksum CHECKSUM("delta-grid-leveling")
+#define delta_grid_leveling_strategy_checksum CHECKSUM("delta-grid")
 
 class StreamOutput;
 class Gcode;
@@ -28,6 +28,8 @@ private:
     void print_bed_level(StreamOutput *stream);
     void doCompensation(float target[3]);
     void reset_bed_level();
+    void save_grid(StreamOutput *stream);
+    void load_grid(StreamOutput *stream);
 
     float initial_height;
     float tolerance;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -134,8 +134,8 @@ void ZProbe::on_config_reload(void *argument)
     this->slow_feedrate = THEKERNEL->config->value(zprobe_checksum, slow_feedrate_checksum)->by_default(5)->as_number(); // feedrate in mm/sec
     this->fast_feedrate = THEKERNEL->config->value(zprobe_checksum, fast_feedrate_checksum)->by_default(100)->as_number(); // feedrate in mm/sec
     this->return_feedrate = THEKERNEL->config->value(zprobe_checksum, return_feedrate_checksum)->by_default(0)->as_number(); // feedrate in mm/sec
+    this->reverse_z     = THEKERNEL->config->value(zprobe_checksum, reverse_z_direction_checksum)->by_default(false)->as_bool(); // Z probe moves in reverse direction
     this->max_z         = THEKERNEL->config->value(gamma_max_checksum)->by_default(500)->as_number(); // maximum zprobe distance
-    this->reverse_z     = THEKERNEL->config->value(reverse_z_direction_checksum)->by_default(false)->as_bool(); // Z probe moves in reverse direction (upside down rdelta)
 }
 
 bool ZProbe::wait_for_probe(int& steps)

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -198,8 +198,7 @@ bool ZProbe::run_probe(int& steps, float feedrate, float max_dist, bool reverse)
     float maxz= max_dist < 0 ? this->max_z*2 : max_dist;
 
     // move Z down
-    bool dir= !reverse_z;
-    if(reverse) dir= !dir;  // specified to move in opposite Z direction
+    bool dir= (!reverse_z != reverse); // xor
     STEPPER[Z_AXIS]->move(dir, maxz * Z_STEPS_PER_MM, 0); // probe in specified direction, no more than maxz
     if(this->is_delta || this->is_rdelta) {
         // for delta need to move all three actuators
@@ -231,7 +230,8 @@ bool ZProbe::return_probe(int steps, bool reverse)
     }
 
     this->current_feedrate = fr * Z_STEPS_PER_MM; // feedrate in steps/sec
-    bool dir= steps < 0;
+    bool dir= ((steps < 0) != reverse_z); // xor
+
     if(reverse) dir= !dir;
     steps= abs(steps);
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -32,6 +32,7 @@
 #include "DeltaCalibrationStrategy.h"
 #include "ThreePointStrategy.h"
 #include "ZGridStrategy.h"
+#include "DeltaGridStrategy.h"
 
 #define enable_checksum          CHECKSUM("enable")
 #define probe_pin_checksum       CHECKSUM("probe_pin")
@@ -107,11 +108,10 @@ void ZProbe::on_config_reload(void *argument)
                      found= true;
                      break;
 
-                // add other strategies here
-                //case zheight_map_strategy:
-                //     this->strategies.push_back(new ZHeightMapStrategy(this));
-                //     found= true;
-                //     break;
+                case delta_grid_leveling_strategy_checksum:
+                    this->strategies.push_back(new DeltaGridStrategy(this));
+                    found= true;
+                    break;
             }
             if(found) this->strategies.back()->handleConfig();
         }


### PR DESCRIPTION
Johann Rocholls Marlin delta grid compensation ported to Smoothie. With a few minor changes.
Main change is the grid is relative to offsets from the height at 0,0 so the probe Z offset is irrelevant.
However probes X and Y offsets are relevant and settable.

Additionally G92 is now saved with M500 if it is not 0,0,0
Reverse direction ZProbes are supported for G30