### PR TITLE
Allow setting for range for S parameter to control laser power

### DIFF
--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -135,8 +135,14 @@ void Laser::on_gcode_execute(void* argument){
             this->laser_on =  true;
         }
     }
+
     if ( gcode->has_letter('S' )){
-        this->laser_power = gcode->get_value('S');
+    	float requested_power = gcode->get_value('S') / this->laser_maximum_s_value;
+    	// Ensure we can't exceed maximum power
+    	if (requested_power > 1)
+    		requested_power = 1;
+
+        this->laser_power = requested_power;
     }
 
     if (this->ttl_used)

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -21,16 +21,18 @@
 #include "Gcode.h"
 #include "PwmOut.h" // mbed.h lib
 
-#define laser_module_enable_checksum        CHECKSUM("laser_module_enable")
-#define laser_module_pin_checksum           CHECKSUM("laser_module_pin")
-#define laser_module_pwm_pin_checksum       CHECKSUM("laser_module_pwm_pin")
-#define laser_module_ttl_pin_checksum    	CHECKSUM("laser_module_ttl_pin")
-#define laser_module_pwm_period_checksum    CHECKSUM("laser_module_pwm_period")
-#define laser_module_maximum_power_checksum CHECKSUM("laser_module_maximum_power")
-#define laser_module_minimum_power_checksum CHECKSUM("laser_module_minimum_power")
-#define laser_module_default_power_checksum CHECKSUM("laser_module_default_power")
-#define laser_module_tickle_power_checksum  CHECKSUM("laser_module_tickle_power")
-#define laser_module_max_power_checksum     CHECKSUM("laser_module_max_power")
+#define laser_module_enable_checksum          	CHECKSUM("laser_module_enable")
+#define laser_module_pin_checksum          	    CHECKSUM("laser_module_pin")
+#define laser_module_pwm_pin_checksum          	CHECKSUM("laser_module_pwm_pin")
+#define laser_module_ttl_pin_checksum    	   	CHECKSUM("laser_module_ttl_pin")
+#define laser_module_pwm_period_checksum   	    CHECKSUM("laser_module_pwm_period")
+#define laser_module_maximum_power_checksum    	CHECKSUM("laser_module_maximum_power")
+#define laser_module_minimum_power_checksum     CHECKSUM("laser_module_minimum_power")
+#define laser_module_default_power_checksum     CHECKSUM("laser_module_default_power")
+#define laser_module_tickle_power_checksum      CHECKSUM("laser_module_tickle_power")
+#define laser_module_max_power_checksum         CHECKSUM("laser_module_max_power")
+#define laser_module_maximum_s_value_checksum   CHECKSUM("laser_module_maximum_s_value")
+
 
 Laser::Laser(){
 }
@@ -81,7 +83,7 @@ void Laser::on_module_loaded() {
 
     this->pwm_pin->period_us(THEKERNEL->config->value(laser_module_pwm_period_checksum)->by_default(20)->as_number());
     this->pwm_pin->write(this->pwm_inverting ? 1 : 0);
-    this->laser_maximum_power = THEKERNEL->config->value(laser_module_maximum_power_checksum   )->by_default(1.0f)->as_number() ;
+    this->laser_maximum_power = THEKERNEL->config->value(laser_module_maximum_power_checksum)->by_default(1.0f)->as_number() ;
 
     // These config variables are deprecated, they have been replaced with laser_module_default_power and laser_module_minimum_power
     this->laser_minimum_power = THEKERNEL->config->value(laser_module_tickle_power_checksum)->by_default(0)->as_number() ;
@@ -90,6 +92,9 @@ void Laser::on_module_loaded() {
     // Load in our preferred config variables
     this->laser_minimum_power = THEKERNEL->config->value(laser_module_minimum_power_checksum)->by_default(this->laser_minimum_power)->as_number() ;
     this->laser_power = THEKERNEL->config->value(laser_module_default_power_checksum)->by_default(this->laser_power)->as_number() ;
+
+    // S value that represents maximum (default 1)
+    this->laser_maximum_s_value = THEKERNEL->config->value(laser_module_maximum_s_value_checksum)->by_default(1.0f)->as_number() ;
 
     //register for events
     this->register_for_event(ON_GCODE_EXECUTE);

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -39,6 +39,7 @@ class Laser : public Module{
         float            laser_maximum_power; // maximum allowed laser power to be output on the pwm pin
         float            laser_minimum_power; // value used to tickle the laser on moves.  Also minimum value for auto-scaling
         float            laser_power;     // current laser power
+        float            laser_maximum_s_value; // Value of S code that will represent max power
 };
 
 #endif

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -24,6 +24,7 @@ class Laser : public Module{
         void on_block_begin(void* argument);
         void on_gcode_execute(void* argument);
         void on_speed_change(void* argument);
+        void on_halt(void* argument);
 
     private:
         void set_proportional_power();


### PR DESCRIPTION
A couple more small items for the laser module.

f95c9fc - Bug fix so the laser TTL pin stays on for the whole of an arc that comprises multiple blocks. Also ensures that TTL is turned off in the case of a HALT event, addressing issue #455.

5a2b237 and 15ddf50 - New optional laser-module_maximum_s_value that allows definition of what S value represents maximum laser power. Suits applications like CamBam that need an integer. Requested by another forum user. Defaults to existing 0-1 range if omitted.