### PR TITLE
Fix saving of G92 with M500

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -421,6 +421,14 @@ void Robot::on_gcode_received(void *argument)
                     // reset G92 offsets to 0
                     g92_offset = wcs_t(0, 0, 0);
 
+                } else if(gcode->subcode == 3) {
+                    // initialize G92 to the specified values, only used for saving it with M500
+                    float x= 0, y= 0, z= 0;
+                    if(gcode->has_letter('X')) x= gcode->get_value('X');
+                    if(gcode->has_letter('Y')) y= gcode->get_value('Y');
+                    if(gcode->has_letter('Z')) z= gcode->get_value('Z');
+                    g92_offset = wcs_t(x, y, z);
+
                 } else {
                     // standard setting of the g92 offsets, making current WCS position whatever the coordinate arguments are
                     float x, y, z;
@@ -609,12 +617,12 @@ void Robot::on_gcode_received(void *argument)
                     }
                     ++n;
                 }
-                // linuxcnc does seem to save G92, so we do too
-                // also it needs to be used to set Z0 on rotary deltas as M206/306 can't be used
+                // linuxcnc saves G92, so we do too
+                // also it needs to be used to set Z0 on rotary deltas as M206/306 can't be used, so saving it is necessary
                 if(g92_offset != wcs_t(0, 0, 0)) {
                     float x, y, z;
                     std::tie(x, y, z) = g92_offset;
-                    gcode->stream->printf("G92 X%f Y%f Z%f\n", x, y, z);
+                    gcode->stream->printf("G92.3 X%f Y%f Z%f\n", x, y, z); // sets G92 to the specified values
                 }
             }
             break;


### PR DESCRIPTION
Added G92.3 which sets the G92 offsets to the supplied X Y Z and is what M500 uses to save it.