### PR TITLE
Fix mistaken fwrite (should be fread)

### DIFF
--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -192,7 +192,7 @@ bool DeltaGridStrategy::load_grid(StreamOutput *stream)
         return false;
     }
 
-    if(fwrite(&radius, sizeof(float), 1, fp) != 1) {
+    if(fread(&radius, sizeof(float), 1, fp) != 1) {
         stream->printf("error:Failed to read grid radius\n");
         fclose(fp);
         return false;


### PR DESCRIPTION
This should fix the "Failed to read grid radius" error when using M375 with delta-grid.