### PR TITLE
motor_driver_control: user configurable current sense resistor

### DIFF
--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
@@ -29,6 +29,7 @@
 
 #define current_checksum               CHECKSUM("current")
 #define max_current_checksum           CHECKSUM("max_current")
+#define sense_resistor_checksum        CHECKSUM("sense_resistor")
 
 #define microsteps_checksum            CHECKSUM("microsteps")
 #define decay_mode_checksum            CHECKSUM("decay_mode")
@@ -136,6 +137,7 @@ bool MotorDriverControl::config_module(uint16_t cs)
     //current_factor= THEKERNEL->config->value(motor_driver_control_checksum, cs, current_factor_checksum )->by_default(1.0F)->as_number();
 
     current= THEKERNEL->config->value(motor_driver_control_checksum, cs, current_checksum )->by_default(1000)->as_number(); // in mA
+    sense_resistor= THEKERNEL->config->value(motor_driver_control_checksum, cs, sense_resistor_checksum )->by_default(50)->as_number(); // in mOhm
     microsteps= THEKERNEL->config->value(motor_driver_control_checksum, cs, microsteps_checksum )->by_default(16)->as_number(); // 1/n
     //decay_mode= THEKERNEL->config->value(motor_driver_control_checksum, cs, decay_mode_checksum )->by_default(1)->as_number();
 
@@ -309,11 +311,13 @@ void MotorDriverControl::initialize_chip()
 {
     // send initialization sequence to chips
     if(chip == DRV8711) {
+        drv8711->set_resistor(sense_resistor);
         drv8711->init();
         set_current(current);
         set_microstep(microsteps);
 
     }else if(chip == TMC2660){
+        tmc26x->setResistor(sense_resistor);
         tmc26x->init();
         set_current(current);
         set_microstep(microsteps);

--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.h
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.h
@@ -58,6 +58,7 @@ class MotorDriverControl : public Module {
         uint32_t max_current; // in milliamps
         uint32_t current; // in milliamps
         uint32_t microsteps;
+        unsigned int sense_resistor; // in mOhm
 
         char designator;
 

--- a/src/modules/utils/motordrivercontrol/drivers/DRV8711/drv8711.cpp
+++ b/src/modules/utils/motordrivercontrol/drivers/DRV8711/drv8711.cpp
@@ -85,6 +85,17 @@ void DRV8711DRV::init (uint16_t gain)
     WriteAllRegisters();
 }
 
+void DRV8711DRV::set_resistor(unsigned int resistor)
+{
+    //store the current sense resistor value for later use
+    this->resistor = resistor;
+}
+
+unsigned int DRV8711DRV::get_resistor()
+{
+    return this->resistor;
+}
+
 void DRV8711DRV::set_current(uint32_t currentma)
 {
     // derive torque and gain from current

--- a/src/modules/utils/motordrivercontrol/drivers/DRV8711/drv8711.h
+++ b/src/modules/utils/motordrivercontrol/drivers/DRV8711/drv8711.h
@@ -20,6 +20,12 @@ public:
   bool set_raw_register(StreamOutput *stream, uint32_t reg, uint32_t val);
   bool check_alarm();
 
+  // returns current sense resistor value in mOhm
+  unsigned int get_resistor();
+
+  // set current sense resistor value in mOhm
+  void set_resistor(unsigned int resistor);
+
 private:
 
   uint16_t ReadWriteRegister(uint8_t dataHi, uint8_t dataLo);
@@ -139,7 +145,7 @@ private:
   STATUS_Register_t  G_STATUS_REG;
 
   std::function<int(uint8_t *b, int cnt, uint8_t *r)> spi;
-  float resistor{0.05};
+  unsigned int resistor{50}; // current sense resitor value in milliohm
   std::bitset<8> error_reported;
   uint8_t gain{20};
 


### PR DESCRIPTION
This adds a "sense_resistor" configuration key (set in mΩ) to the motor_driver_control module.
This impacts/works with both the TMC26X and the DRV8711 drivers.

The default value I chose here (50mΩ) agrees with what was previously set by the TMC26X and the DRV8711 drivers, so this change should give nobody any unpleasant surprises.