### PR TITLE
stop ignoring failed temperature readings

### DIFF
--- a/src/modules/tools/temperaturecontrol/max31855.cpp
+++ b/src/modules/tools/temperaturecontrol/max31855.cpp
@@ -66,12 +66,6 @@ float Max31855::get_temperature()
 
 	float temp = read_temp();
 
-	// Discard occasional errors...
-	if(!isinf(temp))
-	{
-		readings.push_back(temp);
-	}
-
 	if(readings.size()==0) return infinityf();
 
 	float sum = 0;


### PR DESCRIPTION
For https://github.com/Smoothieware/Smoothieware/issues/894 .
Maybe this breaks max31855 in practice, but I don't really care. It makes it safer.