### PR TITLE
BuildShell usable from Eclipse

### DIFF
--- a/linux_install
+++ b/linux_install
@@ -84,7 +84,11 @@ echo "SCRIPT_PATH=\${SCRIPT_PATH%/*}">>$BUILDSHELL_CMD
 echo "cd \$SCRIPT_PATH">>$BUILDSHELL_CMD
 echo "SCRIPT_PATH=\$PWD">>$BUILDSHELL_CMD
 echo "export PATH=\$SCRIPT_PATH/gcc-arm-none-eabi/bin:\$PATH">>$BUILDSHELL_CMD
-echo "exec bash">>$BUILDSHELL_CMD
+echo "if (( \$# )); then">>$BUILDSHELL_CMD
+echo "  \$@ # so it supports ./BuildShell make, e.g. for calling from an Eclipse builder">>$BUILDSHELL_CMD
+echo "else">>$BUILDSHELL_CMD
+echo "  exec bash">>$BUILDSHELL_CMD
+echo "fi">>$BUILDSHELL_CMD
 chmod +x $BUILDSHELL_CMD
 
 echo Cleaning up intermediate files...


### PR DESCRIPTION
Running on Linux, I found no way to use BuildShell for building from Eclipse with an external builder.
This modification is compatible with existing behavior: When no arguments is given to BuildShell, the behavior is left unchanged. Else, additional arguments are executed directly from BuildShell instead of the existing "exec bash".
This way Eclipse can run "./BuildShell make" or "./BuildShell make clean".

Admittedly, the name "BuildShell" becomes misleading. And I did not check Mac & Windows platforms.