### PR TITLE
Z-offset repairs

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -763,10 +763,33 @@ void Robot::distance_in_gcode_is_known(Gcode * gcode)
 // so in those cases the final position is compensated.
 void Robot::reset_axis_position(float x, float y, float z)
 {
+    //float target[3];
+
+
+
     // these are set to the same as compensation was not used to get to the current position
     last_machine_position[X_AXIS]= last_milestone[X_AXIS] = x;
     last_machine_position[Y_AXIS]= last_milestone[Y_AXIS] = y;
     last_machine_position[Z_AXIS]= last_milestone[Z_AXIS] = z;
+
+    // last machine position should actually include compensation if applicable to prevent transform jumping...
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(last_machine_position);
+    }
+/*
+    // unity transform by default
+    memcpy(transformed_target, target, sizeof(transformed_target));
+
+    // check function pointer and call if set to transform the target to compensate for bed
+    if(compensationTransform) {
+        // some compensation strategies can transform XYZ, some just change Z
+        compensationTransform(transformed_target);
+    }
+
+*/
+
 
     // now set the actuator positions to match
     ActuatorCoordinates actuator_pos;
@@ -774,6 +797,7 @@ void Robot::reset_axis_position(float x, float y, float z)
     for (size_t i = 0; i < actuators.size(); i++)
         actuators[i]->change_last_milestone(actuator_pos[i]);
 }
+
 
 // Reset the position for an axis (used in homing)
 void Robot::reset_axis_position(float position, int axis)

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -819,6 +819,97 @@ void Endstops::set_homing_offset(Gcode *gcode)
     gcode->stream->printf("Homing Offset: X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
 }
 
+void Endstops::set_relative_homing_offset(Gcode *gcode)
+{
+    // Similar to M306 but sets Homing offsets relatively based on current position
+    // Can be used in on the fly XYZ calibration during printing.
+    float cartesian[3];
+    std::vector<std::pair<char, float>> params;
+
+    THEKERNEL->robot->get_axis_position(cartesian);    // get actual position from robot
+
+    if (gcode->has_letter('X')) {
+        home_offset[0] -= gcode->get_value('X');
+        params.push_back({'X', gcode->get_value('X')});
+    }
+
+    if (gcode->has_letter('Y')) {
+        home_offset[1] -= gcode->get_value('Y');
+        params.push_back({'Y', gcode->get_value('Y')});
+    }
+
+    if (gcode->has_letter('Z')) {
+        home_offset[2] -= gcode->get_value('Z');
+        params.push_back({'Z', gcode->get_value('Z')});
+    }
+
+
+        // Do an axis move in the magnitude of the calibration value, without changing the current actual position
+    if(!params.empty()) {
+        params.insert(params.begin(), {'G', 0});
+        // use X slow rate to move, Z should have a max speed set anyway
+        params.push_back({'F', this->slow_rates[X_AXIS] * 60.0F});
+        char gcode_buf[64];
+        append_parameters(gcode_buf, params, sizeof(gcode_buf));
+        Gcode gc(gcode_buf, &(StreamOutput::NullStream));
+        THEKERNEL->robot->push_state();
+        THEKERNEL->robot->absolute_mode = false; // needs to be relative mode
+        THEKERNEL->robot->on_gcode_received(&gc); // send to robot directly
+        // Wait for above to finish
+        THEKERNEL->conveyor->wait_for_empty_queue();
+        THEKERNEL->robot->pop_state();
+    }
+
+
+    for (int i = X_AXIS; i <= Z_AXIS; i++) {  // Reset actual position to the initial values.
+      if (gcode->has_letter('X'+i))
+        THEKERNEL->robot->reset_axis_position(cartesian[i], i);
+    }
+
+    gcode->stream->printf("Homing Offset: X %5.3f Y %5.3f Z %5.3f\n", home_offset[0], home_offset[1], home_offset[2]);
+}
+
+/*void Endstops::back_off_home(char axes_to_move)
+{
+    std::vector<std::pair<char, float>> params;
+    this->status = BACK_OFF_HOME;
+
+    // these are handled differently
+    if(is_delta) {
+        // Move off of the endstop using a regular relative move in Z only
+        params.push_back({'Z', this->retract_mm[Z_AXIS] * (this->home_direction[Z_AXIS] ? 1 : -1)});
+
+    } else {
+        // cartesians, concatenate all the moves we need to do into one gcode
+        for( int c = X_AXIS; c <= Z_AXIS; c++ ) {
+            if( ((axes_to_move >> c ) & 1) == 0) continue; // only for axes we asked to move
+
+            // if not triggered no need to move off
+            if(this->limit_enable[c] && debounced_get(c + (this->home_direction[c] ? 0 : 3)) ) {
+                params.push_back({c + 'X', this->retract_mm[c] * (this->home_direction[c] ? 1 : -1)});
+            }
+        }
+    }
+
+    if(!params.empty()) {
+        // Move off of the endstop using a regular relative move
+        params.insert(params.begin(), {'G', 0});
+        // use X slow rate to move, Z should have a max speed set anyway
+        params.push_back({'F', this->slow_rates[X_AXIS] * 60.0F});
+        char gcode_buf[64];
+        append_parameters(gcode_buf, params, sizeof(gcode_buf));
+        Gcode gc(gcode_buf, &(StreamOutput::NullStream));
+        THEKERNEL->robot->push_state();
+        THEKERNEL->robot->absolute_mode = false; // needs to be relative mode
+        THEKERNEL->robot->on_gcode_received(&gc); // send to robot directly
+        // Wait for above to finish
+        THEKERNEL->conveyor->wait_for_empty_queue();
+        THEKERNEL->robot->pop_state();
+    }
+
+    this->status = NOT_HOMING;
+}*/
+
 // Start homing sequences by response to GCode commands
 void Endstops::on_gcode_received(void *argument)
 {
@@ -851,7 +942,12 @@ void Endstops::on_gcode_received(void *argument)
             case 306: // set homing offset based on current position
                 if(is_rdelta) return; // RotaryDeltaCalibration module will handle this
 
-                set_homing_offset(gcode);
+                if (gcode->subcode == 1){
+                    set_relative_homing_offset(gcode);
+                }
+                else {
+                    set_homing_offset(gcode);
+                }
                 break;
 
             case 500: // save settings

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -39,6 +39,7 @@ class Endstops : public Module{
         bool debounced_get(int pin);
         void process_home_command(Gcode* gcode);
         void set_homing_offset(Gcode* gcode);
+        void set_relative_homing_offset(Gcode* gcode);
 
         float homing_position[3];
         float home_offset[3];


### PR DESCRIPTION
Added M306.1 to be able to jog Z calibration during printing
Repaired reset_axis_position in robot to take compensation transform
into account.

This fixes M306 without homing: ZGrid for PCBs (#886)