### PR TITLE
Add option to restrict Play file selector to a subdir.

### DIFF
--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -65,6 +65,8 @@
 #define bed_temp_checksum    CHECKSUM("bed_temperature")
 #define panel_display_message_checksum CHECKSUM("display_message")
 
+#define root_path_checksum         CHECKSUM("root_path")
+
 Panel* Panel::instance= nullptr;
 
 #define MENU_MODE                  0
@@ -179,6 +181,7 @@ void Panel::on_module_loaded()
 //    this->back_button.set_longpress_delay(longpress_delay);
 //    this->pause_button.set_longpress_delay(longpress_delay);
 
+    this->root_path = THEKERNEL->config->value( panel_checksum, root_path_checksum )->by_default("/")->as_string();
 
     THEKERNEL->slow_ticker->attach( 50,  this, &Panel::button_tick );
     if(lcd->encoderReturnsDelta()) {

--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -88,6 +88,9 @@ class Panel : public Module {
         LcdBase* lcd;
         PanelScreen* custom_screen;
 
+        // path prefix to restrict Play panel to
+        std::string root_path;
+
         using encoder_cb_t= std::function<void(int ticks)>;
         bool enter_direct_encoder_mode(encoder_cb_t fnc);
 

--- a/src/modules/utils/panel/screens/FileScreen.cpp
+++ b/src/modules/utils/panel/screens/FileScreen.cpp
@@ -31,8 +31,16 @@ void FileScreen::on_enter()
 {
     THEPANEL->lcd->clear();
 
-    // Default folder to enter
-    this->enter_folder(THEKERNEL->current_path.c_str());
+    // Check if current_path is underneath the virtual root (if panel.root_path option is used)
+    if (THEKERNEL->current_path.compare(0, THEPANEL->root_path.size(), THEPANEL->root_path) == 0)
+    {
+        this->enter_folder(THEKERNEL->current_path.c_str());
+    }
+    else
+    {
+        // disallow paths outside the virtual root
+        this->enter_folder(THEPANEL->root_path.c_str());
+    }
 }
 
 void FileScreen::on_exit()
@@ -90,7 +98,7 @@ void FileScreen::clicked_line(uint16_t line)
 {
     if ( line == 0 ) {
         string path= THEKERNEL->current_path;
-        if(path == "/") {
+        if(path == THEPANEL->root_path || path == "/") {
             // Exit file navigation
             THEPANEL->enter_screen(this->parent);
         } else {


### PR DESCRIPTION
In bulletproofing and streamlining the workflow of my hackerspace's laser cutter that is using a smoothieboard, I want to hide the details of the filesystem on the sd card and only show users the directory that our gcode generator uploads to.

This patch adds a "panel.root_path" configuration option that is used as a virtual root by the Play menu. It opens the configured path (or THEKERNEL->current_dir if it's underneath that path) when the Play menu is selected, and exits when you try to go to it's parent, as if the directory was actually the root of the filesystem. Otherwise you can still navigate into subdirectories and back out again as normal, and if the option is unspecified it defaults to the normal root dir "/".
