### PR TITLE
Fix resume so it uses G53 to restore position

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -213,7 +213,7 @@ void Robot::load_config()
         actuators[a] = new StepperMotor(pins[0], pins[1], pins[2]);
 
         actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
-        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number());
+        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number()/60.0F); // it is in mm/min and converted to mm/sec
     }
 
     check_max_actuator_speeds(); // check the configs are sane

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -647,11 +647,13 @@ void Player::resume_command(string parameters, StreamOutput *stream )
     // force absolute mode for restoring position, then set to the saved relative/absolute mode
     THEKERNEL->robot->absolute_mode= true;
     {
+        // NOTE position was saved in MCS so must use G53 to restore position
         char buf[128];
-        int n = snprintf(buf, sizeof(buf), "G1 X%f Y%f Z%f", saved_position[0], saved_position[1], saved_position[2]);
-        string g(buf, n);
-        Gcode gcode(g, &(StreamOutput::NullStream));
-        THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode );
+        snprintf(buf, sizeof(buf), "G53 G0 X%f Y%f Z%f", saved_position[0], saved_position[1], saved_position[2]);
+        struct SerialMessage message;
+        message.message = buf;
+        message.stream = &(StreamOutput::NullStream);
+        THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
     }
     THEKERNEL->robot->absolute_mode= abs_mode;
 


### PR DESCRIPTION
Fix the alpha_max_speed config setting so it is in mm/min not mm/sec (reverting bug introduced by PR #759