### PR TITLE
Implementation of software movement limits/endstops.

### DIFF
--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -117,11 +117,17 @@ class Robot : public Module {
         // of grbl, and should be on the order or greater than the size of the buffer to help with the
         // computational efficiency of generating arcs.
         int arc_correction;                                   // Setting : how often to rectify arc computation
-        float max_speeds[3];                                 // Setting : max allowable speed in mm/m for each axis
+        float max_speeds[3];                                  // Setting : max allowable speed in mm/m for each axis
 
+        bool homing_done[3];                                  // G28 was executed for specified axis?
+        bool soft_limits_enable;                              // Setting : enable software limits for movement  
+        float soft_limits_max[3];                             // Setting : max allowable position for each axis
+        float soft_limits_min[3];                             // Setting : min allowable position for each axis        
+        
         // Used by Stepper, Planner
         friend class Planner;
         friend class Stepper;
+        friend class Endstops;
 };
 
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -615,6 +615,17 @@ void Endstops::home(char axes_to_move)
         STEPPER[c]->move(0, 0);
     }
     this->status = NOT_HOMING;
+    
+    // if homing was previously done for our axis, don't reset it
+    if (false == THEKERNEL->robot->homing_done[X_AXIS] && (axes_to_move & 0x01)) {
+        THEKERNEL->robot->homing_done[X_AXIS] = true;
+    }
+    if (false == THEKERNEL->robot->homing_done[Y_AXIS] && (axes_to_move & 0x02)) {
+        THEKERNEL->robot->homing_done[Y_AXIS] = true;
+    }
+    if (false == THEKERNEL->robot->homing_done[Z_AXIS] && (axes_to_move & 0x04)) {
+        THEKERNEL->robot->homing_done[Z_AXIS] = true;
+    }
 }
 
 void Endstops::process_home_command(Gcode* gcode)


### PR DESCRIPTION
Feature that should be present from the beginning, IMO. If enabled, will limit movements within specified XYZ positions (after homing is done). Just to prevent breaking something.
I'm not entirely sure, if it's done right - after all, first time when I saw smoothie code was few hours ago, so my knowledge about it's internal magic is limited.

By the way, did You know, that config params checksums can collide? And that can lead to very strange debug problems. Two hours of fighting with enabled, but magically self unloading endstops module.