### PR TITLE
Fix Homing when in G20

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -345,6 +345,7 @@ void Endstops::back_off_home(char axes_to_move)
         append_parameters(gcode_buf, params, sizeof(gcode_buf));
         Gcode gc(gcode_buf, &(StreamOutput::NullStream));
         THEKERNEL->robot->push_state();
+		THEKERNEL->robot->inch_mode = false;     // needs to be in mm
         THEKERNEL->robot->absolute_mode = false; // needs to be relative mode
         THEKERNEL->robot->on_gcode_received(&gc); // send to robot directly
         // Wait for above to finish
@@ -367,8 +368,8 @@ void Endstops::move_to_origin(char axes_to_move)
     // Move to center using a regular move, use slower of X and Y fast rate
     float rate = std::min(this->fast_rates[0], this->fast_rates[1]) * 60.0F;
     char buf[32];
-    snprintf(buf, sizeof(buf), "G53 G0 X0 Y0 F%1.4f", rate); // must use machine coordinates in case G92 or WCS is in effect
     THEKERNEL->robot->push_state();
+	snprintf(buf, sizeof(buf), "G21 G53 G0 X0 Y0 F%1.4f", rate); // must use mm units & machine coordinates in case G92 or WCS is in effect
     struct SerialMessage message;
     message.message = buf;
     message.stream = &(StreamOutput::NullStream);

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -345,7 +345,7 @@ void Endstops::back_off_home(char axes_to_move)
         append_parameters(gcode_buf, params, sizeof(gcode_buf));
         Gcode gc(gcode_buf, &(StreamOutput::NullStream));
         THEKERNEL->robot->push_state();
-		THEKERNEL->robot->inch_mode = false;     // needs to be in mm
+        THEKERNEL->robot->inch_mode = false;     // needs to be in mm
         THEKERNEL->robot->absolute_mode = false; // needs to be relative mode
         THEKERNEL->robot->on_gcode_received(&gc); // send to robot directly
         // Wait for above to finish
@@ -369,7 +369,8 @@ void Endstops::move_to_origin(char axes_to_move)
     float rate = std::min(this->fast_rates[0], this->fast_rates[1]) * 60.0F;
     char buf[32];
     THEKERNEL->robot->push_state();
-	snprintf(buf, sizeof(buf), "G21 G53 G0 X0 Y0 F%1.4f", rate); // must use mm units & machine coordinates in case G92 or WCS is in effect
+    THEKERNEL->robot->inch_mode = false;     // needs to be in mm
+    snprintf(buf, sizeof(buf), "G53 G0 X0 Y0 F%1.4f", rate); // must use machine coordinates in case G92 or WCS is in effect
     struct SerialMessage message;
     message.message = buf;
     message.stream = &(StreamOutput::NullStream);


### PR DESCRIPTION
This is a bug fix when homing when in G20  mode.  It was making the
final move in inches instead of mm.  Homing should always bring you to
the same exact point whether you are in G20 or G21.  See
https://github.com/Smoothieware/Smoothieware/issues/952