### PR TITLE
G28.1 recovery

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -637,7 +637,11 @@ void Endstops::process_home_command(Gcode* gcode)
 
     } else if(gcode->subcode == 1) { // G28.1 set pre defined position
         // saves current position in absolute machine coordinates
-        THEKERNEL->robot->get_axis_position(saved_position);
+        THEROBOT->get_axis_position(saved_position); // Only XY are used
+        // Note the following is only meant to be used for recovering a saved position from config-override
+        // Not a standard Gcode and not to be relied on
+        if (gcode->has_letter('X')) saved_position[X_AXIS] = gcode->get_value('X');
+        if (gcode->has_letter('Y')) saved_position[Y_AXIS] = gcode->get_value('Y');
         return;
 
     } else if(gcode->subcode == 3) { // G28.3 is a smoothie special it sets manual homing
@@ -868,7 +872,7 @@ void Endstops::on_gcode_received(void *argument)
                     gcode->stream->printf(";Max Z\nM665 Z%1.3f\n", this->homing_position[2]);
                 }
                 if(saved_position[X_AXIS] != 0 || saved_position[Y_AXIS] != 0) {
-                    gcode->stream->printf(";predefined position:\nG28.1 X%1.4f Y%1.4f Z%1.4f\n", saved_position[X_AXIS], saved_position[Y_AXIS], saved_position[Z_AXIS]);
+                    gcode->stream->printf(";predefined position:\nG28.1 X%1.4f Y%1.4f\n", saved_position[X_AXIS], saved_position[Y_AXIS]);
                 }
                 break;
 


### PR DESCRIPTION
Recover G28.1 Positions from config-overide file

Requesting these be included in the current edge version for two reasons:

1. I am using these predefined positions on my machines in my homing routine, having them in the official edge version as well as edge-unstable will allow me to switch between the two versions and home correctly for testing purposes.

2. I wanted to contribute to the documentation here: http://smoothieware.org/supported-g-codes to include G28.1, G28.2, G28.3, and G28.4 however if the current edge version does not properly restore G28.1 it could cause issues for people using the current edge version.