### PR TITLE
Home Speed Adjustments

### DIFF
--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -47,6 +47,7 @@ class Endstops : public Module{
         float  trim_mm[3];
         float  fast_rates[3];
         float  slow_rates[3];
+        float  retract_rate;
         Pin    pins[6];
         std::array<uint16_t, 3> debounce;
 


### PR DESCRIPTION
 This is to adjust the feedrates during home procedures so they are the same whether you home one, two, or all three axis at the same time.

The most important section of this is the slow move back toward the limits.  If this is done at different speeds, the home position will be different.. that is why we do dual speed homing in the first place.

When doing a diagonal move at a feedrate, each axis needs to move slower so that the combined movement is at the specified feedrate.  This is working and is correct, however it causes the slow limit seek to be at a different speed if one axis is homed compared to if all three are homed.    Another issue was that if one axis was specified to be a different speed than the others, when homed together they would all go the same speed, however when homing individually, they would use the speed assigned to them, this was causing home speeds to be different during a multi-axis home compared to a single axis home.

There are two methods used to correct this, when homing there are two types of movements used, and each requires a different correction method. 
The first type of movement is moving toward the limit switches to find them. With this movement we must move at least far enough to hit them, but we could move further without hurting anything, because motion is stopped by the limit switch.  
This is the procedure used to adjust the feedrate for this method:
1. Find the minimum distance required to achieve the longest travel
2. Find the slowest designated feedrate
3. scale the distances moved so the faster axis needs to move further, This will slow down the others
4. a new feedrate is then calculated for the combined movement taking into account the speed designated speed of each axis
5. when this combined movement is made at the new feedrate, each individual axis will move  at precisely the specified feedrate.  This will be the same feedrate used if only one axis is homed. Also each axis will always have the required minimum distance required to make it to the switch.

The second type of movement is when we are backing off away from the switches.  For this move, we cannot change the lengths traveled. The reason for adjusting this is so if you have one axis that is drastically slower than the others, you can back it off at the same time while staying within the designated feedrates.
This is the procedure used for this method:
1. find the axis that needs the most amount of time to make it's movement, note that it is not necessarily the axis with the shortest distance or the slowest feedrate
2. calculate the combined length of all axis to be moved
3. calculate a new feedrate which will make the combined move in the time needed to accommodate the axis needing the most time to complete

when this method is used all axis will make the move needed in the amount of time required by the axis needing the longest time to complete.  note that during some movements different axis will move at different speeds if they are homed together as opposed to homing separately, but the exact speed is not important here as we are just getting off the switch. what is important is that no matter which axis are included in the home procedure, they will all take the time needed by the slowest requirement and therefore no axis can move faster than specified.

This has been tested on my CNC router and CNC mill with a wide rage of homing distance differences, speed differences. All axis moved at the expected rates.