### PR TITLE
Reject extremely short GCodes

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1191,13 +1191,13 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
 
     // discard segments so small they cause no movement
     if ((gcode->has_letter('X')) && (millimeters_of_travel < (1/(actuators[0]->get_steps_per_mm())))) {
-        return this->append_milestone(target, rate_mm_s);
+        return false;
     }
     if ((gcode->has_letter('Y')) && (millimeters_of_travel < (1/(actuators[1]->get_steps_per_mm())))) {
-        return this->append_milestone(target, rate_mm_s);
+        return false;
     }
     if ((gcode->has_letter('Z')) && (millimeters_of_travel < (1/(actuators[2]->get_steps_per_mm())))) {
-        return this->append_milestone(target, rate_mm_s);
+        return false;
     }
     
     // limit segments by maximum arc error

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1074,13 +1074,9 @@ bool Robot::append_line(Gcode *gcode, const float target[], float rate_mm_s, flo
     float millimeters_of_travel = sqrtf(powf( target[X_AXIS] - last_milestone[X_AXIS], 2 ) +  powf( target[Y_AXIS] - last_milestone[Y_AXIS], 2 ) +  powf( target[Z_AXIS] - last_milestone[Z_AXIS], 2 ));
 
     // discard segments so small they cause no movement
-    if ((gcode->has_letter('X')) && (millimeters_of_travel < (1/(actuators[0]->get_steps_per_mm())))) {
-        return this->append_milestone(target, rate_mm_s);
-    }
-    if ((gcode->has_letter('Y')) && (millimeters_of_travel < (1/(actuators[1]->get_steps_per_mm())))) {
-        return this->append_milestone(target, rate_mm_s);
-    }
-    if ((gcode->has_letter('Z')) && (millimeters_of_travel < (1/(actuators[2]->get_steps_per_mm())))) {
+    if (((gcode->has_letter('X')) && (millimeters_of_travel < (1/(actuators[0]->get_steps_per_mm())))) &&
+        ((gcode->has_letter('Y')) && (millimeters_of_travel < (1/(actuators[1]->get_steps_per_mm())))) &&
+        ((gcode->has_letter('Z')) && (millimeters_of_travel < (1/(actuators[2]->get_steps_per_mm()))))) {
         return this->append_milestone(target, rate_mm_s);
     }
 
@@ -1190,16 +1186,12 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
 
     // discard segments so small they cause no movement
-    if ((gcode->has_letter('X')) && (millimeters_of_travel < (1/(actuators[0]->get_steps_per_mm())))) {
+    if (((gcode->has_letter('X')) && (millimeters_of_travel < (1/(actuators[0]->get_steps_per_mm())))) && 
+        ((gcode->has_letter('Y')) && (millimeters_of_travel < (1/(actuators[1]->get_steps_per_mm())))) &&
+        ((gcode->has_letter('Z')) && (millimeters_of_travel < (1/(actuators[2]->get_steps_per_mm()))))) {
         return false;
     }
-    if ((gcode->has_letter('Y')) && (millimeters_of_travel < (1/(actuators[1]->get_steps_per_mm())))) {
-        return false;
-    }
-    if ((gcode->has_letter('Z')) && (millimeters_of_travel < (1/(actuators[2]->get_steps_per_mm())))) {
-        return false;
-    }
-    
+
     // limit segments by maximum arc error
     float arc_segment = this->mm_per_arc_segment;
     if ((this->mm_max_arc_error > 0) && (2 * radius > this->mm_max_arc_error)) {


### PR DESCRIPTION
Reject Gcodes which will not result in one step.  There is no need of filling the queue with useless commands that will not generate any motion.  These microscopic segments are typical if you are generating GCode base off true type fonts, and it's too much work to clean them up manually.

there was already a rejection in place for extremely small movements, I just took 1/steps_per_mm to figure out how far one step was and use that instead of an arbitrary number

Also removed check for mm_max_arc_error.  It's best to always use mm_max_arc_error.  you get just a few more segments at very small radii, but you are better off with them them if you are doing very fine work.