### PR TITLE
Clear current_tick when halted, or on start of new block

### DIFF
--- a/src/libs/SlowTicker.cpp
+++ b/src/libs/SlowTicker.cpp
@@ -61,7 +61,7 @@ void SlowTicker::set_frequency( int frequency ){
 // The actual interrupt being called by the timer, this is where work is done
 void SlowTicker::tick(){
 
-    // Call all hooks that need to be called ( bresenham )
+    // Call all hooks that need to be called
     for (Hook* hook : this->hooks){
         hook->countdown -= this->interval;
         if (hook->countdown < 0)
@@ -71,7 +71,7 @@ void SlowTicker::tick(){
         }
     }
 
-    // deduct tick time from secound counter
+    // deduct tick time from second counter
     flag_1s_count -= this->interval;
     // if a whole second has elapsed,
     if (flag_1s_count < 0)

--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -71,6 +71,7 @@ void StepTicker::start()
 {
     NVIC_EnableIRQ(TIMER0_IRQn);     // Enable interrupt handler
     NVIC_EnableIRQ(TIMER1_IRQn);     // Enable interrupt handler
+    current_tick= 0;
 }
 
 // Set the base stepping frequency
@@ -132,8 +133,6 @@ void StepTicker::handle_finish (void)
 // step clock
 void StepTicker::step_tick (void)
 {
-    static uint32_t current_tick = 0;
-
     //SET_STEPTICKER_DEBUG_PIN(running ? 1 : 0);
 
     // if nothing has been setup we ignore the ticks
@@ -149,6 +148,7 @@ void StepTicker::step_tick (void)
 
     if(THEKERNEL->is_halted()) {
         running= false;
+        current_tick = 0;
         return;
     }
 
@@ -260,6 +260,8 @@ bool StepTicker::start_next_block()
         motor[m]->set_direction(current_block->direction_bits[m]);
         motor[m]->start_moving(); // also let motor know it is moving now
     }
+
+    current_tick= 0;
 
     if(ok) {
         //SET_STEPTICKER_DEBUG_PIN(1);

--- a/src/libs/StepTicker.h
+++ b/src/libs/StepTicker.h
@@ -56,6 +56,7 @@ class StepTicker{
         std::bitset<k_max_actuators> unstep;
 
         Block *current_block;
+        uint32_t current_tick{0};
 
         struct {
             volatile bool running:1;

--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -23,12 +23,13 @@ StepperMotor::StepperMotor(Pin &step, Pin &dir, Pin &en) : step_pin(step), dir_p
     last_milestone_steps = 0;
     last_milestone_mm    = 0.0F;
     current_position_steps= 0;
-    enable(false);
     moving= false;
     acceleration= NAN;
     selected= true;
 
-    this->set_direction(false);
+    enable(false);
+    unstep(); // initialize step pin
+    set_direction(false); // initialize dor pin
 
     this->register_for_event(ON_HALT);
     this->register_for_event(ON_ENABLE);

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -151,9 +151,13 @@ try_again:
                     if(THEKERNEL->is_halted()) {
                         // we ignore all commands until M999, unless it is in the exceptions list (like M105 get temp)
                         if(gcode->has_m && gcode->m == 999) {
-                            THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
-                            new_message.stream->printf("WARNING: After HALT you should HOME as position is currently unknown\n");
-                            // fall through and pass onto other modules
+                            if(THEKERNEL->is_halted()) {
+                                THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
+                                new_message.stream->printf("WARNING: After HALT you should HOME as position is currently unknown\n");
+                            }
+                            new_message.stream->printf("ok\n");
+                            delete gcode;
+                            continue;
 
                         }else if(!is_allowed_mcode(gcode->m)) {
                             // ignore everything, return error string to host

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -217,8 +217,10 @@ void SimpleShell::on_console_line_received( void *argument )
                 break;
 
             case 'X':
-                THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
-                new_message.stream->printf("[Caution: Unlocked]\nok\n");
+                if(THEKERNEL->is_halted()) {
+                    THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
+                    new_message.stream->printf("[Caution: Unlocked]\nok\n");
+                }
                 break;
 
             case '#':


### PR DESCRIPTION
cleanup M999 processing.