### PR TITLE
cmath include for ARM GCC 5.4 Q2-2016

### DIFF
--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -16,6 +16,7 @@
 
 #include <tuple>
 #include <algorithm>
+#include <cmath>
 
 #define radius_checksum         CHECKSUM("radius")
 #define initial_height_checksum CHECKSUM("initial_height")


### PR DESCRIPTION
The last release of ARM GCC toolchain (Q2-2016) needs additional <cmath> include for proper float calculations in DeltaCalibrationStrategy.cpp file. 