### PR TITLE
"Fix" problem with flushing 64 byte packets

### DIFF
--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -137,8 +137,11 @@ bool USBSerial::USBEvent_EPIn(uint8_t bEP, uint8_t bEPStatus)
 
     int l = txbuf.available();
     if (l > 0) {
-        if (l > MAX_PACKET_SIZE_EPBULK)
-            l = MAX_PACKET_SIZE_EPBULK;
+        // Use MAX_PACKET_SIZE_EPBULK-1 below instead of MAX_PACKET_SIZE_EPBULK
+        // to work around a problem sending packets that are exactly MAX_PACKET_SIZE_EPBULK
+        // bytes in length. The problem is that these packets don't flush properly.
+        if (l > MAX_PACKET_SIZE_EPBULK-1)
+            l = MAX_PACKET_SIZE_EPBULK-1;
         int i;
         for (i = 0; i < l; i++) {
             txbuf.dequeue(&b[i]);


### PR DESCRIPTION
Regarding issue  #996: 

When exactly 64 bytes are sent, it isn't flushed immediately.
(it is sent later, whenever we have more bytes to send)
If the data is 63 or less bytes, then it is flushed immediately.

This is a problem if the user is waiting for an immediate response from Smoothie.
For example, when sending the '?' character to get the location.

This "fix" is a work-around: we split the data into packets
of 63 bytes or less.  The actual bug should probably be hunted down
and properly fixed.

Other people have hit this problem.  E.g.
   https://community.nxp.com/message/360747