### PR TITLE
Repaired Morgan scara homing on new motor control

### DIFF
--- a/src/modules/robot/arm_solutions/BaseSolution.h
+++ b/src/modules/robot/arm_solutions/BaseSolution.h
@@ -17,6 +17,7 @@ class BaseSolution {
         typedef std::map<char, float> arm_options_t;
         virtual bool set_optional(const arm_options_t& options) { return false; };
         virtual bool get_optional(arm_options_t& options, bool force_all= false) { return false; };
+        bool homing_active;
 };
 
 #endif


### PR DESCRIPTION
Added a boolean that can inform arm solution that homing is active.  Scara homing relies on cartesian homing movement rather than inverse kinematics.