### PR TITLE
Fixed rotary encoder implementation instead of menu offset workaround that did not work (was not implemented for eg jog)

### DIFF
--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -149,7 +149,6 @@ class Panel : public Module {
             volatile bool do_buttons:1;
             volatile bool do_encoder:1;
             char mode:2;
-            char menu_offset:3;
             int encoder_click_resolution:3;
         };
 };

--- a/src/modules/utils/panel/panels/ReprapDiscountGLCD.h
+++ b/src/modules/utils/panel/panels/ReprapDiscountGLCD.h
@@ -48,6 +48,7 @@ class ReprapDiscountGLCD : public LcdBase {
         Pin pause_pin;
         Pin back_pin;
         Pin buzz_pin;
+        int menu_offset;
 };
 
 

--- a/src/modules/utils/panel/panels/ST7565.h
+++ b/src/modules/utils/panel/panels/ST7565.h
@@ -82,6 +82,7 @@ private:
         bool use_pause:1;
         bool use_back:1;
     };
+    int menu_offset;
 };
 
 #endif /* ST7565_H_ */


### PR DESCRIPTION
Old work around for different types of rotary encoders (X2/X4) was implemented with a menu offset, this causes problems eg. in jog screen instead of 1 step there were 2 steps. Instead of using a menu offset and complicate all the menu/panel related code we implement the encoder readout different so we can support X2/X4 encoding

* Panel.cpp/Panel.h:
  - removed menu_offset_checksum (no longer necessary)
  - removed all menu_offsets in the code
* ReprapDiscountGLCD/ST7565:
  - add menu_offset, if == 0 (X4 mode, same as before), else X2 mode