### PR TITLE
When homing have ? print the current position

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -182,7 +182,7 @@ std::string Kernel::get_query_string()
         str.append("Run,");
     }
 
-    if(running) {
+    if(running || homing) {
         // get real time current actuator position in mm
         ActuatorCoordinates current_position{
             robot->actuators[X_AXIS]->get_current_position(),


### PR DESCRIPTION
I use the ? command to update the current position on my app every 100ms.
This works fine, except when homing.  This change fixes that.

Maybe the software was written like this on purpose.  Perhaps it was
assumed that if the user wants to home, then the coordinates can't be trusted,
so why show them?

My counter argument is: yes, the coordinates _might_ not be good
(i.e. represent the actual position).  However it's possible they are fine.
If the coordinates aren't good, what harm is there in returning them?
It's no worse than returning the last milestone which also wouldn't be
good either. In fact, by returning them the user can see that there is movement
on the screen of the app.  By returning the last milestone, it looks like the device is
stationary.