### PR TITLE
grbl mode homing response

### DIFF
--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -234,9 +234,11 @@ void SimpleShell::on_console_line_received( void *argument )
                     // issue G28.2 which is force homing cycle
                     Gcode gcode("G28.2", new_message.stream);
                     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+                    new_message.stream->printf("ok\n");
                 }else{
                     Gcode gcode("G28", new_message.stream);
                     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
+                    new_message.stream->printf("ok\n");
                 }
                 break;
 


### PR DESCRIPTION
Added 'ok' response for '$H' command.  As far as I can tell, grbl sends back an ok after a homing cycle.  Currently, smoothie was not (when using the '$H" command), which was creating issues with bCNC having any command immediately following homing commands to be stuck in the send buffer.