### PR TITLE
workaround to handle kill and not wait for motors to stop

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -118,7 +118,7 @@ void TemperatureControl::on_main_loop(void *argument)
 {
     if (this->temp_violated) {
         this->temp_violated = false;
-        THEKERNEL->streams->printf("ERROR : MINTEMP or MAXTEMP triggered on %s. Check your temperature sensors!\n", designator.c_str());
+        THEKERNEL->streams->printf("ERROR: MINTEMP or MAXTEMP triggered on %s. Check your temperature sensors!\n", designator.c_str());
         THEKERNEL->streams->printf("HALT asserted - reset or M999 required\n");
         THEKERNEL->call_event(ON_HALT, nullptr);
     }
@@ -542,7 +542,7 @@ void TemperatureControl::on_second_tick(void *argument)
                 this->runaway_heating_timer++;
                 if( this->runaway_heating_timer > this->runaway_heating_timeout && this->runaway_heating_timeout != 0 ){
                     this->runaway_heating_timer = 0;
-                    THEKERNEL->streams->printf("ERROR : Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
+                    THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
                 break;
@@ -550,7 +550,7 @@ void TemperatureControl::on_second_tick(void *argument)
                 float delta= this->get_temperature() - this->target_temperature;
                 // If the temperature is outside the acceptable range
                 if(this->runaway_range != 0 && fabsf(delta) > this->runaway_range){
-                    THEKERNEL->streams->printf("ERROR : Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+                    THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
             }


### PR DESCRIPTION
Works around a bug or maybe a race condition where kill will wait indefinitely for a motor to stop, even though all motors have stopped.