### PR TITLE
Better and correct fix for Kill hanging on E moving

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -150,9 +150,9 @@ Kernel::Kernel(){
     this->step_ticker->set_unstep_time( microseconds_per_step_pulse );
 
     // Core modules
+    this->add_module( this->conveyor       = new Conveyor()      );
     this->add_module( this->gcode_dispatch = new GcodeDispatch() );
     this->add_module( this->robot          = new Robot()         );
-    this->add_module( this->conveyor       = new Conveyor()      );
     this->add_module( this->simpleshell    = new SimpleShell()   );
 
     this->planner = new Planner();

--- a/src/libs/StepTicker.cpp
+++ b/src/libs/StepTicker.cpp
@@ -149,6 +149,7 @@ void StepTicker::step_tick (void)
     if(THEKERNEL->is_halted()) {
         running= false;
         current_tick = 0;
+        current_block= nullptr;
         return;
     }
 

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -22,9 +22,9 @@ class StepperMotor  : public Module {
         // called from step ticker ISR
         inline void set_direction(bool f) { dir_pin.set(f); direction= f; }
 
-        inline void enable(bool state) { en_pin.set(!state); };
-        inline bool is_enabled() const { return !en_pin.get(); };
-        inline bool is_moving() const { return moving; };
+        void enable(bool state) { en_pin.set(!state); };
+        bool is_enabled() const { return !en_pin.get(); };
+        bool is_moving() const { return moving; };
         void start_moving() { moving= true; }
         void stop_moving() { moving= false; }
 

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -133,7 +133,7 @@ bool Conveyor::is_idle() const
 }
 
 // Wait for the queue to be empty and for all the jobs to finish in step ticker
-void Conveyor::wait_for_idle()
+void Conveyor::wait_for_idle(bool wait_for_motors)
 {
     // wait for the job queue to empty, this means cycling everything on the block queue into the job queue
     // forcing them to be jobs
@@ -143,10 +143,13 @@ void Conveyor::wait_for_idle()
         THEKERNEL->call_event(ON_IDLE, this);
     }
 
-    // now we wait for all motors to stop moving
-    while(!is_idle()) {
-        THEKERNEL->call_event(ON_IDLE, this);
+    if(wait_for_motors) {
+        // now we wait for all motors to stop moving
+        while(!is_idle()) {
+            THEKERNEL->call_event(ON_IDLE, this);
+        }
     }
+
     running = true;
     // returning now means that everything has totally finished
 }
@@ -189,7 +192,7 @@ void Conveyor::check_queue(bool force)
     // we do this to allow an idle system to pre load the queue a bit so the first few blocks run smoothly.
     if(force || queue.is_full() || (us_ticker_read() - last_time_check) >= (queue_delay_time_ms * 1000)) {
         last_time_check = us_ticker_read(); // reset timeout
-        allow_fetch = true;
+        if(!flush) allow_fetch = true;
         return;
     }
 }
@@ -207,7 +210,7 @@ bool Conveyor::get_next_block(Block **block)
     // default the feerate to zero if there is no block available
     this->current_feedrate= 0;
 
-    if(queue.isr_tail_i == queue.head_i) return false; // we do not have anything to give
+    if(halted || queue.isr_tail_i == queue.head_i) return false; // we do not have anything to give
 
     // wait for queue to fill up, optimizes planning
     if(!allow_fetch) return false;
@@ -248,18 +251,8 @@ void Conveyor::flush_queue()
 
     // TODO force deceleration of last block
 
-    running = false; // stops on_idle calling check_queue
-    if(halted) {
-        // wait for the queue to be drained by the stepticker and emptied by on idle
-        // FIXME we do not wait for motors to stop here due to a race condition or bug
-        while (!queue.is_empty()) {
-            check_queue(true); // forces queue to be made available to stepticker
-            THEKERNEL->call_event(ON_IDLE, this);
-        }
-    }else{
-        // now wait until the job queue has finished and all motors are idle too
-        wait_for_idle();
-    }
+    // now wait until the block queue has been flushed
+    wait_for_idle(false);
 
     flush= false;
 }

--- a/src/modules/robot/Conveyor.h
+++ b/src/modules/robot/Conveyor.h
@@ -27,7 +27,7 @@ public:
     void on_idle(void *);
     void on_halt(void *);
 
-    void wait_for_idle();
+    void wait_for_idle(bool wait_for_motors=true);
     bool is_queue_empty() { return queue.is_empty(); };
     bool is_queue_full() { return queue.is_full(); };
     bool is_idle() const;


### PR DESCRIPTION
Issue was ON_HALT being blocked in conveyor waiting for motors to stop, but that meant the ON_Halt was not being delivered to the extruder steppermotor, so it was not seen as being stopped.