### PR TITLE
fixed the runaway temperature monitor.

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -440,6 +440,17 @@ void TemperatureControl::set_desired_temperature(float desired_temperature)
         if (this->iTerm > this->i_max) this->iTerm = this->i_max;
         else if (this->iTerm < 0.0) this->iTerm = 0.0;
     }
+
+    // set the runaway state.
+    this->runaway_last_temperature = get_temperature();
+    this->runaway_heating_timer = 0;
+    if ( this->target_temperature <= 0.0F ) {
+        this->runaway_state = NOT_HEATING;
+    } else if ( this->target_temperature < last_target_temperature ) {
+        this->runaway_state = COOLING_DOWN;
+    } else if ( this->target_temperature > last_target_temperature ) {
+        this->runaway_state = HEATING_UP;
+    }
 }
 
 float TemperatureControl::get_temperature()
@@ -529,28 +540,61 @@ void TemperatureControl::on_second_tick(void *argument)
         this->runaway_state = NOT_HEATING;
     }else{
         switch( this->runaway_state ){
-            case NOT_HEATING: // If we were previously not trying to heat, but we are now, change to state WAITING_FOR_TEMP_TO_BE_REACHED
-                if( this->target_temperature > 0 ){
-                    this->runaway_state = WAITING_FOR_TEMP_TO_BE_REACHED;
+            case NOT_HEATING: // handle the case where the temperature control is idle.
+                if ( this->target_temperature > 0 ) {
+                    // If we were previously not trying to heat, but we are now, change to state COOLING_DOWN or HEATING_UP
+                    this->runaway_state = (this->target_temperature < get_temperature()) ? COOLING_DOWN : HEATING_UP;
                     this->runaway_heating_timer = 0;
+                    this->runaway_last_temperature = get_temperature();
                 }
                 break;
-            case WAITING_FOR_TEMP_TO_BE_REACHED: // In we are in state 1 ( waiting for temperature to be reached ), and the temperature has been reached, change to state TARGET_TEMPERATURE_REACHED
-                if( this->get_temperature() >= this->target_temperature ){
-                    this->runaway_state = TARGET_TEMPERATURE_REACHED;
+
+            case HEATING_UP:     // handle the case where temperature has to be increased to reach the target.
+            case COOLING_DOWN: { // handle the case where temperature has to be decreased to reach the target.
+                bool target_reached;
+                bool trending_correctly;
+                // check whether the temperature is trending in the right direction.
+                if ( this->runaway_state == HEATING_UP ) {
+                    target_reached = (this->get_temperature() >= this->target_temperature);
+                    trending_correctly = (get_temperature() > this->runaway_last_temperature);
                 }
-                this->runaway_heating_timer++;
-                if( this->runaway_heating_timer > this->runaway_heating_timeout && this->runaway_heating_timeout != 0 ){
+                else if ( this->runaway_state == COOLING_DOWN ) {
+                    target_reached = (this->get_temperature() <= this->target_temperature);
+                    trending_correctly = (get_temperature() < this->runaway_last_temperature);
+                }
+
+                if ( target_reached ) {
+                    // the temperature has been reached, change to state MAINTAINING_TEMPERATURE
                     this->runaway_heating_timer = 0;
-                    THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
+                    this->runaway_state = MAINTAINING_TEMPERATURE;
+                }
+
+                // as long as the temperature is trending correctly, all is well.
+                // if it stalls, tick the heating timer.
+                if ( trending_correctly ) {
+                    // temperature is trending, reset the timer.
+                    this->runaway_heating_timer = 0;
+                } else {
+                    // temperature is stalled, tick the timer.
+                    this->runaway_heating_timer++;
+                }
+                this->runaway_last_temperature = get_temperature();
+
+                // check whether the temperature has stalled longer than the timeout period.
+                if( this->runaway_heating_timer > this->runaway_heating_timeout && this->runaway_heating_timeout != 0 ) {
+                    this->runaway_heating_timer = 0;
+                    THEKERNEL->streams->printf("ERROR : Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
                 break;
-            case TARGET_TEMPERATURE_REACHED: { // If we are in state TARGET_TEMPERATURE_REACHED, check for thermal runaway
+            }
+            case MAINTAINING_TEMPERATURE: { // handle the case where the target has been reached and temperature is being maintained.
+                // check for thermal runaway
                 float delta= this->get_temperature() - this->target_temperature;
+
                 // If the temperature is outside the acceptable range
-                if(this->runaway_range != 0 && fabsf(delta) > this->runaway_range){
-                    THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+                if ( this->runaway_range != 0 && fabsf(delta) > this->runaway_range ) {
+                    THEKERNEL->streams->printf("ERROR : Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
             }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -581,9 +581,9 @@ void TemperatureControl::on_second_tick(void *argument)
                 this->runaway_last_temperature = get_temperature();
 
                 // check whether the temperature has stalled longer than the timeout period.
-                if( this->runaway_heating_timer > this->runaway_heating_timeout && this->runaway_heating_timeout != 0 ) {
+                if(this->runaway_heating_timer > this->runaway_heating_timeout && this->runaway_heating_timeout != 0) {
                     this->runaway_heating_timer = 0;
-                    THEKERNEL->streams->printf("ERROR : Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
+                    THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
                 break;
@@ -593,8 +593,8 @@ void TemperatureControl::on_second_tick(void *argument)
                 float delta= this->get_temperature() - this->target_temperature;
 
                 // If the temperature is outside the acceptable range
-                if ( this->runaway_range != 0 && fabsf(delta) > this->runaway_range ) {
-                    THEKERNEL->streams->printf("ERROR : Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+                if(this->runaway_range != 0 && fabsf(delta) > this->runaway_range){
+                    THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
                     THEKERNEL->call_event(ON_HALT, nullptr);
                 }
             }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -31,8 +31,6 @@ class TemperatureControl : public Module {
 
         float get_temperature();
         
-        enum RUNAWAY_TYPE {NOT_HEATING, WAITING_FOR_TEMP_TO_BE_REACHED, TARGET_TEMPERATURE_REACHED};
-
         friend class PID_Autotuner;
 
     private:
@@ -83,14 +81,17 @@ class TemperatureControl : public Module {
         float PIDdt;
 
         // Temperature runaway values
+        enum RUNAWAY_TYPE {NOT_HEATING, HEATING_UP, COOLING_DOWN, MAINTAINING_TEMPERATURE};
+
         RUNAWAY_TYPE runaway_state;      
+        uint8_t runaway_heating_timer;
+        float runaway_last_temperature;
+        // Temperature runaway config options
+        uint8_t runaway_range;
+        uint8_t runaway_heating_timeout;
 
 
         struct {
-            uint8_t runaway_heating_timer:8;
-            // Temperature runaway config options
-            uint8_t runaway_range:8;
-            uint8_t runaway_heating_timeout:8; 
             bool use_bangbang:1;
             bool waiting:1;
             bool temp_violated:1;


### PR DESCRIPTION
@arthurwolf asked that I fix a runaway temperature bug.  The original runaway monitor was added in https://github.com/Smoothieware/Smoothieware/pull/782.  There has been a bug described as follows:

>If you are at a given temperature, and ask the firmware ( via a Gcode ) to change the target temperature, and the difference between the two is higher than the detection offset, it will erroneously trigger the error even though the action was legitimate.

I modified the monitoring states a bit, adding a state where the target temperature is lower than the current temperature.  I modified the `HEATING_UP` and `COOLING_DOWN` states to monitor increase and decrease from the previously checked value.  The `MAINTAIN_TEMPERATURE` state still monitors a range around the target.

I modified my config file as follows:
>\# runaway temperature parameters.
runaway_range                                  20             # maintain temp within +/- 20C.
runaway_heating_timeout                        20             # halt if temperature stalls for 20 seconds (heating or cooling).

This should result in the following behavior:
1.  If the temperature must be raised to attain the target and the temperature fails to increase for 20 seconds, the `HALT` condition is set.
2.  If the temperature must be lowered to attain the target and the temperature fails to decrease for 20 seconds, the `HALT` condition is set.
3.  If the target is attained and the temperature is being maintained, the `HALT` condition is set if the temperature is outside the range of +/- 20C from the target.