### PR TITLE
simple fix for the runaway issue.

### DIFF
--- a/ConfigSamples/AzteegX5Mini.delta/Version3/config
+++ b/ConfigSamples/AzteegX5Mini.delta/Version3/config
@@ -109,6 +109,11 @@ temperature_control.hotend.designator        T                #
 #temperature_control.hotend.max_temp         300              # Set maximum temperature - Will prevent heating above 300 by default
 #temperature_control.hotend.min_temp         0                # Set minimum temperature - Will prevent heating below 0 by default
 
+# safety control is enabled by default and can be overidden here, the values show the defaults
+#temperature_control.hotend.runaway_heating_timeout      900   # max is 2040 seconds, how long it can take to heat up
+#temperature_control.hotend.runaway_cooling_timeout      900   # max is 2040 seconds, how long it can take to cool down if temp is set lower
+#temperature_control.hotend.runaway_range                20    # Max setting is 63°C
+
 #P39.98 I5.00 D79.91
 # temperature_control.hotend.p_factor          39.98            #
 # temperature_control.hotend.i_factor          5.00             #

--- a/ConfigSamples/AzteegX5Mini/Version3/config
+++ b/ConfigSamples/AzteegX5Mini/Version3/config
@@ -90,6 +90,11 @@ temperature_control.hotend.designator        T                #
 #temperature_control.hotend.max_temp         300              # Set maximum temperature - Will prevent heating above 300 by default
 #temperature_control.hotend.min_temp         0                # Set minimum temperature - Will prevent heating below 0 by default
 
+# safety control is enabled by default and can be overidden here, the values show the defaults
+#temperature_control.hotend.runaway_heating_timeout      900   # max is 2040 seconds, how long it can take to heat up
+#temperature_control.hotend.runaway_cooling_timeout      900   # max is 2040 seconds, how long it can take to cool down if temp is set lower
+#temperature_control.hotend.runaway_range                20    # Max setting is 63°C
+
 temperature_control.hotend.p_factor          13.7             #
 temperature_control.hotend.i_factor          0.097            #
 temperature_control.hotend.d_factor          24               #

--- a/ConfigSamples/Smoothieboard.delta/config
+++ b/ConfigSamples/Smoothieboard.delta/config
@@ -137,6 +137,11 @@ temperature_control.hotend.designator        T                #
 #temperature_control.hotend.max_temp         300              # Set maximum temperature - Will prevent heating above 300 by default
 #temperature_control.hotend.min_temp         0                # Set minimum temperature - Will prevent heating below 0 by default
 
+# safety control is enabled by default and can be overidden here, the values show the defaults
+#temperature_control.hotend.runaway_heating_timeout      900   # max is 2040 seconds, how long it can take to heat up
+#temperature_control.hotend.runaway_cooling_timeout      900   # max is 2040 seconds, how long it can take to cool down if temp is set lower
+#temperature_control.hotend.runaway_range                20    # Max setting is 63°C
+
 #temperature_control.hotend.p_factor         13.7             # permanently set the PID values after an auto pid
 #temperature_control.hotend.i_factor         0.097            #
 #temperature_control.hotend.d_factor         24               #

--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -142,6 +142,11 @@ temperature_control.hotend.designator        T                #
 #temperature_control.hotend.max_temp         300              # Set maximum temperature - Will prevent heating above 300 by default
 #temperature_control.hotend.min_temp         0                # Set minimum temperature - Will prevent heating below if set
 
+# safety control is enabled by default and can be overidden here, the values show the defaults
+#temperature_control.hotend.runaway_heating_timeout      900   # max is 2040 seconds, how long it can take to heat up
+#temperature_control.hotend.runaway_cooling_timeout      900   # max is 2040 seconds, how long it can take to cool down if temp is set lower
+#temperature_control.hotend.runaway_range                20    # Max setting is 63°C
+
 #temperature_control.hotend.p_factor         13.7             # permanently set the PID values after an auto pid
 #temperature_control.hotend.i_factor         0.097            #
 #temperature_control.hotend.d_factor         24               #

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -143,12 +143,12 @@ void TemperatureControl::load_config()
     if(n > 63) n= 63;
     this->runaway_range= n;
 
-    // these need to fit in 7 bits after dividing by 8 so max is 1016 secs or 17 minutes
+    // these need to fit in 7 bits after dividing by 8 so max is 2040 secs or 34 minutes
     n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
-    if(n > 1016) n= 1016;
+    if(n > 2040) n= 2040;
     this->runaway_heating_timeout = n/8; // we have 8 second ticks
     n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_cooling_timeout_checksum)->by_default((float)n)->as_number();
-    if(n > 1016) n= 1016;
+    if(n > 2040) n= 2040;
     this->runaway_cooling_timeout = n/8;
 
     // Max and min temperatures we are not allowed to get over (Safety)

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -139,12 +139,12 @@ void TemperatureControl::load_config()
     this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
 
     // Runaway parameters
-    uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
+    uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(20)->as_number();
     if(n > 63) n= 63;
     this->runaway_range= n;
 
     // these need to fit in 7 bits after dividing by 8 so max is 2040 secs or 34 minutes
-    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
+    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(900)->as_number();
     if(n > 2040) n= 2040;
     this->runaway_heating_timeout = n/8; // we have 8 second ticks
     n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_cooling_timeout_checksum)->by_default((float)n)->as_number();

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -137,8 +137,12 @@ void TemperatureControl::load_config()
     this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
 
     // Runaway parameters
-    this->runaway_range           = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
-    this->runaway_heating_timeout = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
+    uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
+    if(n > 63) n= 63;
+    this->runaway_range= n;
+    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
+    if(n > 511) n= 511;
+    this->runaway_heating_timeout = n;
 
     // Max and min temperatures we are not allowed to get over (Safety)
     this->max_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_temp_checksum)->by_default(300)->as_number();

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -66,6 +66,7 @@
 
 #define runaway_range_checksum             CHECKSUM("runaway_range")
 #define runaway_heating_timeout_checksum   CHECKSUM("runaway_heating_timeout")
+#define runaway_cooling_timeout_checksum   CHECKSUM("runaway_cooling_timeout")
 
 TemperatureControl::TemperatureControl(uint16_t name, int index)
 {
@@ -75,6 +76,7 @@ TemperatureControl::TemperatureControl(uint16_t name, int index)
     temp_violated= false;
     sensor= nullptr;
     readonly= false;
+    tick= 0;
 }
 
 TemperatureControl::~TemperatureControl()
@@ -140,9 +142,14 @@ void TemperatureControl::load_config()
     uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
     if(n > 63) n= 63;
     this->runaway_range= n;
+
+    // these need to fit in 7 bits after dividing by 8 so max is 1016 secs or 17 minutes
     n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
-    if(n > 511) n= 511;
-    this->runaway_heating_timeout = n;
+    if(n > 1016) n= 1016;
+    this->runaway_heating_timeout = n/8; // we have 8 second ticks
+    n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_cooling_timeout_checksum)->by_default((float)n)->as_number();
+    if(n > 1016) n= 1016;
+    this->runaway_cooling_timeout = n/8;
 
     // Max and min temperatures we are not allowed to get over (Safety)
     this->max_temp = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, max_temp_checksum)->by_default(300)->as_number();
@@ -535,32 +542,36 @@ void TemperatureControl::on_second_tick(void *argument)
     // see if runaway detection is enabled
     if(this->runaway_heating_timeout == 0 && this->runaway_range == 0) return;
 
+    // check every 8 seconds, depends on tick being 3 bits
+    if(++tick != 0) return;
+
     if(this->target_temperature <= 0){ // If we are not trying to heat, state is NOT_HEATING
         this->runaway_state = NOT_HEATING;
 
     }else{
+        float current_temperature= this->get_temperature();
         // heater is active
         switch( this->runaway_state ){
             case NOT_HEATING: // If we were previously not trying to heat, but we are now, change to state WAITING_FOR_TEMP_TO_BE_REACHED
-                if( this->target_temperature > 0 ){
-                    this->runaway_state = WAITING_FOR_TEMP_TO_BE_REACHED;
-                    this->runaway_heating_timer = 0;
-                }
+                this->runaway_state= (this->target_temperature > current_temperature) ? HEATING_UP : COOLING_DOWN;
+                this->runaway_timer = 0;
                 break;
 
-            case WAITING_FOR_TEMP_TO_BE_REACHED:
-                // we are in state 1 ( waiting for temperature to be reached ), and the temperature has been reached, change to state TARGET_TEMPERATURE_REACHED
-                if( this->get_temperature() >= this->target_temperature ){
+            case HEATING_UP:
+            case COOLING_DOWN:
+                if( (runaway_state == HEATING_UP && current_temperature >= this->target_temperature) ||
+                    (runaway_state == COOLING_DOWN && current_temperature <= this->target_temperature) ) {
                     this->runaway_state = TARGET_TEMPERATURE_REACHED;
-                    this->runaway_heating_timer = 0;
+                    this->runaway_timer = 0;
 
-                }else if(this->runaway_heating_timeout != 0) {
+                }else{
+                    uint16_t t= (runaway_state == HEATING_UP) ? this->runaway_heating_timeout : this->runaway_cooling_timeout;
                     // we are still heating up see if we have hit the max time allowed
-                    if(++this->runaway_heating_timer > this->runaway_heating_timeout){
-                        this->runaway_heating_timer = 0;
+                    if(t > 0 && ++this->runaway_timer > t){
                         THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());
                         THEKERNEL->call_event(ON_HALT, nullptr);
                         this->runaway_state = NOT_HEATING;
+                        this->runaway_timer = 0;
                     }
                 }
                 break;
@@ -568,22 +579,22 @@ void TemperatureControl::on_second_tick(void *argument)
             case TARGET_TEMPERATURE_REACHED:
                 if(this->runaway_range != 0) {
                     // we are in state TARGET_TEMPERATURE_REACHED, check for thermal runaway
-                    float delta= this->get_temperature() - this->target_temperature;
+                    float delta= current_temperature - this->target_temperature;
 
-                    // If the temperature is outside the acceptable range for 10 seconds, this allows for some noise spikes without halting
+                    // If the temperature is outside the acceptable range for 8 seconds, this allows for some noise spikes without halting
                     if(fabsf(delta) > this->runaway_range){
-                        this->runaway_heating_timer++;
+                        if(this->runaway_timer++ >= 1) { // this being 8 seconds
+                            THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
+                            THEKERNEL->call_event(ON_HALT, nullptr);
+                            this->runaway_state = NOT_HEATING;
+                            this->runaway_timer= 0;
+                        }
 
                     }else{
-                        this->runaway_heating_timer= 0;
-                    }
-
-                    if(this->runaway_heating_timer > 10) {
-                        THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str(), delta);
-                        THEKERNEL->call_event(ON_HALT, nullptr);
-                        this->runaway_state = NOT_HEATING;
+                        this->runaway_timer= 0;
                     }
                 }
+
                 break;
         }
     }

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -30,7 +30,7 @@ class TemperatureControl : public Module {
         void set_desired_temperature(float desired_temperature);
 
         float get_temperature();
-        
+
         enum RUNAWAY_TYPE {NOT_HEATING, WAITING_FOR_TEMP_TO_BE_REACHED, TARGET_TEMPERATURE_REACHED};
 
         friend class PID_Autotuner;
@@ -83,14 +83,14 @@ class TemperatureControl : public Module {
         float PIDdt;
 
         // Temperature runaway values
-        RUNAWAY_TYPE runaway_state;      
+        RUNAWAY_TYPE runaway_state;
 
 
         struct {
-            uint8_t runaway_heating_timer:8;
             // Temperature runaway config options
-            uint8_t runaway_range:8;
-            uint8_t runaway_heating_timeout:8; 
+            uint8_t runaway_range:6; // max 63
+            uint16_t runaway_heating_timeout:9;   // max 511
+            uint16_t runaway_heating_timer:9;
             bool use_bangbang:1;
             bool waiting:1;
             bool temp_violated:1;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -31,7 +31,6 @@ class TemperatureControl : public Module {
 
         float get_temperature();
 
-        enum RUNAWAY_TYPE {NOT_HEATING, WAITING_FOR_TEMP_TO_BE_REACHED, TARGET_TEMPERATURE_REACHED};
 
         friend class PID_Autotuner;
 
@@ -39,6 +38,9 @@ class TemperatureControl : public Module {
         void load_config();
         uint32_t thermistor_read_tick(uint32_t dummy);
         void pid_process(float);
+        void setPIDp(float p);
+        void setPIDi(float i);
+        void setPIDd(float d);
 
         int pool_index;
 
@@ -49,29 +51,14 @@ class TemperatureControl : public Module {
         float preset2;
 
         TempSensor *sensor;
-
-        // PID runtime
         float i_max;
-
         int o;
-
         float last_reading;
-
         float readings_per_second;
-
-        uint16_t name_checksum;
-
         Pwm  heater_pin;
-
-        uint16_t set_m_code;
-        uint16_t set_and_wait_m_code;
-        uint16_t get_m_code;
 
         std::string designator;
 
-        void setPIDp(float p);
-        void setPIDi(float i);
-        void setPIDd(float d);
 
         float hysteresis;
         float iTerm;
@@ -82,15 +69,21 @@ class TemperatureControl : public Module {
         float d_factor;
         float PIDdt;
 
-        // Temperature runaway values
-        RUNAWAY_TYPE runaway_state;
+        enum RUNAWAY_TYPE {NOT_HEATING, HEATING_UP, COOLING_DOWN, TARGET_TEMPERATURE_REACHED};
 
-
+        // pack these to save memory
         struct {
+            uint16_t name_checksum;
+            uint16_t set_m_code:10;
+            uint16_t set_and_wait_m_code:10;
+            uint16_t get_m_code:10;
+            RUNAWAY_TYPE runaway_state:3;
             // Temperature runaway config options
             uint8_t runaway_range:6; // max 63
-            uint16_t runaway_heating_timeout:9;   // max 511
-            uint16_t runaway_heating_timer:9;
+            uint16_t runaway_heating_timeout:7; // 1016 secs
+            uint16_t runaway_cooling_timeout:7; // 1016 secs
+            uint16_t runaway_timer:7;
+            uint8_t tick:3;
             bool use_bangbang:1;
             bool waiting:1;
             bool temp_violated:1;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -77,12 +77,12 @@ class TemperatureControl : public Module {
             uint16_t set_m_code:10;
             uint16_t set_and_wait_m_code:10;
             uint16_t get_m_code:10;
-            RUNAWAY_TYPE runaway_state:3;
+            RUNAWAY_TYPE runaway_state:2;
             // Temperature runaway config options
             uint8_t runaway_range:6; // max 63
-            uint16_t runaway_heating_timeout:7; // 1016 secs
-            uint16_t runaway_cooling_timeout:7; // 1016 secs
-            uint16_t runaway_timer:7;
+            uint16_t runaway_heating_timeout:8; // 2040 secs
+            uint16_t runaway_cooling_timeout:8; // 2040 secs
+            uint16_t runaway_timer:8;
             uint8_t tick:3;
             bool use_bangbang:1;
             bool waiting:1;


### PR DESCRIPTION
This fixes the issue where changing the temp causes ON_HALT.

- It refactors slightly to optimize the case where runaway is disabled.
- Adds a timeout for over temp runaway which should mitigate issues where a temporary noise glitch would cause a HALT.
- Allows for setting the temp lower than it was providing a separate timeout for cooldown vs heatup.
- Allows for some noise before triggering ON_HALT for range errors.
- Increases the maximum heating and cooling timeout to about 34 minutes