### PR TITLE
added use-cases to the runaway temperature monitoring.

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -140,6 +140,7 @@ void TemperatureControl::load_config()
     this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
 
     // Runaway parameters
+    delete this->temperature_monitor;
     uint8_t range = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
     uint16_t timeout = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
     this->temperature_monitor = new TemperatureMonitor(range, timeout);

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -141,8 +141,10 @@ void TemperatureControl::load_config()
 
     // Runaway parameters
     delete this->temperature_monitor;
-    uint8_t range = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
-    uint16_t timeout = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
+    uint32_t range = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(0)->as_number();
+    if(range > 63) range = 63;
+    uint32_t timeout = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_heating_timeout_checksum)->by_default(0)->as_number();
+    if(timeout > 511) timeout = 511;
     this->temperature_monitor = new TemperatureMonitor(range, timeout);
 
     // Max and min temperatures we are not allowed to get over (Safety)

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -13,6 +13,8 @@
 #include "TempSensor.h"
 #include "TemperatureControlPublicAccess.h"
 
+class TemperatureMonitor;
+
 class TemperatureControl : public Module {
 
     public:
@@ -31,8 +33,6 @@ class TemperatureControl : public Module {
 
         float get_temperature();
         
-        enum RUNAWAY_TYPE {NOT_HEATING, WAITING_FOR_TEMP_TO_BE_REACHED, TARGET_TEMPERATURE_REACHED};
-
         friend class PID_Autotuner;
 
     private:
@@ -82,15 +82,9 @@ class TemperatureControl : public Module {
         float d_factor;
         float PIDdt;
 
-        // Temperature runaway values
-        RUNAWAY_TYPE runaway_state;      
-
+        TemperatureMonitor* temperature_monitor;
 
         struct {
-            uint8_t runaway_heating_timer:8;
-            // Temperature runaway config options
-            uint8_t runaway_range:8;
-            uint8_t runaway_heating_timeout:8; 
             bool use_bangbang:1;
             bool waiting:1;
             bool temp_violated:1;

--- a/src/modules/tools/temperaturecontrol/TemperatureMonitor.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureMonitor.cpp
@@ -1,0 +1,116 @@
+/*
+ * TemperatureMonitor.cpp
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: mmoore
+ */
+
+#include "TemperatureMonitor.h"
+#include "Kernel.h"
+#include "StreamOutputPool.h"
+
+#include <math.h>
+
+
+#define TEMPERATURE_INTEGER_MASK   0x3F
+#define TEMPERATURE_TO_INTEGER(t)  ((uint8_t)(((uint32_t)t) & TEMPERATURE_INTEGER_MASK))
+
+
+TemperatureMonitor::TemperatureMonitor(uint8_t range, uint16_t timeout)
+{
+    this->state = NOT_HEATING;
+    this->heating_timer = 0;
+    this->heating_timeout = timeout;
+    this->range = range;
+    this->last_temperature = 0;
+}
+
+TemperatureMonitor::~TemperatureMonitor()
+{
+    // TODO Auto-generated destructor stub
+}
+
+void TemperatureMonitor::set_target_temperature(float target, float last_target, float current_temp)
+{
+    // set the runaway state.
+    this->last_temperature = TEMPERATURE_TO_INTEGER(current_temp);
+    this->heating_timer = 0;
+
+    if ( target <= 0.0F ) {
+        this->state = NOT_HEATING;
+    } else if ( target < last_target ) {
+        this->state = COOLING_DOWN;
+    } else if ( target > last_target ) {
+        this->state = HEATING_UP;
+    }
+}
+
+void TemperatureMonitor::on_second_tick(float target_temp, float current_temp, string control_designator)
+{
+    if( target_temp <= 0 ){ // If we are not trying to heat, state is NOT_HEATING
+        this->state = NOT_HEATING;
+    }else{
+        uint8_t current_temp_as_integer = TEMPERATURE_TO_INTEGER(current_temp);
+        switch( this->state ){
+            case NOT_HEATING: // handle the case where the temperature control is idle.
+                if ( target_temp > 0 ) {
+                    // If we were previously not trying to heat, but we are now, change to state COOLING_DOWN or HEATING_UP
+                    this->state = (target_temp < current_temp) ? COOLING_DOWN : HEATING_UP;
+                    this->heating_timer = 0;
+                    this->last_temperature = current_temp_as_integer;
+                }
+                break;
+
+            case HEATING_UP:     // handle the case where temperature has to be increased to reach the target.
+            case COOLING_DOWN: { // handle the case where temperature has to be decreased to reach the target.
+                bool target_reached = false;
+                bool trending_correctly = true;
+                // check whether the temperature is trending in the right direction.
+                if ( this->state == HEATING_UP ) {
+                    target_reached = (current_temp >= target_temp);
+                    trending_correctly = (current_temp_as_integer > this->last_temperature);
+                }
+                else if ( this->state == COOLING_DOWN ) {
+                    target_reached = (current_temp <= target_temp);
+                    trending_correctly = (current_temp_as_integer < this->last_temperature);
+                }
+
+                if ( target_reached ) {
+                    // the temperature has been reached, change to state MAINTAINING_TEMPERATURE
+                    this->heating_timer = 0;
+                    this->state = MAINTAINING_TEMPERATURE;
+                }
+
+                // as long as the temperature is trending correctly, all is well.
+                // if it stalls, tick the heating timer.
+                if ( trending_correctly ) {
+                    // temperature is trending, reset the timer.
+                    this->heating_timer = 0;
+                } else {
+                    // temperature is stalled, tick the timer.
+                    this->heating_timer++;
+                }
+                this->last_temperature = current_temp_as_integer;
+
+                // check whether the temperature has stalled longer than the timeout period.
+                if(this->heating_timer > this->heating_timeout && this->heating_timeout != 0) {
+                    this->heating_timer = 0;
+                    THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", control_designator.c_str());
+                    THEKERNEL->call_event(ON_HALT, nullptr);
+                }
+                break;
+            }
+            case MAINTAINING_TEMPERATURE: { // handle the case where the target has been reached and temperature is being maintained.
+                // check for thermal runaway
+                float delta= current_temp - target_temp;
+
+                // If the temperature is outside the acceptable range
+                if(this->range != 0 && fabsf(delta) > this->range){
+                    THEKERNEL->streams->printf("ERROR: Temperature runaway on %s (delta temp %f), HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", control_designator.c_str(), delta);
+                    THEKERNEL->call_event(ON_HALT, nullptr);
+                }
+            }
+                break;
+        }
+    }
+}

--- a/src/modules/tools/temperaturecontrol/TemperatureMonitor.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureMonitor.h
@@ -1,0 +1,44 @@
+/*
+ * TemperatureMonitor.h
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: mmoore
+ */
+
+#ifndef SRC_MODULES_TOOLS_TEMPERATURECONTROL_TEMPERATUREMONITOR_H_
+#define SRC_MODULES_TOOLS_TEMPERATURECONTROL_TEMPERATUREMONITOR_H_
+
+#include <stdint.h>
+#include <string>
+
+using std::string;
+
+
+class TemperatureMonitor
+{
+public:
+    TemperatureMonitor(uint8_t range, uint16_t timeout);
+    virtual ~TemperatureMonitor();
+
+    void set_target_temperature(float target, float last_target, float current_temp);
+    void on_second_tick(float target_temp, float current_temp, string control_designator);
+
+private:
+    enum RUNAWAY_TYPE {
+        NOT_HEATING              = 0,
+        HEATING_UP               = 1,
+        COOLING_DOWN             = 2,
+        MAINTAINING_TEMPERATURE  = 3,
+    };
+
+
+    struct {
+        RUNAWAY_TYPE state       :2; // max value 3.
+        uint16_t heating_timer   :9; // max value 511 (08:31).
+        uint16_t heating_timeout :9; // max value 511 (08:31).
+        uint8_t range            :6; // max value 63.
+        uint8_t last_temperature :6; // max value 63 (we only track the lowest 6-bits of the integer temperature value).
+    };
+};
+
+#endif /* SRC_MODULES_TOOLS_TEMPERATURECONTROL_TEMPERATUREMONITOR_H_ */


### PR DESCRIPTION
At the suggestion of @arthurwolf, I have separated runaway temperature monitoring into a class.  The purpose of this pull request is to introduce handling two new use-cases to the temperature monitoring.

First, the use case where the temperature has to be lowered in order to reach the target.  I often encounter this scenario as part of my normal workflow.  I will typically set the temperature lower than printing temperature in order to do a cold pull before changing filament (PLA for example would be 85C to cold pull, as opposed to 190C to print). Many times I do this whilst the hotend is still hot, so the temperature has to cool to reach the target. Sometimes I get distracted with other things and am not closely monitoring, waiting for the temperature to be reached.

Second, the use case where the temperature takes too long to get to the target.  An example of this would be when I print ABS I set the bed temperature to 95C.  I have a 12V system which takes around 15 minutes to get the bed from room temperature to 95C. Since the runaway control is not granular, I would need to set the runaway to 15 minutes universally so it would not get a false HALT due to the bed taking too long to heat. If I let my hotend heater run un-controlled for 15 minutes, it would likely start a fire.

The code for this pull request is primarily derived from https://github.com/Smoothieware/Smoothieware/pull/1045.  I also utilized some changes from https://github.com/Smoothieware/Smoothieware/pull/1046.  I have optimized memory usage so that this approach does not use any additional memory.  The IVARs for the `TemperatureMonitor` class have been optimized to fit within a single 32-bit word.  The IVAR for the monitor within the `TemperatureControl` class is a pointer, which is 32-bits.  So there are 64 bits of memory used, which is the same amount used in the original implementation.