### PR TITLE
modified watch screen to display extruder when printing.

### DIFF
--- a/ConfigSamples/Snippets/panel.config
+++ b/ConfigSamples/Snippets/panel.config
@@ -1,0 +1,33 @@
+# Panel See http://smoothieware.org/panel
+panel.enable                                 false             # set to true to enable the panel code
+
+# Example viki2 config for an azteeg mini V2 with IDC cable
+panel.lcd                                    viki2             # set type of panel
+panel.spi_channel                            0                 # set spi channel to use P0_18,P0_15 MOSI,SCLK
+panel.spi_cs_pin                             0.16              # set spi chip select
+panel.encoder_a_pin                          3.25!^            # encoder pin
+panel.encoder_b_pin                          3.26!^            # encoder pin
+panel.click_button_pin                       2.11!^            # click button
+panel.a0_pin                                 2.6               # st7565 needs an a0
+panel.contrast                               8                 # override contrast setting (default is 9) miniViki (4 or lower)
+#panel.encoder_resolution                    4                 # override number of clicks to move 1 item (default is 4)
+#panel.button_pause_pin                      1.30^             # kill/pause set one of these for the auxilliary button on viki2
+#panel.back_button_pin                       1.30!^            # back button recommended to use this on EXP1
+panel.buzz_pin                               0.25              # pin for buzzer on EXP2
+panel.red_led_pin                            2.8               # pin for red led on viki2 on EXP1
+panel.blue_led_pin                           4.29              # pin for blue led on viki2 on EXP1
+panel.external_sd                            true              # set to true if there is an extrernal sdcard on the panel
+panel.external_sd.spi_channel                0                 # set spi channel the sdcard is on
+panel.external_sd.spi_cs_pin                 1.23              # set spi chip select for the sdcard
+panel.external_sd.sdcd_pin                   1.31!^            # sd detect signal (set to nc if no sdcard detect)
+panel.menu_offset                            1                 # some panels will need 1 here
+
+
+panel.alpha_jog_feedrate                     6000              # x jogging feedrate in mm/min
+panel.beta_jog_feedrate                      6000              # y jogging feedrate in mm/min
+panel.gamma_jog_feedrate                     200               # z jogging feedrate in mm/min
+
+panel.hotend_temperature                     185               # temp to set hotend when preheat is selected
+panel.bed_temperature                        60                # temp to set bed when preheat is selected
+
+panel.display_extruder                       true              # enable to display Extruder position on the Watch screen when printing

--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -61,10 +61,11 @@
 #define spi_channel_checksum       CHECKSUM("spi_channel")
 #define spi_cs_pin_checksum        CHECKSUM("spi_cs_pin")
 
-#define hotend_temp_checksum CHECKSUM("hotend_temperature")
-#define bed_temp_checksum    CHECKSUM("bed_temperature")
+#define hotend_temp_checksum       CHECKSUM("hotend_temperature")
+#define bed_temp_checksum          CHECKSUM("bed_temperature")
 #define panel_display_message_checksum CHECKSUM("display_message")
-#define laser_checksum CHECKSUM("laser")
+#define laser_checksum             CHECKSUM("laser")
+#define display_extruder_checksum  CHECKSUM("display_extruder")
 
 Panel* Panel::instance= nullptr;
 
@@ -90,6 +91,7 @@ Panel::Panel()
     this->extmounter= nullptr;
     this->external_sd_enable= false;
     this->in_idle= false;
+    this->display_extruder= false;
     strcpy(this->playing_file, "Playing file");
 }
 
@@ -189,6 +191,9 @@ void Panel::on_module_loaded()
         // read encoder pins
         THEKERNEL->slow_ticker->attach( 1000, this, &Panel::encoder_check );
     }
+
+    // configure display options.
+    this->display_extruder = THEKERNEL->config->value( panel_checksum, display_extruder_checksum )->by_default(false)->as_bool();
 
     // Register for events
     this->register_for_event(ON_IDLE);
@@ -641,6 +646,12 @@ bool Panel::is_suspended() const
     }
     return false;
 }
+
+bool Panel::is_extruder_display_enabled(void)
+{
+    return this->display_extruder;
+}
+
 
 void  Panel::set_playing_file(string f)
 {

--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -84,6 +84,8 @@ class Panel : public Module {
         void set_jogging_speed(int i, float v) { jogging_speed_mm_min[i]= v; }
         bool has_laser() const { return laser_enabled; }
 
+        bool is_extruder_display_enabled(void);
+
         // public as it is directly accessed by screens... not good
         // TODO pass lcd into ctor of each sub screen
         LcdBase* lcd;
@@ -135,23 +137,26 @@ class Panel : public Module {
         std::string message;
         encoder_cb_t encoder_cb_fnc;
 
-        uint16_t screen_lines;
-        uint16_t menu_current_line;
         char playing_file[20];
-        uint8_t extsd_spi_channel;
 
         volatile struct {
+            uint16_t screen_lines:16;
+            uint16_t menu_current_line:16;
+            uint8_t extsd_spi_channel:8;
+
             bool start_up:1;
             bool menu_changed:1;
             bool control_value_changed:1;
             bool external_sd_enable:1;
             bool laser_enabled:1;
             bool in_idle:1;
+            bool display_extruder:1;
             volatile bool counter_changed:1;
             volatile bool click_changed:1;
             volatile bool refresh_flag:1;
             volatile bool do_buttons:1;
             volatile bool do_encoder:1;
+
             char mode:2;
             char menu_offset:3;
             int encoder_click_resolution:3;

--- a/src/modules/utils/panel/screens/3dprinter/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/WatchScreen.cpp
@@ -22,6 +22,7 @@
 #include "SwitchPublicAccess.h"
 #include "checksumm.h"
 #include "TemperatureControlPool.h"
+#include "ExtruderPublicAccess.h"
 
 
 #include <math.h>
@@ -29,6 +30,8 @@
 #include <string>
 #include <stdio.h>
 #include <algorithm>
+
+#define extruder_checksum CHECKSUM("extruder")
 
 using namespace std;
 static const uint8_t icons[] = { // 16x80 - he1, he2, he3, bed, fan
@@ -249,7 +252,17 @@ void WatchScreen::display_menu_line(uint16_t line)
             }
             break;
         }
-        case 1: THEPANEL->lcd->printf("X%4d Y%4d Z%7.2f", (int)round(this->pos[0]), (int)round(this->pos[1]), this->pos[2]); break;
+        case 1:
+            if ( THEPANEL->is_playing() ) {
+                pad_extruder_t rd;
+                float extruder_pos = (PublicData::get_value( extruder_checksum, (void *)&rd )) ? rd.current_position : -1;
+                THEPANEL->lcd->printf("E %1.2f", extruder_pos);
+                THEPANEL->lcd->setCursor(12, line);
+                THEPANEL->lcd->printf("Z%7.2f", this->pos[2]);
+            } else {
+                THEPANEL->lcd->printf("X%4d Y%4d Z%7.2f", (int)round(this->pos[0]), (int)round(this->pos[1]), this->pos[2]);
+            }
+            break;
         case 2: THEPANEL->lcd->printf("%3d%%  %02lu:%02lu:%02lu  %3u%%", this->current_speed, this->elapsed_time / 3600, (this->elapsed_time % 3600) / 60, this->elapsed_time % 60, this->sd_pcnt_played); break;
         case 3: THEPANEL->lcd->printf("%19s", this->get_status()); break;
     }

--- a/src/modules/utils/panel/screens/3dprinter/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/WatchScreen.cpp
@@ -5,18 +5,18 @@
       You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "libs/Kernel.h"
+#include "Kernel.h"
 #include "LcdBase.h"
 #include "Panel.h"
 #include "PanelScreen.h"
 #include "MainMenuScreen.h"
 #include "WatchScreen.h"
-#include "libs/nuts_bolts.h"
-#include "libs/utils.h"
-#include "modules/tools/temperaturecontrol/TemperatureControlPublicAccess.h"
+#include "nuts_bolts.h"
+#include "utils.h"
+#include "TemperatureControlPublicAccess.h"
 #include "Robot.h"
-#include "modules/robot/Conveyor.h"
-#include "modules/utils/player/PlayerPublicAccess.h"
+#include "Conveyor.h"
+#include "PlayerPublicAccess.h"
 #include "NetworkPublicAccess.h"
 #include "PublicData.h"
 #include "SwitchPublicAccess.h"
@@ -30,8 +30,6 @@
 #include <string>
 #include <stdio.h>
 #include <algorithm>
-
-#define extruder_checksum CHECKSUM("extruder")
 
 using namespace std;
 static const uint8_t icons[] = { // 16x80 - he1, he2, he3, bed, fan
@@ -47,6 +45,8 @@ static const uint8_t icons[] = { // 16x80 - he1, he2, he3, bed, fan
 	0x85, 0x03, 0x85, 0xc3, 0x00, 0xe0, 0x3e, 0xf9, 0xbf, 0xfd, 0x9f, 0x7c, 0x07, 0x00, 0xc3,
 	0xa1, 0xc0, 0xa1, 0xc5, 0x93, 0xd9, 0x47, 0xc2, 0x37, 0x9c
 };
+
+#define extruder_checksum CHECKSUM("extruder")
 
 WatchScreen::WatchScreen()
 {
@@ -252,10 +252,10 @@ void WatchScreen::display_menu_line(uint16_t line)
             }
             break;
         }
-        case 1:
-            if ( THEPANEL->is_playing() ) {
-                pad_extruder_t rd;
-                float extruder_pos = (PublicData::get_value( extruder_checksum, (void *)&rd )) ? rd.current_position : -1;
+        case 1: {
+            pad_extruder_t rd;
+            if ( THEPANEL->is_extruder_display_enabled() && THEPANEL->is_playing() && PublicData::get_value(extruder_checksum, (void *)&rd)) {
+                float extruder_pos = rd.current_position;
                 THEPANEL->lcd->printf("E %1.2f", extruder_pos);
                 THEPANEL->lcd->setCursor(12, line);
                 THEPANEL->lcd->printf("Z%7.2f", this->pos[2]);
@@ -263,6 +263,7 @@ void WatchScreen::display_menu_line(uint16_t line)
                 THEPANEL->lcd->printf("X%4d Y%4d Z%7.2f", (int)round(this->pos[0]), (int)round(this->pos[1]), this->pos[2]);
             }
             break;
+        }
         case 2: THEPANEL->lcd->printf("%3d%%  %02lu:%02lu:%02lu  %3u%%", this->current_speed, this->elapsed_time / 3600, (this->elapsed_time % 3600) / 60, this->elapsed_time % 60, this->sd_pcnt_played); break;
         case 3: THEPANEL->lcd->printf("%19s", this->get_status()); break;
     }


### PR DESCRIPTION
I have found that when a print is in progress, I have more interest in the Extruder position than the X and Y positions (which are changing too rapidly).  I modified the watch screen to display the X, Y and Z positions when the printer is idle, and the Extruder and Z positions when printing.

I present this for your consideration, in case anyone else would find it useful.