### PR TITLE
Hotend and bed can be preheated separately

### DIFF
--- a/src/modules/utils/panel/screens/3dprinter/PreheatScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/PreheatScreen.cpp
@@ -1,0 +1,72 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/Kernel.h"
+#include "Panel.h"
+#include "PanelScreen.h"
+#include "LcdBase.h"
+#include "PreheatScreen.h"
+#include "libs/nuts_bolts.h"
+#include "libs/utils.h"
+#include "checksumm.h"
+#include "PublicDataRequest.h"
+#include "PublicData.h"
+#include "TemperatureControlPublicAccess.h"
+#include "TemperatureControlPool.h"
+
+#include <string>
+using namespace std;
+
+PreheatScreen::PreheatScreen()
+{
+    this->hotend_temp_preheat = THEPANEL->get_default_hotend_temp();
+    this->bed_temp_preheat = THEPANEL->get_default_bed_temp();
+}
+
+void PreheatScreen::on_enter()
+{
+    THEPANEL->enter_menu_mode();
+    THEPANEL->setup_menu(3);
+    this->refresh_menu();
+}
+
+void PreheatScreen::on_refresh()
+{
+    if ( THEPANEL->menu_change() ) {
+        this->refresh_menu();
+    }
+    if ( THEPANEL->click() ) {
+        this->clicked_menu_entry(THEPANEL->get_menu_current_line());
+    }
+}
+
+void PreheatScreen::display_menu_line(uint16_t line)
+{
+    switch ( line ) {
+        case 0: THEPANEL->lcd->printf("Back"          ); break;
+        case 1: THEPANEL->lcd->printf("Preheat hotend"); break;
+        case 2: THEPANEL->lcd->printf("Preheat bed"   ); break;
+    }
+}
+
+void PreheatScreen::clicked_menu_entry(uint16_t line)
+{
+    switch ( line ) {
+        case 0: THEPANEL->enter_screen(this->parent); break;
+        case 1: preheat_hotend(); break;
+        case 2: preheat_bed(); break;
+    }
+}
+
+void PreheatScreen::preheat_hotend() {
+    PublicData::set_value( temperature_control_checksum, hotend_checksum, &(this->hotend_temp_preheat) );
+}
+
+void PreheatScreen::preheat_bed()
+{
+    PublicData::set_value( temperature_control_checksum, bed_checksum, &(this->bed_temp_preheat) );
+}

--- a/src/modules/utils/panel/screens/3dprinter/PreheatScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/PreheatScreen.cpp
@@ -30,7 +30,7 @@ PreheatScreen::PreheatScreen()
 void PreheatScreen::on_enter()
 {
     THEPANEL->enter_menu_mode();
-    THEPANEL->setup_menu(3);
+    THEPANEL->setup_menu(4);
     this->refresh_menu();
 }
 
@@ -48,8 +48,9 @@ void PreheatScreen::display_menu_line(uint16_t line)
 {
     switch ( line ) {
         case 0: THEPANEL->lcd->printf("Back"          ); break;
-        case 1: THEPANEL->lcd->printf("Preheat hotend"); break;
-        case 2: THEPANEL->lcd->printf("Preheat bed"   ); break;
+        case 1: THEPANEL->lcd->printf("Preheat all"); break;
+        case 2: THEPANEL->lcd->printf("Preheat hotend"); break;
+        case 3: THEPANEL->lcd->printf("Preheat bed"   ); break;
     }
 }
 
@@ -57,8 +58,9 @@ void PreheatScreen::clicked_menu_entry(uint16_t line)
 {
     switch ( line ) {
         case 0: THEPANEL->enter_screen(this->parent); break;
-        case 1: preheat_hotend(); break;
-        case 2: preheat_bed(); break;
+        case 1: preheat_hotend(); preheat_bed(); break;
+        case 2: preheat_hotend(); break;
+        case 3: preheat_bed(); break;
     }
 }
 

--- a/src/modules/utils/panel/screens/3dprinter/PreheatScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/PreheatScreen.h
@@ -5,15 +5,15 @@
       You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PREPARESCREEN_H
-#define PREPARESCREEN_H
+#ifndef PREHEATSCREEN_H
+#define PREHEATSCREEN_H
 
 #include "PanelScreen.h"
 
-class PrepareScreen : public PanelScreen
+class PreheatScreen : public PanelScreen
 {
 public:
-    PrepareScreen();
+    PreheatScreen();
 
     void on_refresh();
     void on_enter();
@@ -22,12 +22,11 @@ public:
     int idle_timeout_secs() { return 60; }
 
 private:
-    void preheat();
-    void cooldown();
-    void setup_temperature_screen();
+    void preheat_hotend();
+    void preheat_bed();
 
-    PanelScreen *extruder_screen;
-    PanelScreen *preheat_screen;
+    float hotend_temp_preheat;
+    float bed_temp_preheat;
 };
 
 #endif

--- a/src/modules/utils/panel/screens/3dprinter/PrepareScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/PrepareScreen.cpp
@@ -10,6 +10,7 @@
 #include "PanelScreen.h"
 #include "LcdBase.h"
 #include "PrepareScreen.h"
+#include "PreheatScreen.h"
 #include "ExtruderScreen.h"
 #include "libs/nuts_bolts.h"
 #include "libs/utils.h"
@@ -30,8 +31,10 @@ PrepareScreen::PrepareScreen()
     bool ok = PublicData::get_value(temperature_control_checksum, poll_controls_checksum, &controllers);
     if (ok && controllers.size() > 0) {
         this->extruder_screen = (new ExtruderScreen())->set_parent(this);
+        this->preheat_screen = (new PreheatScreen())->set_parent(this);
     }else{
         this->extruder_screen= nullptr;
+        this->preheat_screen= nullptr;
     }
 }
 
@@ -62,7 +65,7 @@ void PrepareScreen::display_menu_line(uint16_t line)
         case 3: THEPANEL->lcd->printf("Set Z0"         ); break;
         case 4: THEPANEL->lcd->printf("Motors off"     ); break;
         // these won't be accessed if no heaters or extruders
-        case 5: THEPANEL->lcd->printf("Pre Heat"       ); break;
+        case 5: THEPANEL->lcd->printf("Pre Heat..."    ); break;
         case 6: THEPANEL->lcd->printf("Cool Down"      ); break;
         case 7: THEPANEL->lcd->printf("Extruder..."    ); break;
         case 8: THEPANEL->lcd->printf("Set Temperature"); break;
@@ -77,19 +80,11 @@ void PrepareScreen::clicked_menu_entry(uint16_t line)
         case 2: send_command("G92 X0 Y0 Z0"); break;
         case 3: send_command("G92 Z0"); break;
         case 4: send_command("M84"); break;
-        case 5: this->preheat(); break;
+        case 5: THEPANEL->enter_screen(this->preheat_screen); break;
         case 6: this->cooldown(); break;
         case 7: THEPANEL->enter_screen(this->extruder_screen); break;
         case 8: setup_temperature_screen(); break;
     }
-}
-
-void PrepareScreen::preheat()
-{
-    float t = THEPANEL->get_default_hotend_temp();
-    PublicData::set_value( temperature_control_checksum, hotend_checksum, &t );
-    t = THEPANEL->get_default_bed_temp();
-    PublicData::set_value( temperature_control_checksum, bed_checksum, &t );
 }
 
 void PrepareScreen::cooldown()


### PR DESCRIPTION
Some heated beds take significantly longer to heat up rather than most hotends, so I often find myself turning on the former a minute or two before the latter. I guess that having the possibility to preheat a single element could benefit many users.

I created a subscreen in **Prepare > Pre Heat...**, with the options to preheat everything (as to maintain backwards compatibility, the old behavior is just one more button press away), preheat the hotend only, and preheat the bed only.

_Do you think that this could be a valuable addition to the fw?_

+ The feature was tested on my _Smoothieboard 5X v1.0a _ and [_RepRapDiscount GLCD_](http://smoothieware.org/panel#toc6).