### PR TITLE
Support for signed commit in versioning script

### DIFF
--- a/src/generate-version.sh
+++ b/src/generate-version.sh
@@ -1,2 +1,2 @@
-echo `git symbolic-ref HEAD 2> /dev/null | cut -b 12-`-`git log --pretty=format:%h -1`
+echo `git symbolic-ref HEAD 2> /dev/null | cut -b 12-`-`git rev-parse --short=7 HEAD`
 touch version.cpp


### PR DESCRIPTION
Relevant discussion is in #1057 .

**Tests:**

### Unsigned commits

  + Original `git log --pretty=format:%h -1`:
```
$ strings LPC1768/main.bin | grep -i $(git log --pretty=format:%h -1)
edge-27d3f52
```
  + Patched `git rev-parse --short=7 HEAD`:
```
$ strings LPC1768/main.bin | grep -i $(git rev-parse --short=7 HEAD)
edge-27d3f52
```

### Signed commits

  + Original `git log --pretty=format:%h -1`:
```
BUILD ERROR
```
  + Patched `git rev-parse --short=7 HEAD`:
```
$ strings LPC1768/main.bin | grep -i $(git rev-parse --short=7 HEAD)
edge-0e82de9
```