### PR TITLE
Fix error: 'isnan' was not declared in this scope

### DIFF
--- a/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaCalibrationStrategy.cpp
@@ -14,6 +14,7 @@
 #include "BaseSolution.h"
 #include "StepperMotor.h"
 
+#include <cmath>
 #include <tuple>
 #include <algorithm>
 


### PR DESCRIPTION
Log excerpt from compilation using default arm toolset available on Fedora:
$ arm-none-eabi-g++ --version
arm-none-eabi-g++ (Fedora 6.1.0-2.fc24) 6.1.0

compiling modules/tools/zprobe/DeltaCalibrationStrategy.cpp
modules/tools/zprobe/DeltaCalibrationStrategy.cpp: In member function 'bool DeltaCalibrationStrategy::probe_delta_points(Gcode*)':
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:99:19: error: 'isnan' was not declared in this scope
     if(isnan(bedht)) return false;
                   ^
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:117:19: error: 'NAN' was not declared in this scope
     float last_z= NAN;
                   ^~~
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:137:24: error: 'isnan' was not declared in this scope
         if(isnan(last_z)) {
                        ^
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:140:58: error: 'fabsf' was not declared in this scope
             max_delta= std::max(max_delta, fabsf(z-last_z));
                                                          ^
modules/tools/zprobe/DeltaCalibrationStrategy.cpp: In member function 'float DeltaCalibrationStrategy::findBed()':
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:156:30: error: 'NAN' was not declared in this scope
     zprobe->coordinated_move(NAN, NAN, -deltaz, zprobe->getFastFeedrate(), true);
                              ^~~
modules/tools/zprobe/DeltaCalibrationStrategy.cpp: In member function 'bool DeltaCalibrationStrategy::calibrate_delta_endstops(Gcode*)':
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:214:19: error: 'isnan' was not declared in this scope
     if(isnan(bedht)) return false;
                   ^
modules/tools/zprobe/DeltaCalibrationStrategy.cpp:222:16: error: 'fabsf' was not declared in this scope
     if(fabsf(dz) > target) {