### PR TITLE
add a configurable range for the runaway temp checks

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -421,10 +421,18 @@ void Robot::on_gcode_received(void *argument)
             case 1:  motion_mode = LINEAR;  break;
             case 2:  motion_mode = CW_ARC;  break;
             case 3:  motion_mode = CCW_ARC; break;
-            case 4: { // G4 pause
+            case 4: { // G4 Dwell
                 uint32_t delay_ms = 0;
                 if (gcode->has_letter('P')) {
-                    delay_ms = gcode->get_int('P');
+                    if(THEKERNEL->is_grbl_mode()) {
+                        // in grbl mode (and linuxcnc) P is decimal seconds
+                        float f= gcode->get_value('P');
+                        delay_ms= f * 1000.0F;
+
+                    }else{
+                        // in reprap P is milliseconds, they always have to be different!
+                        delay_ms = gcode->get_int('P');
+                    }
                 }
                 if (gcode->has_letter('S')) {
                     delay_ms += gcode->get_int('S') * 1000;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -69,6 +69,8 @@ class TemperatureControl : public Module {
         float d_factor;
         float PIDdt;
 
+        float runaway_error_range;
+
         enum RUNAWAY_TYPE {NOT_HEATING, HEATING_UP, COOLING_DOWN, TARGET_TEMPERATURE_REACHED};
 
         // pack these to save memory


### PR DESCRIPTION
One issue people run into is if the bed is not well PID tuned it may sit a little above the target temperature set. This becomes an issue if the bed is still hot and the temp is set, the runaway detection will go into cool down mode and timeout because the temp never drops below or reaches the set point.
By adding a fudge factor it, by default, only needs to get within 1°C of the set temp to change state.
A new optional configuration setting of `runaway_error_range` can be set to change the fudge factor.
**NOTE** that by default cool down mode is disabled.

Also changed G4 Pxxx to be float seconds when in grbl compatibility mode.