### PR TITLE
Fix the z-probe delta grid code for cartesian printers.

### DIFF
--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -261,7 +261,7 @@ bool DeltaGridStrategy::probe_grid(int n, float radius, StreamOutput *stream)
             float distance_from_center = sqrtf(x*x + y*y);
             float z= 0.0F;
             if ((!is_square && (distance_from_center <= radius)) ||
-               (is_square && (x < -x_max || x > x_max || y < -y_max || y > y_max))) {
+                (is_square && x >= -x_max && x <= x_max && y >= -y_max && y <= y_max)) {
                 float mm;
                 if(!zprobe->doProbeAt(mm, x, y)) return false;
                 z = zprobe->getProbeHeight() - mm;


### PR DESCRIPTION
Fixes the G29 command using the delta grid leveling strategy on cartesian printers (is_square = true).
Before the fix only the center of my printer was probed, after the fix all the points are probed as expected.