### PR TITLE
Fix a bug where very slow feedrates could cause the step rate to be less than the stepticker period.

### DIFF
--- a/src/modules/robot/ActuatorCoordinates.h
+++ b/src/modules/robot/ActuatorCoordinates.h
@@ -18,6 +18,10 @@
     #endif
 #endif
 
+#if MAX_ROBOT_ACTUATORS < 3 || MAX_ROBOT_ACTUATORS > 6
+#error "MAX_ROBOT_ACTUATORS must be >= 3 and <= 6"
+#endif
+
 #ifndef N_PRIMARY_AXIS
     // This may chnage and include ABC
     #define N_PRIMARY_AXIS 3

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -84,9 +84,9 @@ void Block::debug() const
 {
     THEKERNEL->streams->printf("%p: steps-X:%lu Y:%lu Z:%lu ", this, this->steps[0], this->steps[1], this->steps[2]);
     for (size_t i = E_AXIS; i < n_actuators; ++i) {
-        THEKERNEL->streams->printf("E%d:%lu ", i-E_AXIS, this->steps[i]);
+        THEKERNEL->streams->printf("%c:%lu ", 'A' + i-E_AXIS, this->steps[i]);
     }
-    THEKERNEL->streams->printf("(max:%lu) nominal:r%1.4f/s%1.4f mm:%1.4f acc:%1.2f accu:%lu decu:%lu ticks:%lu rates:%1.4f entry/max:%1.4f/%1.4f exit:%1.4f primary:%d ready:%d locked:%d ticking:%d recalc:%d nomlen:%d time:%f\r\n",
+    THEKERNEL->streams->printf("(max:%lu) nominal:r%1.4f/s%1.4f mm:%1.4f acc:%1.2f accu:%lu decu:%lu ticks:%lu rates:%1.4f/%1.4f entry/max:%1.4f/%1.4f exit:%1.4f primary:%d ready:%d locked:%d ticking:%d recalc:%d nomlen:%d time:%f\r\n",
                                this->steps_event_count,
                                this->nominal_rate,
                                this->nominal_speed,
@@ -96,6 +96,7 @@ void Block::debug() const
                                this->decelerate_after,
                                this->total_move_ticks,
                                this->initial_rate,
+                               this->maximum_rate,
                                this->entry_speed,
                                this->max_entry_speed,
                                this->exit_speed,
@@ -201,7 +202,7 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
     // Now figure out the acceleration PER TICK, this should ideally be held as a float, even a double if possible as it's very critical to the block timing
     // steps/tick^2
 
-    this->acceleration_per_tick =  acceleration_in_steps / STEP_TICKER_FREQUENCY_2;
+    this->acceleration_per_tick = acceleration_in_steps / STEP_TICKER_FREQUENCY_2;
     this->deceleration_per_tick = deceleration_in_steps / STEP_TICKER_FREQUENCY_2;
 
     // We now have everything we need for this block to call a Steppermotor->move method !!!!

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -178,8 +178,9 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
     // the exact rate we want
 
     // First off round total time, acceleration time and deceleration time in ticks
-    uint32_t acceleration_ticks = floorf( time_to_accelerate * STEP_TICKER_FREQUENCY );
-    uint32_t deceleration_ticks = floorf( time_to_decelerate * STEP_TICKER_FREQUENCY );
+    // NOTE we need to make sure this is no less than 1 which would happen if the time to accelerate was less than the current step period
+    uint32_t acceleration_ticks = ceilf( time_to_accelerate * STEP_TICKER_FREQUENCY );
+    uint32_t deceleration_ticks = ceilf( time_to_decelerate * STEP_TICKER_FREQUENCY );
     uint32_t total_move_ticks   = floorf( total_move_time    * STEP_TICKER_FREQUENCY );
 
     // Now deduce the plateau time for those new values expressed in tick
@@ -189,8 +190,8 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
     float acceleration_time = acceleration_ticks / STEP_TICKER_FREQUENCY;  // This can be moved into the operation below, separated for clarity, note we need to do this instead of using time_to_accelerate(seconds) directly because time_to_accelerate(seconds) and acceleration_ticks(seconds) do not have the same value anymore due to the rounding
     float deceleration_time = deceleration_ticks / STEP_TICKER_FREQUENCY;
 
-    float acceleration_in_steps = (acceleration_time > 0.0F ) ? ( this->maximum_rate - initial_rate ) / acceleration_time : 0;
-    float deceleration_in_steps =  (deceleration_time > 0.0F ) ? ( this->maximum_rate - final_rate ) / deceleration_time : 0;
+    float acceleration_in_steps = ( this->maximum_rate - initial_rate ) / acceleration_time;
+    float deceleration_in_steps = ( this->maximum_rate - final_rate ) / deceleration_time;
 
     // we have a potential race condition here as we could get interrupted anywhere in the middle of this call, we need to lock
     // the updates to the blocks to get around it

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -110,7 +110,7 @@ void Conveyor::on_idle(void*)
         } else {
             // Cleanly delete block
             Block* block = queue.tail_ref();
-            //block->debug();
+            block->debug();
             block->clear();
             queue.consume_tail();
         }

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -110,7 +110,7 @@ void Conveyor::on_idle(void*)
         } else {
             // Cleanly delete block
             Block* block = queue.tail_ref();
-            block->debug();
+            //block->debug();
             block->clear();
             queue.consume_tail();
         }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -626,7 +626,7 @@ void Robot::on_gcode_received(void *argument)
                 return;
 
             case 114:{
-                char buf[64];
+                char buf[128];
                 int n= print_position(gcode->subcode, buf, sizeof buf);
                 if(n > 0) gcode->txt_after_ok.append(buf, n);
                 return;

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -817,7 +817,7 @@ void SimpleShell::get_command( string parameters, StreamOutput *stream)
 
    } else if (what == "pos") {
         // convenience to call all the various M114 variants
-        char buf[64];
+        char buf[128];
         THEROBOT->print_position(0, buf, sizeof buf); stream->printf("last %s\n", buf);
         THEROBOT->print_position(1, buf, sizeof buf); stream->printf("realtime %s\n", buf);
         THEROBOT->print_position(2, buf, sizeof buf); stream->printf("%s\n", buf);


### PR DESCRIPTION
Potential fix used here is to make sure that the minimum ticks for acceleration is 1. 
Not sure if that may have consequences.

This showed up as a problem doing G1 X1 F1 where it would step at high rates and finish immediately