### PR TITLE
free up old config value when a duplicate is found.

### DIFF
--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -34,6 +34,7 @@ void ConfigCache::replace_or_push_back(ConfigValue *new_value)
         // If this configvalue matches the checksum
         if(memcmp(new_value->check_sums, cv->check_sums, sizeof(cv->check_sums)) == 0) {
             // Replace with the provided value
+            delete cv; // free up old one
             cv =  new_value;
             printf("WARNING: duplicate config line replaced\n");
             return;


### PR DESCRIPTION
Duplicate config entries can cause a memory leak.