### PR TITLE
release the include directive if found in config

### DIFF
--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -26,6 +26,13 @@ void ConfigCache::add(ConfigValue *v)
     store.push_back(v);
 }
 
+void ConfigCache::pop()
+{
+    auto cv= store.back();
+    store.pop_back();
+    delete cv;
+}
+
 // If we find an existing value, replace it, otherwise, push it at the back of the list
 void ConfigCache::replace_or_push_back(ConfigValue *new_value)
 {

--- a/src/libs/ConfigCache.h
+++ b/src/libs/ConfigCache.h
@@ -23,6 +23,7 @@ class ConfigCache {
         void clear();
 
         void add(ConfigValue* v);
+        void pop();
 
         // lookup and return the entru that matches the check sums,return NULL if not found
         ConfigValue *lookup(const uint16_t *check_sums) const;

--- a/src/libs/ConfigSources/FileConfigSource.cpp
+++ b/src/libs/ConfigSources/FileConfigSource.cpp
@@ -80,6 +80,8 @@ void FileConfigSource::transfer_values_to_cache( ConfigCache *cache, const char 
             // if this line is an include directive then attempt to read the included file
             if(cv->check_sums[0] == include_checksum) {
                 string inc_file_name = cv->value.c_str();
+                cache->pop(); // we do not need to keep this around or leave it on the list
+
                 if(!file_exists(inc_file_name)) {
                     // if the file is not found at the location entered then look around for it a bit
                     if(inc_file_name[0] != '/') inc_file_name = "/" + inc_file_name;


### PR DESCRIPTION
no need to have it in the cache. Would also cause a memory leak if multiple includes were in the config.