### PR TITLE
Add ZGrid compatibility to CartesianGrid

### DIFF
--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -294,12 +294,15 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
             // first wait for an empty queue i.e. no moves left
             THEKERNEL->conveyor->wait_for_idle();
 
-            int m = gcode->has_letter('I') ? gcode->get_value('I') : grid_size_x;
-            int n = gcode->has_letter('J') ? gcode->get_value('J') : grid_size_y;
+            int n = gcode->has_letter('I') ? gcode->get_value('I') : 7;
+
+            // Add option to specify X and Y independent grid sizes
+            int o = gcode->has_letter('J') ? gcode->get_value('I') : n;
+
             float x = x_size, y = y_size;
             if(gcode->has_letter('X')) x = gcode->get_value('X'); // override default probe width
             if(gcode->has_letter('Y')) y = gcode->get_value('Y'); // override default probe length
-            probe_grid(m, n, x, y, gcode->stream);
+            probe_grid(n, o, x, y, gcode->stream);
 
             return true;
 

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -36,7 +36,7 @@ private:
     float *grid;
     std::tuple<float, float, float> probe_offsets;
     std::tuple<float, float, float> m_attach;
-    uint8_t grid_size,grid_size_x,grid_size_y;
+    uint8_t grid_size, grid_size_x, grid_size_y;
     float x_size,y_size;
 
     struct {

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -28,14 +28,14 @@ private:
     void reset_bed_level();
     void save_grid(StreamOutput *stream);
     bool load_grid(StreamOutput *stream);
-    bool probe_grid(int n, float x_size, float y_size, StreamOutput *stream);
+    bool probe_grid(int m, int n, float x_size, float y_size, StreamOutput *stream);
 
     float initial_height;
     float tolerance;
 
     float *grid;
     std::tuple<float, float, float> probe_offsets;
-    uint8_t grid_size;
+    uint8_t grid_size,grid_size_x,grid_size_y;
     float x_size,y_size;
 
     struct {

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -35,11 +35,13 @@ private:
 
     float *grid;
     std::tuple<float, float, float> probe_offsets;
+    std::tuple<float, float, float> m_attach;
     uint8_t grid_size,grid_size_x,grid_size_y;
     float x_size,y_size;
 
     struct {
         bool save:1;
         bool do_home:1;
+        bool do_manual_attach:1;
     };
 };

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -238,8 +238,8 @@ bool ZProbe::run_probe_return(float& mm, float feedrate, float max_dist, bool re
         if(fr > this->fast_feedrate) fr = this->fast_feedrate; // unless that is greater than fast feedrate
     }
 
-    // absolute move back to saved starting position
-    coordinated_move(save_pos[0], save_pos[1], save_pos[2], fr, false);
+    // absolute move back to saved starting position: Only in Z direction
+    coordinated_move(NAN, NAN, save_pos[2], fr, false);
 
     return ok;
 }


### PR DESCRIPTION
Adds functions to cartgrid in order to make it usable for machines with long beds, like Morgan.
* Ability to specify different X and Y grid resolution
* Ability for head to park for manual attachment of probe
* One line change in ZProbe: return move only in Z direction to prevent stalling in undefined positions created by irregular bed shapes (halfmoon bed on Morgan)

All the changes are backwards compatible, and will have no adverse affects on current CartGrid users. 