### PR TITLE
Added support for PT100 using E3D amplifier.

### DIFF
--- a/src/modules/tools/temperaturecontrol/PT100_E3D.cpp
+++ b/src/modules/tools/temperaturecontrol/PT100_E3D.cpp
@@ -1,0 +1,70 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PT100_E3D.h"
+#include "libs/Kernel.h"
+#include "libs/Pin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "Adc.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+
+#define e3d_amplifier_pin_checksum  CHECKSUM("e3d_amplifier_pin")
+
+PT100_E3D::PT100_E3D()
+{
+}
+
+PT100_E3D::~PT100_E3D()
+{
+}
+
+// Get configuration from the config file
+void PT100_E3D::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
+{
+	// Pin used for ADC readings
+    this->amplifier_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, e3d_amplifier_pin_checksum)->required()->as_string());
+    THEKERNEL->adc->enable_pin(&amplifier_pin);
+}
+
+float PT100_E3D::get_temperature()
+{
+    float t = adc_value_to_temperature(new_pt100_reading());
+    // keep track of min/max for M305
+    if (t > max_temp) max_temp = t;
+    if (t < min_temp) min_temp = t;
+    return t;
+}
+
+void PT100_E3D::get_raw()
+{
+    int adc_value= new_pt100_reading();
+    float t = adc_value_to_temperature(new_pt100_reading());
+    THEKERNEL->streams->printf("PT100_E3D: adc= %d, temp= %f\n", adc_value, t);
+    // reset the min/max
+    min_temp = max_temp = t;
+}
+
+float PT100_E3D::adc_value_to_temperature(uint32_t adc_value)
+{
+    const uint32_t max_adc_value= THEKERNEL->adc->get_max_value();
+    if ((adc_value >= max_adc_value) || (adc_value == 0))
+        return infinityf();
+
+    // polynomial approximation of E3D published curve, using normalized ADC values instead of voltages
+    float x = (adc_value / (float)max_adc_value);
+    float x2 = (x * x);
+    float t = (382.7f * x2) + (1004.8f * x) - 241.84f;
+
+    return t;
+}
+
+int PT100_E3D::new_pt100_reading()
+{
+    return THEKERNEL->adc->read(&amplifier_pin);
+}

--- a/src/modules/tools/temperaturecontrol/PT100_E3D.h
+++ b/src/modules/tools/temperaturecontrol/PT100_E3D.h
@@ -1,0 +1,34 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PT100_E3D_H
+#define PT100_E3D_H
+
+#include "TempSensor.h"
+#include "Pin.h"
+
+// PT100 sensor via E3D amplifier
+class PT100_E3D : public TempSensor
+{
+public:
+	PT100_E3D();
+	~PT100_E3D();
+
+	// TempSensor interface.
+	void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
+	float get_temperature();
+	void get_raw();
+
+private:
+    int new_pt100_reading();
+    float adc_value_to_temperature(uint32_t adc_value);
+
+	Pin amplifier_pin;
+    float min_temp, max_temp;
+};
+
+#endif

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -30,6 +30,7 @@
 #include "Thermistor.h"
 #include "max31855.h"
 #include "AD8495.h"
+#include "PT100_E3D.h"
 
 #include "MRI_Hooks.h"
 
@@ -178,6 +179,8 @@ void TemperatureControl::load_config()
         sensor = new Max31855();
     } else if(sensor_type.compare("ad8495") == 0) {
         sensor = new AD8495();
+    } else if(sensor_type.compare("pt100_e3d") == 0) {
+        sensor = new PT100_E3D();
     } else {
         sensor = new TempSensor(); // A dummy implementation
     }


### PR DESCRIPTION
This PR adds support for the E3D PT100 amplifier.

The amplifier should be powered from AVCC (the exact voltage does not matter because the maths use normalized ADC values), unlike PR #1086. The configuration is simple:

```
temperature_control.hotend.sensor                pt100_e3d
temperature_control.hotend.e3d_amplifier_pin     1.30
```

The only gotcha (as discussed in the other PR) is that a standard temperature input cannot be used due to the pull-ups on the board, you have to use a free ADC pin (so 1.30 or 1.31 on most boards).

I have tested this with a PT100 and a Semitec thermistor connected to the same heaterblock (T0 was the PT100 and T1 was the reference thermistor), and the reported temperatures from the PT100 always matched within 1C for the operating range of the thermistor (i.e. below 280C).

Let me know if you want me to change things.