### PR TITLE
Junction deviation tweak

### DIFF
--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -160,10 +160,10 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
             #endif
 
             // Skip and use default max junction speed for 0 degree acute junction.
-            if (cos_theta < 1.0F) {
+            if (cos_theta < 0.999999F) {
                 vmax_junction = std::min(previous_nominal_speed, block->nominal_speed);
                 // Skip and avoid divide by zero for straight junctions at 180 degrees. Limit to min() of nominal speeds.
-                if (cos_theta > -1.0F) {
+                if (cos_theta > -0.999999F) {
                     // Compute maximum junction velocity based on maximum acceleration and junction deviation
                     float sin_theta_d2 = sqrtf(0.5F * (1.0F - cos_theta)); // Trig half angle identity. Always positive.
                     vmax_junction = std::min(vmax_junction, sqrtf(acceleration * junction_deviation * sin_theta_d2 / (1.0F - sin_theta_d2)));

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -160,10 +160,10 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
             #endif
 
             // Skip and use default max junction speed for 0 degree acute junction.
-            if (cos_theta < 0.95F) {
+            if (cos_theta < 1.0F) {
                 vmax_junction = std::min(previous_nominal_speed, block->nominal_speed);
                 // Skip and avoid divide by zero for straight junctions at 180 degrees. Limit to min() of nominal speeds.
-                if (cos_theta > -0.95F) {
+                if (cos_theta > -1.0F) {
                     // Compute maximum junction velocity based on maximum acceleration and junction deviation
                     float sin_theta_d2 = sqrtf(0.5F * (1.0F - cos_theta)); // Trig half angle identity. Always positive.
                     vmax_junction = std::min(vmax_junction, sqrtf(acceleration * junction_deviation * sin_theta_d2 / (1.0F - sin_theta_d2)));

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -160,10 +160,10 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
             #endif
 
             // Skip and use default max junction speed for 0 degree acute junction.
-            if (cos_theta < 0.999999F) {
+            if (cos_theta <= 0.9999F) {
                 vmax_junction = std::min(previous_nominal_speed, block->nominal_speed);
                 // Skip and avoid divide by zero for straight junctions at 180 degrees. Limit to min() of nominal speeds.
-                if (cos_theta > -0.999999F) {
+                if (cos_theta >= -0.9999F) {
                     // Compute maximum junction velocity based on maximum acceleration and junction deviation
                     float sin_theta_d2 = sqrtf(0.5F * (1.0F - cos_theta)); // Trig half angle identity. Always positive.
                     vmax_junction = std::min(vmax_junction, sqrtf(acceleration * junction_deviation * sin_theta_d2 / (1.0F - sin_theta_d2)));


### PR DESCRIPTION
In the original code, junction deviation was not calculated at values less than 0.95 (~18.2 degrees).  Any gcode file that allows the machine to reach max speed in a straight line and then goes into a turn consisting of line segments less than 18 degrees of change between them will keep the machine at full speed throughout the turn.  If 10 very short segments are placed together in this manner, the machine can complete a 180 degree movement change at max set speed without decelerating through the turn.  The 0.95 value has been changed to 1.0 allowing the max junction speed calculation to work with any line segments that are not co-linear.  This makes the code match the description in the comment.

This also fixes an issue described in the smoothie forums: http://forum.smoothieware.org/forum/t-2146070/smoothie-takes-a-corner-too-fast.

This has been tested for the last 3 months on a 3 axis mill and rigidbot 3d printer.

