### PR TITLE
Added MAX31865 support

### DIFF
--- a/src/modules/tools/temperaturecontrol/TempSensor.h
+++ b/src/modules/tools/temperaturecontrol/TempSensor.h
@@ -26,6 +26,7 @@ public:
     virtual bool set_optional(const sensor_options_t& options) { return false; }
     virtual bool get_optional(sensor_options_t& options) { return false; }
     virtual void get_raw() {}
+    virtual void on_idle() {}
 };
 
 #endif

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -29,6 +29,7 @@
 // Temp sensor implementations:
 #include "Thermistor.h"
 #include "max31855.h"
+#include "max31865.h"
 #include "AD8495.h"
 #include "PT100_E3D.h"
 
@@ -103,6 +104,7 @@ void TemperatureControl::on_module_loaded()
         this->register_for_event(ON_MAIN_LOOP);
         this->register_for_event(ON_SET_PUBLIC_DATA);
         this->register_for_event(ON_HALT);
+        this->register_for_event(ON_IDLE);
     }
 }
 
@@ -115,6 +117,12 @@ void TemperatureControl::on_halt(void *arg)
         this->target_temperature = UNDEFINED;
     }
 }
+
+void TemperatureControl::on_idle(void *arg)
+{
+    sensor->on_idle();
+}
+
 
 void TemperatureControl::on_main_loop(void *argument)
 {
@@ -177,6 +185,8 @@ void TemperatureControl::load_config()
         sensor = new Thermistor();
     } else if(sensor_type.compare("max31855") == 0) {
         sensor = new Max31855();
+    } else if(sensor_type.compare("max31865") == 0) {
+        sensor = new Max31865();
     } else if(sensor_type.compare("ad8495") == 0) {
         sensor = new AD8495();
     } else if(sensor_type.compare("pt100_e3d") == 0) {

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -26,6 +26,7 @@ class TemperatureControl : public Module {
         void on_get_public_data(void* argument);
         void on_set_public_data(void* argument);
         void on_halt(void* argument);
+        void on_idle(void* argument);
 
         void set_desired_temperature(float desired_temperature);
 

--- a/src/modules/tools/temperaturecontrol/max31855.cpp
+++ b/src/modules/tools/temperaturecontrol/max31855.cpp
@@ -22,6 +22,7 @@
 Max31855::Max31855() :
     spi(nullptr)
 {
+    this->read_flag=true;
 }
 
 Max31855::~Max31855()
@@ -57,40 +58,35 @@ void Max31855::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
     spi->format(16);
 }
 
+// returns an average of the last few temperature values we've read
 float Max31855::get_temperature()
 {
-	// Return an average of the last readings
-    if (readings.size() >= readings.capacity()) {
-        readings.delete_tail();
-    }
+    // allow read from hardware via SPI on next call to on_idle()
+    this->read_flag=true;
 
-	float temp = read_temp();
+    // Return an average of the last readings
+    if(readings.size()==0) return infinityf();
 
-	// Discard occasional errors...
-	if(!isinf(temp))
-	{
-		readings.push_back(temp);
-	}
-
-	if(readings.size()==0) return infinityf();
-
-	float sum = 0;
-    for (int i=0; i<readings.size(); i++) {
+    float sum = 0;
+    for (int i=0; i<readings.size(); i++)
         sum += *readings.get_ref(i);
-    }
 
-	return sum / readings.size();
+    return sum / readings.size();
 }
 
-float Max31855::read_temp()
+// ask the temperature sensor hardware for a value, store it in a buffer
+void Max31855::on_idle()
 {
+    // this rate limits SPI access
+    if(!this->read_flag) return;
+
     this->spi_cs_pin.set(false);
     wait_us(1); // Must wait for first bit valid
 
     // Read 16 bits (writing something as well is required by the api)
     uint16_t data = spi->write(0);
-	//  Read next 16 bits (diagnostics)
-//	uint16_t data2 = spi->write(0);
+    //  Read next 16 bits (diagnostics)
+    //	uint16_t data2 = spi->write(0);
 
     this->spi_cs_pin.set(true);
 
@@ -114,5 +110,17 @@ float Max31855::read_temp()
             temperature = ((data & 0x1FFF) + 1) / -4.f;
         }
     }
-    return temperature;
+
+    if (readings.size() >= readings.capacity()) {
+        readings.delete_tail();
+    }
+
+    // Discard occasional errors...
+    if(!isinf(temperature))
+    {
+        readings.push_back(temperature);
+    }
+
+    // don't read again until get_temperature() is called
+    this->read_flag=false;
 }

--- a/src/modules/tools/temperaturecontrol/max31855.h
+++ b/src/modules/tools/temperaturecontrol/max31855.h
@@ -21,9 +21,10 @@ public:
     ~Max31855();
     void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
     float get_temperature();
+    void on_idle();
 
 private:
-	float read_temp();
+    struct { bool read_flag:1; } ; //when true, the next call to on_idle will read a new temperature value
     Pin spi_cs_pin;
     mbed::SPI *spi;
     RingBuffer<float,16> readings;

--- a/src/modules/tools/temperaturecontrol/max31865.cpp
+++ b/src/modules/tools/temperaturecontrol/max31865.cpp
@@ -1,0 +1,259 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/Kernel.h"
+#include <math.h>
+#include "libs/Pin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+#include "utils.h"
+
+#include "max31865.h"
+
+#include "MRI_Hooks.h"
+
+#define MAX31856_CONFIG_REG            0x00
+#define MAX31856_RTDMSB_REG            0x01
+#define MAX31856_RTDLSB_REG            0x02
+#define MAX31856_HFAULTMSB_REG         0x03
+#define MAX31856_HFAULTLSB_REG         0x04
+#define MAX31856_LFAULTMSB_REG         0x05
+#define MAX31856_LFAULTLSB_REG         0x06
+#define MAX31856_FAULTSTAT_REG         0x07
+
+#define MAX31856_CONFIG_BIAS           0x80
+#define MAX31856_CONFIG_MODEAUTO       0x40
+#define MAX31856_CONFIG_MODEOFF        0x00
+#define MAX31856_CONFIG_1SHOT          0x20
+#define MAX31856_CONFIG_3WIRE          0x10
+#define MAX31856_CONFIG_24WIRE         0x00
+#define MAX31856_CONFIG_FAULTSTAT      0x02
+#define MAX31856_CONFIG_FILT50HZ       0x01
+#define MAX31856_CONFIG_FILT60HZ       0x00
+
+#define MAX31865_FAULT_HIGHTHRESH      0x80
+#define MAX31865_FAULT_LOWTHRESH       0x40
+#define MAX31865_FAULT_REFINLOW        0x20
+#define MAX31865_FAULT_REFINHIGH       0x10
+#define MAX31865_FAULT_RTDINLOW        0x08
+#define MAX31865_FAULT_OVUV            0x04
+
+#define RTD_A 3.9083e-3
+#define RTD_B -5.775e-7
+
+// at 50hz in AUTO mode, MAX31865 returns a new temperature reading (at worst) every 21ms
+#define MINIMUM_READ_INTERVAL_MS 25
+
+// MAX31865 supports SPI mode 1 and 3, autodetects based on SCLK state when CS is low
+#define SPI_MODE 3
+
+#define rtd_nominal_resistance_checksum CHECKSUM("rtd_nominal_resistance")
+#define reference_resistor_checksum CHECKSUM("reference_resistor")
+#define use_50hz_filter_checksum CHECKSUM("use_50hz_filter")
+#define chip_select_checksum CHECKSUM("chip_select_pin")
+#define spi_channel_checksum CHECKSUM("spi_channel")
+
+Max31865::Max31865() :
+    spi(nullptr)
+{
+    this->last_reading_time = 0;
+    this->last_temperature = infinityf();
+    this->errors_reported = 0;
+}
+
+Max31865::~Max31865()
+{
+    delete spi;
+}
+
+void Max31865::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
+{
+    this->rtd_nominal_resistance = THEKERNEL->config->value(module_checksum, name_checksum, rtd_nominal_resistance_checksum)->by_default(100.0f)->as_number();
+    this->reference_resistor = THEKERNEL->config->value(module_checksum, name_checksum, reference_resistor_checksum)->by_default(430.0f)->as_number();
+    this->use_50hz_filter = THEKERNEL->config->value(module_checksum, name_checksum, use_50hz_filter_checksum)->by_default(false)->as_bool();
+
+    // Chip select
+    this->spi_cs_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, chip_select_checksum)->by_default("0.16")->as_string());
+    this->spi_cs_pin.set(true);
+    this->spi_cs_pin.as_output();
+
+    // select which SPI channel to use
+    int spi_channel = THEKERNEL->config->value(module_checksum, name_checksum, spi_channel_checksum)->by_default(0)->as_number();
+    PinName miso;
+    PinName mosi;
+    PinName sclk;
+    if(spi_channel == 0) {
+        // Channel 0
+        mosi=P0_18; miso=P0_17; sclk=P0_15;
+    } else {
+        // Channel 1
+        mosi=P0_9; miso=P0_8; sclk=P0_7;
+    }
+
+    delete spi;
+    spi = new mbed::SPI(mosi, miso, sclk);
+
+    init_rtd();
+}
+
+void Max31865::init_rtd()
+{
+    // enable bias, enable automatic conversions, clear pending faults, set 50/60hz filter
+    uint8_t cfg = MAX31856_CONFIG_BIAS | MAX31856_CONFIG_MODEAUTO | MAX31856_CONFIG_FAULTSTAT;
+    if (this->use_50hz_filter)
+        cfg |= MAX31856_CONFIG_FILT50HZ;
+
+    write_register_8(MAX31856_CONFIG_REG, cfg);
+    write_register_8(MAX31856_HFAULTMSB_REG, 0xff);
+    write_register_8(MAX31856_HFAULTLSB_REG, 0xff);
+    write_register_8(MAX31856_LFAULTMSB_REG, 0x00);
+    write_register_8(MAX31856_LFAULTLSB_REG, 0x00);
+
+    // initial bias voltage startup time is 10ms
+    // first temperature conversion after enabling AUTO mode takes at most 66ms
+    this->last_reading_time = us_ticker_read() + ((10 + 66) * 1000);
+}
+
+float Max31865::get_temperature()
+{
+    return this->last_temperature.load();
+}
+
+void Max31865::get_raw()
+{
+    uint16_t rawData = read_register_16(MAX31856_RTDMSB_REG);
+    uint16_t adcValue = rawData >> 1;
+
+    float Rt = adc_value_to_resistance(adcValue);
+    float t = resistance_to_temperature(Rt);
+
+    THEKERNEL->streams->printf("Max31865: adc= %d/32767, resistance= %f, temp= %f\n", adcValue, Rt, t);
+    THEKERNEL->streams->printf("RTD nominal resistance= %f, reference resistor= %f, using %dHz filter\n", 
+        this->rtd_nominal_resistance, this->reference_resistor, this->use_50hz_filter ? 50 : 60);
+
+    // reset in case of fault
+    if (rawData & 1)
+    {
+        print_errors(true);
+        init_rtd();
+    }
+}
+
+// ask the temperature sensor hardware for a value, store it in a buffer
+void Max31865::on_idle()
+{
+    // wait if next temperature conversion is not yet ready
+    if ((us_ticker_read() - last_reading_time) < MINIMUM_READ_INTERVAL_MS * 1000)
+        return;
+
+    float t = infinityf();
+
+    uint16_t rawData = read_register_16(MAX31856_RTDMSB_REG);
+    if (!(rawData & 1))
+    {
+        uint16_t adcValue = (rawData >> 1);
+
+        float Rt = adc_value_to_resistance(adcValue);
+        t = resistance_to_temperature(Rt);
+    }
+    else
+    {
+        // reset in case of fault
+        print_errors();
+        init_rtd();
+    }
+
+    this->last_reading_time = us_ticker_read();
+    this->last_temperature.store(t);
+}
+
+float Max31865::adc_value_to_resistance(uint16_t adcValue)
+{
+    return (adcValue / 32767.0f) * this->reference_resistor;
+}
+
+float Max31865::resistance_to_temperature(float Rt)
+{
+    float Z1 = -RTD_A;
+    float Z2 = RTD_A * RTD_A - (4 * RTD_B);
+    float Z3 = (4 * RTD_B) / this->rtd_nominal_resistance;
+    float Z4 = 2 * RTD_B;
+
+    float temp = Z2 + (Z3 * Rt);
+    temp = (sqrt(temp) + Z1) / Z4;
+
+    return temp;
+}
+
+void Max31865::print_errors(bool always)
+{
+    uint8_t fault = read_register_8(MAX31856_FAULTSTAT_REG);
+    uint8_t msgReported = always ? 0 : this->errors_reported;
+
+    if ((fault & 0x80) && !(msgReported & 0x80))
+        THEKERNEL->streams->printf("Max31865 error: RTD input is disconnected\n");
+    if ((fault & 0x40) && !(msgReported & 0x40))
+        THEKERNEL->streams->printf("Max31865 error: RTD input is shorted\n");
+    if ((fault & 0x20) && !(msgReported & 0x20))
+        THEKERNEL->streams->printf("Max31865 error: VREF- is greater than 0.85 * VBIAS, FORCE- open\n");
+    if ((fault & 0x10) && !(msgReported & 0x10))
+        THEKERNEL->streams->printf("Max31865 error: VREF- is less than 0.85 * VBIAS, FORCE- open\n");
+    if ((fault & 0x08) && !(msgReported & 0x08))
+        THEKERNEL->streams->printf("Max31865 error: VRTD- is less than 0.85 * VBIAS, FORCE- open\n");
+    if ((fault & 0x04) && !(msgReported & 0x04))
+        THEKERNEL->streams->printf("Max31865 error: Overvoltage or undervoltage fault\n");
+    if ((fault & 0x03) && !(msgReported & 0x03))
+        THEKERNEL->streams->printf("Max31865 error: Unspecified error\n");
+
+    this->errors_reported = fault;
+}
+
+uint8_t Max31865::read_register_8(uint8_t reg)
+{
+    // always set the mode to ensure SCLK is the right polarity before lowering CS
+    spi->format(8, SPI_MODE);
+
+    this->spi_cs_pin.set(false);
+
+    spi->write(reg & 0x7f);
+    uint8_t val = spi->write(0);
+
+    this->spi_cs_pin.set(true);
+
+    return val;
+}
+
+uint16_t Max31865::read_register_16(uint8_t reg)
+{
+    // always set the mode to ensure SCLK is the right polarity before lowering CS
+    spi->format(8, SPI_MODE);
+
+    this->spi_cs_pin.set(false);
+
+    spi->write(reg & 0x7f);
+    uint8_t msb = spi->write(0);
+    uint8_t lsb = spi->write(0);
+
+    this->spi_cs_pin.set(true);
+
+    return (msb << 8) | lsb;
+}
+
+void Max31865::write_register_8(uint8_t reg, uint8_t val)
+{
+    // always set the SPI mode to ensure SCLK is the right polarity before lowering CS
+    spi->format(8, SPI_MODE);
+
+    this->spi_cs_pin.set(false);
+
+    spi->write(reg | 0x80);
+    spi->write(val);
+
+    this->spi_cs_pin.set(true);
+}

--- a/src/modules/tools/temperaturecontrol/max31865.h
+++ b/src/modules/tools/temperaturecontrol/max31865.h
@@ -1,0 +1,50 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef max31865_h
+#define max31865_h
+
+#include "TempSensor.h"
+#include <atomic>
+#include <string>
+#include <libs/Pin.h>
+#include <mbed.h>
+
+class Max31865 : public TempSensor
+{
+public:
+    Max31865();
+    ~Max31865();
+    void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
+    float get_temperature();
+    void get_raw();
+    void on_idle();
+
+private:
+    void init_rtd();
+    float adc_value_to_resistance(uint16_t adcValue);
+    float resistance_to_temperature(float Rt);
+    void print_errors(bool always = false);
+
+    uint8_t read_register_8(uint8_t reg);
+    uint16_t read_register_16(uint8_t reg);
+    void write_register_8(uint8_t reg, uint8_t val);
+
+    Pin spi_cs_pin;
+    mbed::SPI *spi;
+
+    float rtd_nominal_resistance;
+    float reference_resistor;
+    bool use_50hz_filter;
+
+    uint32_t last_reading_time;
+    std::atomic<float> last_temperature;
+
+    uint8_t errors_reported;
+};
+
+#endif


### PR DESCRIPTION
Here is a PR for MAX31865 support. Unfortunately it is dependent on the (uncommitted) PR #891 to avoid doing SPI inside interrupts, so I don't expect it will be merged directly.

This PR includes the code from #891 as well in order to compile, but I would prefer updating this PR after the other is submitted. Also I would be grateful for some amount of external testing by other Smoothie users.

Minimum configuration is as follows:
```
temperature_control.hotend.enable            true
temperature_control.hotend.sensor            max31865
temperature_control.hotend.chip_select_pin   1.20
```

I have tested the code using dual Adafruit MAX31865 boards connected to E3D PT100 cartridge sensors, and the default values reflect this. Other MAX31865-based amplifiers can be adapted by extra configuration options. Default values are shown below.

```
temperature_control.hotend.spi_channel              0      # SPI channel 0 or 1, as usual
temperature_control.hotend.rtd_nominal_resistance   100    # resistance at 0C, i.e. 100 ohms for PT100, 1000 ohms for PT1000
temperature_control.hotend.reference_resistor       430    # reference resistor on the board, Adafruit uses 430 ohms
temperature_control.hotend.use_50hz_filter          false  # true to use 50hz noise filter, false to use 60hz noise filter
```

I am not sure if exposing the 31865 filter selection in the config file is a good idea. Duet uses hardcoded 50Hz in their implementation, this works fine for me as well, but 60Hz would be better for North America.

Faults are handled correctly and diagnostics are printed (once) when errors occur. Easy failures to test for include disconnecting the PT100 or shorting the inputs, both of these are detected correctly and return Inf for temperature (which would cause a HALT during printing).

SPI communications validated with a Logic analyzer, no errors even with multiple devices sharing the bus (Viki2 LCD and 5x TMC2660 SPI drivers).

One gotcha is that the MAX31865 will automatically detect the SPI mode based on the current state of SCLK when CS is lowered, but with the mbed SPI API it is not possible to acquire ownership of the registers explicitly without doing *something* to the API object, this is why I have to call `spi->format()` for every register write to set up SCLK correctly before touching CS. I am surprised this never came up anywhere else in the Smoothie code.

Let me know if you want me to change anything. This works for me, hopefully it will work for you.