### PR TITLE
Allow multiple extruders to use the same temperature control.

### DIFF
--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -24,6 +24,7 @@
 #include "PublicDataRequest.h"
 #include "StreamOutputPool.h"
 #include "ExtruderPublicAccess.h"
+#include "utils.h"
 
 #include <mri.h>
 
@@ -51,6 +52,7 @@
 #define x_offset_checksum                    CHECKSUM("x_offset")
 #define y_offset_checksum                    CHECKSUM("y_offset")
 #define z_offset_checksum                    CHECKSUM("z_offset")
+#define temperature_control_checksum         CHECKSUM("temperature_control")
 
 #define retract_length_checksum              CHECKSUM("retract_length")
 #define retract_feedrate_checksum            CHECKSUM("retract_feedrate")
@@ -124,6 +126,13 @@ void Extruder::config_load()
     if(filament_diameter > 0.01F) {
         this->volumetric_multiplier = 1.0F / (powf(this->filament_diameter / 2, 2) * PI);
     }
+
+    // Get associated temperature_control name, defaults to extruder name
+    string s = THEKERNEL->config->value(extruder_checksum, this->identifier, temperature_control_checksum)->by_default("" )->as_string();
+    if (s.empty())
+        this->temperature_control_name = this->identifier;
+    else
+        this->temperature_control_name = get_checksum(s);
 
     // Stepper motor object for the extruder
     stepper_motor = new StepperMotor(step_pin, dir_pin, en_pin);

--- a/src/modules/tools/extruder/Extruder.h
+++ b/src/modules/tools/extruder/Extruder.h
@@ -28,6 +28,7 @@ class Extruder : public Tool {
         void select();
         void deselect();
         float get_e_scale(void) const { return volumetric_multiplier * extruder_multiplier; }
+        uint16_t get_temperature_control_name(void) const { return temperature_control_name; }
 
     private:
         void config_load();
@@ -63,4 +64,6 @@ class Extruder : public Tool {
             bool saved_selected:1;
             bool g92e0_detected:1;
         };
+
+        uint16_t temperature_control_name;
 };

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -325,10 +325,10 @@ void TemperatureControl::on_gcode_received(void *argument)
             // this is safe as old configs as well as single extruder configs the toolmanager will not be running so will return false
             // this will also ignore anything that the tool manager is not controlling and return false, otherwise it returns the active tool
             void *returned_data;
-            bool ok = PublicData::get_value( tool_manager_checksum, is_active_tool_checksum, this->name_checksum, &returned_data );
+            bool ok = PublicData::get_value( tool_manager_checksum, get_active_temp_control_name_checksum, &returned_data );
             if (ok) {
-                uint16_t active_tool_name =  *static_cast<uint16_t *>(returned_data);
-                this->active = (active_tool_name == this->name_checksum);
+                uint16_t active_temp_control_name =  *static_cast<uint16_t *>(returned_data);
+                this->active = (active_temp_control_name == this->name_checksum);
             }
 
             if(this->active) {

--- a/src/modules/tools/toolmanager/ToolManager.h
+++ b/src/modules/tools/toolmanager/ToolManager.h
@@ -11,7 +11,7 @@
 using namespace std;
 #include <vector>
 
-class Tool;
+class Extruder;
 
 class ToolManager : public Module
 {
@@ -22,14 +22,14 @@ public:
     void on_gcode_received(void *);
     void on_get_public_data(void *argument);
     void on_set_public_data(void *argument);
-    void add_tool(Tool *tool_to_add);
+    void add_tool(Extruder *tool_to_add);
     int get_active_tool() const { return active_tool; }
 
 private:
-    vector<Tool *> tools;
+    vector<Extruder *> tools;
 
     int active_tool;
-    uint16_t current_tool_name;
+    uint16_t current_temp_control_name;
 };
 
 

--- a/src/modules/tools/toolmanager/ToolManagerPublicAccess.h
+++ b/src/modules/tools/toolmanager/ToolManagerPublicAccess.h
@@ -2,10 +2,9 @@
 #define __TOOLMANAGERPUBLICACCESS_H
 
 // addresses used for public data access
-#define tool_manager_checksum             CHECKSUM("tool_manager")
-#define current_tool_name_checksum        CHECKSUM("current_tool_name")
-#define is_active_tool_checksum           CHECKSUM("is_active_tool")
-#define get_active_tool_checksum          CHECKSUM("get_active_tool")
+#define tool_manager_checksum                 CHECKSUM("tool_manager")
+#define get_active_temp_control_name_checksum CHECKSUM("get_active_temp_control_name")
+#define get_active_tool_checksum              CHECKSUM("get_active_tool")
 
 #endif // __TOOLMANAGERPUBLICACCESS_H
 


### PR DESCRIPTION
This change allows multiple extruder modules to use the same temperature control module.

Currently, there is an implicit association based on module name, so that `extruder.xxx` is automatically paired with `temperature_control.xxx`.  Currently, for multi extruder single hotend configurations, the temperature of the hotend can only be changed when T0 is selected.  While I can work around this by post processing my gcode, it seems like the the firmware should be able to change the hotend temp of the active extruder when multiple extruders share the same hot end.

This change adds a new configuration option to the extruder module allowing the user to specify the temperature_control module to use.  If the configuration is omitted, the default value of the extruder module name is used making it backwards compatible.  A full example would be:

```
# hotend1 uses the same temperature_control as hotend
extruder.hotend2.temperature_control        hotend
```

I have tested the change and verified the following behavior with two extruders and a single temperature_control

```
; extruder.hotend2.temperature_control config omitted
M104 S150 T0; hotend target changes to 150
M104 S155 T1; hotend target stays at 150
M104 S160 T0; hotend target changes to 160
```

```
; extruder.hotend2.temperature_control hotend specified
M104 S150 T0; hotend target changes to 150
M104 S155 T1; hotend target changes to 155
M104 S160 T0; hotend target changes to 160
```

I wanted to get your feedback on the change.  It was easiest to change the tool manager to contain Extruder* instead of Tool* which does couple the two objects more closely.  However, the only place the tool manager is constructed is in the ExtruderMaker, so the coupling seemed reasonable.

Still need to do do docs but wanted some initial feedback.
