### PR TITLE
Fix issue where a single temperature control with multiple extruders …

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -77,6 +77,7 @@ TemperatureControl::TemperatureControl(uint16_t name, int index)
     sensor= nullptr;
     readonly= false;
     tick= 0;
+    single= false;
 }
 
 TemperatureControl::~TemperatureControl()
@@ -322,13 +323,15 @@ void TemperatureControl::on_gcode_received(void *argument)
             // this only gets handled if it is not controlled by the tool manager or is active in the toolmanager
             this->active = true;
 
-            // this is safe as old configs as well as single extruder configs the toolmanager will not be running so will return false
-            // this will also ignore anything that the tool manager is not controlling and return false, otherwise it returns the active tool
-            void *returned_data;
-            bool ok = PublicData::get_value( tool_manager_checksum, is_active_tool_checksum, this->name_checksum, &returned_data );
-            if (ok) {
-                uint16_t active_tool_name =  *static_cast<uint16_t *>(returned_data);
-                this->active = (active_tool_name == this->name_checksum);
+            if(!single) {
+                // this is safe as old configs as well as single extruder configs the toolmanager will not be running so will return false
+                // this will also ignore anything that the tool manager is not controlling and return false, otherwise it returns the active tool
+                void *returned_data;
+                bool ok = PublicData::get_value( tool_manager_checksum, is_active_tool_checksum, this->name_checksum, &returned_data );
+                if (ok) {
+                    uint16_t active_tool_name =  *static_cast<uint16_t *>(returned_data);
+                    this->active = (active_tool_name == this->name_checksum);
+                }
             }
 
             if(this->active) {

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -28,7 +28,7 @@ class TemperatureControl : public Module {
         void on_halt(void* argument);
 
         void set_desired_temperature(float desired_temperature);
-
+        void set_single() { single= true; }
         float get_temperature();
 
 
@@ -89,8 +89,8 @@ class TemperatureControl : public Module {
             bool use_bangbang:1;
             bool waiting:1;
             bool temp_violated:1;
-            bool link_to_tool:1;
             bool active:1;
+            bool single:1;
             bool readonly:1;
             bool windup:1;
             bool sensor_settings:1;

--- a/src/modules/tools/temperaturecontrol/TemperatureControlPool.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControlPool.cpp
@@ -25,10 +25,12 @@ void TemperatureControlPool::load_tools()
     vector<uint16_t> modules;
     THEKERNEL->config->get_module_list( &modules, temperature_control_checksum );
     int cnt = 0;
+    TemperatureControl *controller;
+
     for( auto cs : modules ) {
         // If module is enabled
         if( THEKERNEL->config->value(temperature_control_checksum, cs, enable_checksum )->as_bool() ) {
-            TemperatureControl *controller = new TemperatureControl(cs, cnt++);
+            controller = new TemperatureControl(cs, cnt++);
             THEKERNEL->add_module(controller);
         }
     }
@@ -37,5 +39,10 @@ void TemperatureControlPool::load_tools()
     if(cnt > 0) {
         PID_Autotuner *pidtuner = new PID_Autotuner();
         THEKERNEL->add_module( pidtuner );
+
+    } else if(cnt == 1) {
+        // only a single temperature control, make sure it is always active
+        controller->set_single();
     }
+
 }


### PR DESCRIPTION
…needs to have tool 0 selected.

Now temp setting will always work regardless of which extruder is set.
