### PR TITLE
Temperature sensor average

### DIFF
--- a/ConfigSamples/Snippets/temperature_noise_reduction.config
+++ b/ConfigSamples/Snippets/temperature_noise_reduction.config
@@ -1,0 +1,5 @@
+temperature_control.bed.enable               true             #
+temperature_control.bed.resample             100               # average 100 samples to one value. Effective interval for PID 5 seconds
+temperature_control.bed.pwm_frequency        20      # 20 samples per second, 50ms interval
+temperature_control.bed.thermistor_pin       0.23             #
+temperature_control.bed.heater_pin           2.5      

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -55,6 +55,9 @@ class TemperatureControl : public Module {
         int o;
         float last_reading;
         float readings_per_second;
+        int resample_window;
+        int resample_counter;
+        float resample_accumulator;
         Pwm  heater_pin;
 
         std::string designator;


### PR DESCRIPTION
This is addition to implement "moving average" filter to reduce noise from temperature sensors.
The problem: thermistor readings may have some noise. For a massive bed heater, the noise may be much higher than overall temperature change. In my case, even with thermistor connected by twisted pair, average derivation was about 0.2 - 0.3 degrees, comparing to some between measures 0.01 degree added by  heating.
This overtakes 'differential' part of PID and effectively converts it into `PI`. It's less essential for extruder, but makes Bed temperature stabilization impossible.
The solution: Add digital filter to resample noisy signal and reduce temperature controller frequency. The algorithm described at https://en.wikipedia.org/wiki/Finite_impulse_response .
Default resample value is 1 that's the same behavior as it was before.
Tested with Azteeg mini and 2lb aluminum bed. 25W heater, EPCOS 100k thermistor

