### PR TITLE
Feature/pressure advance 0.01

### DIFF
--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -27,6 +27,7 @@ StepperMotor::StepperMotor(Pin &step, Pin &dir, Pin &en) : step_pin(step), dir_p
     current_position_steps= 0;
     moving= false;
     acceleration= NAN;
+    pressure_advance     = 0.0F;
     selected= true;
     extruder= false;
 

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -49,6 +49,8 @@ class StepperMotor  : public Module {
         void set_max_rate(float mr) { max_rate= mr; }
         void set_acceleration(float a) { acceleration= a; }
         float get_acceleration() const { return acceleration; }
+        void set_pressure_advance(float pa) { pressure_advance= pa; }
+        float get_pressure_advance() const { return pressure_advance; }
         bool is_selected() const { return selected; }
         void set_selected(bool b) { selected= b; }
         bool is_extruder() const { return extruder; }
@@ -69,6 +71,7 @@ class StepperMotor  : public Module {
         float steps_per_mm;
         float max_rate; // this is not really rate it is in mm/sec, misnamed used in Robot and Extruder
         float acceleration;
+        float pressure_advance;
 
         volatile int32_t current_position_steps;
         int32_t last_milestone_steps;

--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -59,6 +59,8 @@
 #define retract_zlift_length_checksum        CHECKSUM("retract_zlift_length")
 #define retract_zlift_feedrate_checksum      CHECKSUM("retract_zlift_feedrate")
 
+#define pressure_advance_checksum            CHECKSUM("pressure_advance")
+
 #define PI 3.14159265358979F
 
 
@@ -77,6 +79,7 @@ Extruder::Extruder( uint16_t config_identifier)
     this->extruder_multiplier = 1.0F;
     this->stepper_motor = nullptr;
     this->max_volumetric_rate = 0;
+    this->pressure_advance = 0;
     this->g92e0_detected = false;
     memset(this->offset, 0, sizeof(this->offset));
 }
@@ -120,6 +123,7 @@ void Extruder::config_load()
     this->retract_recover_feedrate = THEKERNEL->config->value(extruder_checksum, this->identifier, retract_recover_feedrate_checksum)->by_default(8)->as_number();
     this->retract_zlift_length     = THEKERNEL->config->value(extruder_checksum, this->identifier, retract_zlift_length_checksum)->by_default(0)->as_number();
     this->retract_zlift_feedrate   = THEKERNEL->config->value(extruder_checksum, this->identifier, retract_zlift_feedrate_checksum)->by_default(100 * 60)->as_number() / 60.0F; // mm/min
+    this->pressure_advance         = THEKERNEL->config->value(extruder_checksum, this->identifier, pressure_advance_checksum )->by_default(0)->as_number();
 
     if(filament_diameter > 0.01F) {
         this->volumetric_multiplier = 1.0F / (powf(this->filament_diameter / 2, 2) * PI);
@@ -132,6 +136,7 @@ void Extruder::config_load()
     stepper_motor->set_max_rate(THEKERNEL->config->value(extruder_checksum, this->identifier, max_speed_checksum)->by_default(1000)->as_number());
     stepper_motor->set_acceleration(acceleration);
     stepper_motor->change_steps_per_mm(steps_per_millimeter);
+    stepper_motor->set_pressure_advance(pressure_advance);
     stepper_motor->set_selected(false); // not selected by default
     stepper_motor->set_extruder(true);  // indicates it is an extruder
 }
@@ -166,6 +171,7 @@ void Extruder::on_get_public_data(void *argument)
     e->flow_rate = this->extruder_multiplier;
     e->accleration = stepper_motor->get_acceleration();
     e->retract_length = this->retract_length;
+    e->pressure_advance = this->pressure_advance;
     e->current_position = stepper_motor->get_current_position();
     pdr->set_taken();
 }
@@ -338,6 +344,15 @@ void Extruder::on_gcode_received(void *argument)
 
             } else {
                 gcode->stream->printf("Flow rate at %6.2f %%\n", this->extruder_multiplier * 100.0F);
+            }
+
+        } else if (gcode->m == 572 && ( (this->selected && !gcode->has_letter('P')) || (gcode->has_letter('P') && gcode->get_value('P') == this->identifier)) ) {
+            // M572 - set or report extruder pressure advance
+            if(gcode->has_letter('S')) {
+                pressure_advance = gcode->get_value('S');
+                stepper_motor->set_pressure_advance(pressure_advance);
+            } else {
+                gcode->stream->printf("Pressure advance at %f %%\n", this->pressure_advance);
             }
 
         } else if (gcode->m == 500 || gcode->m == 503) { // M500 saves some volatile settings to config override file, M503 just prints the settings

--- a/src/modules/tools/extruder/Extruder.h
+++ b/src/modules/tools/extruder/Extruder.h
@@ -52,6 +52,9 @@ class Extruder : public Tool {
         float retract_zlift_length;
         float retract_zlift_feedrate;
 
+        // for extruder pressure advance
+        float pressure_advance;             // advances extruder velocity by (pressure_advance * acceleration) while accelerating and decelerating
+
         // for saving and restoring extruder position
         std::tuple<float, float, int32_t> saved_position;
 

--- a/src/modules/tools/extruder/ExtruderPublicAccess.h
+++ b/src/modules/tools/extruder/ExtruderPublicAccess.h
@@ -11,5 +11,6 @@ using pad_extruder_t = struct pad_extruder {
     float flow_rate;
     float accleration;
     float retract_length;
+    float pressure_advance;
     float current_position;
 };

--- a/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.cpp
@@ -109,5 +109,12 @@ void ExtruderScreen::setupConfigSettings()
         0.0F  // Min
         );
 
+    mvs->addMenuItem("Press adv", // menu name
+        []() -> float { pad_extruder_t rd; if(PublicData::get_value( extruder_checksum, (void *)&rd )) return rd.pressure_advance; else return 0; }, // getter
+        [this](float pa) { send_gcode("M572", 'S', pa); }, // setter
+        0.01F, // increment
+        0.0F  // Min
+        );
+
     THEPANEL->enter_screen(mvs);
 }


### PR DESCRIPTION
This is preliminary code to enable pressure advance.  I don't expect it to be accepted straight away, I'd like some feedback on how to improve it, and a pull request seemed to be the best way to achieve this.

Currently this has been tested on a delta, but no other arm solutions.  It probably needs checks to ensure that other arm solutions won't cause issues.  

This algorithm depends on the use of segments, as suggested by Arthur Wolf via email.

In my testing, I can see that blobbing is much reduced on corners, and the general accuracy of the extrusion line is improved greatly.  This algorithm also does a slight retract as the extruder comes to a stop, the higher the factor, the higher the retract.  This is part and parcel of the accepted solution which has been implemented in other firmwares.

On my delta, with a short bowden tube (10cm) running PLA, values of pressure advance of around 0.1 work well.  Longer bowden tubes, and more flexible filaments will require higher values of advance.

![img_6741](https://cloud.githubusercontent.com/assets/489642/25476839/096b2534-2b6e-11e7-93f8-d8cc458d4ca9.jpg)
![img_6742](https://cloud.githubusercontent.com/assets/489642/25476820/fc4d8284-2b6d-11e7-86a6-c800fcf0ccd9.jpg)


Note: I need a way to handle retracts/unretracts more gracefully than the current system in here.  Right now I just test against an arbitrary high value of steps (100), which isn't the best way to do this.  I thought that just testing to see if this was a primary axis move would work, but it didn't appear to do so.  
Some feed back would be appreciated.
