### PR TITLE
save state when doing z probe

### DIFF
--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -27,19 +27,6 @@
 
 #include <mri.h>
 
-// OLD config names for backwards compatibility, NOTE new configs will not be added here
-#define extruder_module_enable_checksum      CHECKSUM("extruder_module_enable")
-#define extruder_steps_per_mm_checksum       CHECKSUM("extruder_steps_per_mm")
-#define extruder_filament_diameter_checksum  CHECKSUM("extruder_filament_diameter")
-#define extruder_acceleration_checksum       CHECKSUM("extruder_acceleration")
-#define extruder_step_pin_checksum           CHECKSUM("extruder_step_pin")
-#define extruder_dir_pin_checksum            CHECKSUM("extruder_dir_pin")
-#define extruder_en_pin_checksum             CHECKSUM("extruder_en_pin")
-#define extruder_max_speed_checksum          CHECKSUM("extruder_max_speed")
-#define extruder_default_feed_rate_checksum  CHECKSUM("extruder_default_feed_rate")
-
-// NEW config names
-
 #define default_feed_rate_checksum           CHECKSUM("default_feed_rate")
 #define steps_per_mm_checksum                CHECKSUM("steps_per_mm")
 #define filament_diameter_checksum           CHECKSUM("filament_diameter")

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -469,11 +469,13 @@ void ZProbe::coordinated_move(float x, float y, float z, float feedrate, bool re
     //THEKERNEL->streams->printf("DEBUG: move: %s: %u\n", cmd, strlen(cmd));
 
     // send as a command line as may have multiple G codes in it
+    THEROBOT->push_state();
     struct SerialMessage message;
     message.message = cmd;
     message.stream = &(StreamOutput::NullStream);
     THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
     THEKERNEL->conveyor->wait_for_idle();
+    THEROBOT->pop_state();
 }
 
 // issue home command

--- a/src/modules/utils/killbutton/KillButton.cpp
+++ b/src/modules/utils/killbutton/KillButton.cpp
@@ -58,7 +58,7 @@ void KillButton::on_idle(void *argument)
     if(state == KILL_BUTTON_DOWN) {
         if(!THEKERNEL->is_halted()) {
             THEKERNEL->call_event(ON_HALT, nullptr);
-            THEKERNEL->streams->printf("Kill button pressed - reset or M999 to continue\r\n");
+            THEKERNEL->streams->printf("ALARM: Kill button pressed - reset or M999 to continue\r\n");
         }
 
     }else if(state == UNKILL_FIRE) {


### PR DESCRIPTION
As G38.x uses a coordinated move to probe and this uses G0 we save state so the current G0 seek feedrate is not changed after the move.