### PR TITLE
Module for reading a pin using G-code command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "modules/utils/killbutton/KillButton.h"
 #include "modules/utils/PlayLed/PlayLed.h"
 #include "modules/utils/panel/Panel.h"
+#include "modules/utils/readpin/ReadPinPool.h"
 #include "libs/Network/uip/Network.h"
 #include "Config.h"
 #include "checksumm.h"
@@ -190,6 +191,11 @@ void init() {
     #ifndef NO_UTILS_MOTORDRIVERCONTROL
     kernel->add_module( new MotorDriverControl(0) );
     #endif
+
+    auto rpp = new ReadPinPool();
+    rpp->load_tools();
+    delete rpp;
+
     // Create and initialize USB stuff
     u.init();
 

--- a/src/modules/utils/readpin/ReadPin.cpp
+++ b/src/modules/utils/readpin/ReadPin.cpp
@@ -1,0 +1,59 @@
+#include "libs/Kernel.h"
+#include "ReadPin.h"
+#include "libs/nuts_bolts.h"
+#include "libs/utils.h"
+#include "Config.h"
+#include "SlowTicker.h"
+#include "libs/SerialMessage.h"
+#include "libs/StreamOutput.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+
+using namespace std;
+
+#define gcode_checksum               CHECKSUM("gcode")
+#define pin_checksum                 CHECKSUM("pin")
+
+ReadPin::ReadPin() {
+}
+
+ReadPin::ReadPin(uint16_t name) {
+    name_checksum = name;
+}
+
+void ReadPin::on_module_loaded() {
+    THEKERNEL->slow_ticker->attach(5, this, &ReadPin::pin_tick);
+    register_for_event(ON_GCODE_RECEIVED);
+
+    // Settings
+    on_config_reload(this);
+}
+
+// Get config
+void ReadPin::on_config_reload(void*) {
+    my_pin.from_string(THEKERNEL->config->value(readpin_checksum, name_checksum, pin_checksum )->by_default("nc")->as_string())->as_input();
+    if (my_pin.connected())
+        my_pin.pull_none();
+    auto gc = THEKERNEL->config->value(readpin_checksum, name_checksum, gcode_checksum)->by_default("")->as_string();
+    my_gcode.reset(new Gcode(gc, nullptr)); // alas, no make_unique
+}
+
+void ReadPin::on_gcode_received(void* argument) {
+    auto gcode = static_cast<Gcode*>(argument);
+    if ((gcode->has_g && my_gcode->has_g && (gcode->g == my_gcode->g)) ||
+        (gcode->has_m && my_gcode->has_m && (gcode->m == my_gcode->m))) {
+        if (!my_pin.connected())
+            THEKERNEL->streams->printf("Pin is not connected\n");
+        else
+            THEKERNEL->streams->printf("Pin %d.%d = %d\n", my_pin.port_number, my_pin.pin, state);
+    }
+}
+
+// Check the state of the pin
+// Note this is ISR so don't do anything nasty in here
+uint32_t ReadPin::pin_tick(uint32_t) {
+    state = my_pin.get();
+
+    return 0;
+}

--- a/src/modules/utils/readpin/ReadPin.h
+++ b/src/modules/utils/readpin/ReadPin.h
@@ -1,0 +1,38 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "libs/Pin.h"
+#include "Gcode.h"
+
+#define readpin_checksum CHECKSUM("readpin")
+
+class ReadPin : public Module {
+public:
+    ReadPin();
+    ReadPin(uint16_t name);
+    
+    void on_module_loaded() override;
+
+    // This is not virtual?
+    void on_config_reload(void* argument);
+    
+    void on_gcode_received(void* argument) override;
+    
+    uint32_t pin_tick(uint32_t dummy);
+
+private:
+    uint16_t name_checksum;
+    Pin my_pin;
+    std::unique_ptr<Gcode> my_gcode;
+
+    // Pin state, set in ISR
+    volatile bool state = false;
+};

--- a/src/modules/utils/readpin/ReadPinPool.cpp
+++ b/src/modules/utils/readpin/ReadPinPool.cpp
@@ -1,0 +1,36 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/Module.h"
+#include "libs/Kernel.h"
+#include <math.h>
+using namespace std;
+#include <vector>
+#include "ReadPinPool.h"
+#include "ReadPin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+
+#define enable_checksum CHECKSUM("enable")
+
+void ReadPinPool::load_tools() {
+    vector<uint16_t> modules;
+    THEKERNEL->config->get_module_list(&modules, readpin_checksum);
+
+    for (const auto& m : modules) {
+        if (THEKERNEL->config->value(readpin_checksum, m, enable_checksum )->as_bool()) {
+            auto controller = new ReadPin(m);
+            THEKERNEL->add_module(controller);
+        }
+    }
+}
+
+
+
+
+

--- a/src/modules/utils/readpin/ReadPinPool.h
+++ b/src/modules/utils/readpin/ReadPinPool.h
@@ -1,0 +1,14 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+class ReadPinPool {
+public:
+    void load_tools();
+};
+


### PR DESCRIPTION
This adds a new `readpin` module which I have found useful for debugging. Sample usage:
```
readpin.d1.enable                            true
readpin.d1.pin                               2.11
readpin.d1.gcode                             M700
```
Now, issuing `M700` prints the current state of pin 2.11 to the console.
