### PR TITLE
Use stepper acceleration for extruder only moves

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1218,7 +1218,9 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
             if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
                 float ca = fabsf((d/distance) * acceleration);
-                if (ca > ma) {
+                // For moves with XYZ component, use minimum of default_acceleration and actuator acceleration
+                // For E only moves (retract), use the actuator acceleration
+                if (ca > ma || auxilliary_move) {
                     acceleration *= ( ma / ca );
                 }
             }


### PR DESCRIPTION
For extruder only moves (retracts) use the extruders's acceleration and not min(extruder.acceleration, default_acceleration).

I have a geared bowden extruder that can run reasonably high accelerations (5000mm/s^2).  I have cura and slic3r configured to change my motion acceleration from 2000 for infill and 800 for perimeters.  I noticed that the `M204 S800` gcode was effecting my retraction speeds.  The current smoothie implementation uses the minimum of default_acceleration and the stepper's acceleration when scheduling moves.  This means my extruder acceleration is being dropped to 800.  The following gcode demonstrates the issue:

```
G91
M204 E5000 ; Extruder acceleration 5000
M204 S10 ; Silly slow acceleration
G0 X50 F150000 ; Accelerates slowly
G0 E-4 F2400 ; Expect to accelerate quickly, but is slow
```

With this change, the extruder only moves will just use the stepper's configured acceleration and not the minimum.
