### PR TITLE
Add ability to define "slaves" pins for each Actuator or Extruder. (Dual X, Y, Z, ...)

### DIFF
--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -13,7 +13,7 @@
 #include <math.h>
 #include "mbed.h"
 
-StepperMotor::StepperMotor(Pin &step, Pin &dir, Pin &en) : step_pin(step), dir_pin(dir), en_pin(en)
+StepperMotor::StepperMotor(Pin &step, Pin &dir, Pin &en, Pin &slaveStep, Pin &slaveDir, Pin &slaveEn) : step_pin(step), dir_pin(dir), en_pin(en), step_slave_pin(slaveStep), dir_slave_pin(slaveDir), en_slave_pin(slaveEn)
 {
     if(en.connected()) {
         set_high_on_debug(en.port_number, en.pin);
@@ -109,13 +109,16 @@ void StepperMotor::manual_step(bool dir)
     if(this->direction != dir) {
         this->direction= dir;
         this->dir_pin.set(dir);
+        this->dir_slave_pin.set(dir);
         wait_us(1);
     }
 
     // pulse step pin
     this->step_pin.set(1);
+	this->step_slave_pin.set(1);
     wait_us(3);
     this->step_pin.set(0);
+	this->step_slave_pin.set(0);
 
 
     // keep track of actuators actual position in steps

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -12,20 +12,24 @@
 
 class StepperMotor  : public Module {
     public:
-        StepperMotor(Pin& step, Pin& dir, Pin& en);
+        StepperMotor(Pin &step, Pin &dir, Pin &en, Pin &slaveStep, Pin &slaveDir, Pin &slaveEn) ;
         ~StepperMotor();
 
         void set_motor_id(uint8_t id) { motor_id= id; }
         uint8_t get_motor_id() const { return motor_id; }
 
         // called from step ticker ISR
-        inline bool step() { step_pin.set(1); current_position_steps += (direction?-1:1); return moving; }
+        inline bool step() { step_pin.set(1);step_slave_pin.set(1); current_position_steps += (direction?-1:1); return moving; }
         // called from unstep ISR
-        inline void unstep() { step_pin.set(0); }
+        inline void unstep() { step_pin.set(0); step_slave_pin.set(0);}
         // called from step ticker ISR
-        inline void set_direction(bool f) { dir_pin.set(f); direction= f; }
+        inline void set_direction(bool f) { dir_pin.set(f);
+		                                    dir_slave_pin.set(f);
+		                                    direction= f; }
 
-        void enable(bool state) { en_pin.set(!state); };
+        void enable(bool state) { en_pin.set(!state);
+								  en_slave_pin.set(!state);
+								};
         bool is_enabled() const { return !en_pin.get(); };
         bool is_moving() const { return moving; };
         void start_moving() { moving= true; }
@@ -64,6 +68,9 @@ class StepperMotor  : public Module {
         Pin step_pin;
         Pin dir_pin;
         Pin en_pin;
+		Pin step_slave_pin;
+        Pin dir_slave_pin;
+        Pin en_slave_pin;
 
         float steps_per_second;
         float steps_per_mm;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -76,6 +76,10 @@
 #define  dir_pin_checksum                    CHEKCSUM("dir_pin")
 #define  en_pin_checksum                     CHECKSUM("en_pin")
 
+#define  step_slave_pin_checksum             CHECKSUM("step_slave_pin")
+#define  dir_slave_pin_checksum              CHEKCSUM("dir_slave_pin")
+#define  en_slave_pin_checksum               CHECKSUM("en_slave_pin")
+
 #define  steps_per_mm_checksum               CHECKSUM("steps_per_mm")
 #define  max_rate_checksum                   CHECKSUM("max_rate")
 #define  acceleration_checksum               CHECKSUM("acceleration")
@@ -127,6 +131,9 @@ void Robot::on_module_loaded()
     CHECKSUM(X "_step_pin"),        \
     CHECKSUM(X "_dir_pin"),         \
     CHECKSUM(X "_en_pin"),          \
+	CHECKSUM(X "_step_slave_pin"),  \
+    CHECKSUM(X "_dir_slave_pin"),   \
+    CHECKSUM(X "_en_slave_pin"),    \
     CHECKSUM(X "_steps_per_mm"),    \
     CHECKSUM(X "_max_rate"),        \
     CHECKSUM(X "_acceleration")     \
@@ -194,7 +201,7 @@ void Robot::load_config()
     this->s_value             = THEKERNEL->config->value(laser_module_default_power_checksum)->by_default(0.8F)->as_number();
 
      // Make our Primary XYZ StepperMotors, and potentially A B C
-    uint16_t const checksums[][6] = {
+    uint16_t const checksums[][9] = {
         ACTUATOR_CHECKSUMS("alpha"), // X
         ACTUATOR_CHECKSUMS("beta"),  // Y
         ACTUATOR_CHECKSUMS("gamma"), // Z
@@ -214,8 +221,8 @@ void Robot::load_config()
 
     // make each motor
     for (size_t a = 0; a < MAX_ROBOT_ACTUATORS; a++) {
-        Pin pins[3]; //step, dir, enable
-        for (size_t i = 0; i < 3; i++) {
+        Pin pins[6]; //step, dir, enable
+        for (size_t i = 0; i < 6; i++) {
             pins[i].from_string(THEKERNEL->config->value(checksums[a][i])->by_default("nc")->as_string())->as_output();
         }
 
@@ -228,7 +235,7 @@ void Robot::load_config()
             break; // if any pin is not defined then the axis is not defined (and axis need to be defined in contiguous order)
         }
 
-        StepperMotor *sm = new StepperMotor(pins[0], pins[1], pins[2]);
+	StepperMotor *sm = new StepperMotor(pins[0], pins[1], pins[2], pins[3], pins[4], pins[5] );// provide here pins and optional slave pins
         // register this motor (NB This must be 0,1,2) of the actuators array
         uint8_t n= register_motor(sm);
         if(n != a) {
@@ -237,9 +244,9 @@ void Robot::load_config()
             return;
         }
 
-        actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][3])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
-        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][4])->by_default(30000.0F)->as_number()/60.0F); // it is in mm/min and converted to mm/sec
-        actuators[a]->set_acceleration(THEKERNEL->config->value(checksums[a][5])->by_default(NAN)->as_number()); // mm/secs²
+        actuators[a]->change_steps_per_mm(THEKERNEL->config->value(checksums[a][6])->by_default(a == 2 ? 2560.0F : 80.0F)->as_number());
+        actuators[a]->set_max_rate(THEKERNEL->config->value(checksums[a][7])->by_default(30000.0F)->as_number()/60.0F); // it is in mm/min and converted to mm/sec
+        actuators[a]->set_acceleration(THEKERNEL->config->value(checksums[a][8])->by_default(NAN)->as_number()); // mm/secs²
     }
 
     check_max_actuator_speeds(); // check the configs are sane

--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -34,6 +34,9 @@
 #define step_pin_checksum                    CHECKSUM("step_pin")
 #define dir_pin_checksum                     CHECKSUM("dir_pin")
 #define en_pin_checksum                      CHECKSUM("en_pin")
+#define step_slave_pin_checksum              CHECKSUM("step_slave_pin")
+#define dir_slave_pin_checksum               CHECKSUM("dir_slave_pin")
+#define en_slave_pin_checksum                CHECKSUM("en_slave_pin")
 #define max_speed_checksum                   CHECKSUM("max_speed")
 #define x_offset_checksum                    CHECKSUM("x_offset")
 #define y_offset_checksum                    CHECKSUM("y_offset")
@@ -88,10 +91,14 @@ void Extruder::on_module_loaded()
 void Extruder::config_load()
 {
 
-    Pin step_pin, dir_pin, en_pin;
+    Pin step_pin, dir_pin, en_pin, step_slave_pin, dir_slave_pin, en_slave_pin;
     step_pin.from_string( THEKERNEL->config->value(extruder_checksum, this->identifier, step_pin_checksum          )->by_default("nc" )->as_string())->as_output();
     dir_pin.from_string(  THEKERNEL->config->value(extruder_checksum, this->identifier, dir_pin_checksum           )->by_default("nc" )->as_string())->as_output();
     en_pin.from_string(   THEKERNEL->config->value(extruder_checksum, this->identifier, en_pin_checksum            )->by_default("nc" )->as_string())->as_output();
+	
+	step_slave_pin.from_string( THEKERNEL->config->value(extruder_checksum, this->identifier, step_slave_pin_checksum)->by_default("nc" )->as_string())->as_output();
+    dir_slave_pin.from_string(  THEKERNEL->config->value(extruder_checksum, this->identifier, dir_slave_pin_checksum )->by_default("nc" )->as_string())->as_output();
+    en_slave_pin.from_string(   THEKERNEL->config->value(extruder_checksum, this->identifier, en_slave_pin_checksum  )->by_default("nc" )->as_string())->as_output();
 
     float steps_per_millimeter = THEKERNEL->config->value(extruder_checksum, this->identifier, steps_per_mm_checksum)->by_default(1)->as_number();
     float acceleration         = THEKERNEL->config->value(extruder_checksum, this->identifier, acceleration_checksum)->by_default(1000)->as_number();
@@ -113,7 +120,7 @@ void Extruder::config_load()
     }
 
     // Stepper motor object for the extruder
-    stepper_motor = new StepperMotor(step_pin, dir_pin, en_pin);
+    stepper_motor = new StepperMotor(step_pin, dir_pin, en_pin, step_slave_pin, dir_slave_pin, en_slave_pin);
     motor_id = THEROBOT->register_motor(stepper_motor);
 
     stepper_motor->set_max_rate(THEKERNEL->config->value(extruder_checksum, this->identifier, max_speed_checksum)->by_default(1000)->as_number());


### PR DESCRIPTION
This allows to link/clone 1 stepper movement/directions to another one.

This feature mimics "Dual Z" / "Dual Y" or even "Dual X" features of Marlin firmware but can be used in any other kinds of applications where the driver max current is not enough to drive 2 stepper motors.

In order to make this work , new parameters in config files have been added:
step_slave_pin
dir_slave_pin
en_slave_pin

These parameters can be used for all actuators ( alpha, beta, gamma, delta, epsilon, zeta)
As well as extruders .

Here is an example for Gamma (to perform dual Z in my case)
gamma_step_pin                               2.3              # Pin for gamma stepper step signal
gamma_dir_pin                                0.22             # Pin for gamma stepper direction
gamma_en_pin                                 0.21             # Pin for gamma enable
#---------------Slave pins for Dual Z------------
gamma_step_slave_pin                         2.8              # Slave Pin for gamma stepper step signal
gamma_dir_slave_pin                          2.13             # Slave Pin for gamma stepper direction
gamma_en_slave_pin                           4.29             # Slave Pin for gamma enable
#---------------------------------------------------
gamma_current                                1.0              # Z stepper motor current
z_axis_max_speed                             180              # mm/min
gamma_max_rate                               180.0            # mm/min actuator max speed

Note that the pins must not be declared/used anywhere in this config file.
I reused the pins from my 2nd extruder, and i commented out the whole extruder 2.
Note also that you can use other existing pins. This will also allow you to use any kind of Stepper extenders.
