### PR TITLE
Add remote temperature ExternalSensor support

### DIFF
--- a/ConfigSamples/Snippets/external_sensor.config
+++ b/ConfigSamples/Snippets/external_sensor.config
@@ -1,0 +1,19 @@
+## Chamber heater configuration
+temperature_control.heater.enable                true               #
+temperature_control.heater.sensor                ExternalSensor     # Emulated sensor, the temperature is provided by UART
+temperature_control.heater.set_temp_m_code       933                # M code used to set the current temperature
+temperature_control.heater.designator            R                  #
+temperature_control.heater.max_temp              75                 # Set maximum temperature - Will prevent heating above
+temperature_control.heater.readings_per_second   1                  # Reduced sampling
+
+## Heated chamber configuration
+temperature_control.chamber.enable               true               #
+temperature_control.chamber.heater_pin           1.19               #
+temperature_control.chamber.sensor               ExternalSensor     # Emulated sensor, the temperature is provided by UART
+temperature_control.chamber.set_temp_m_code      934                # M code used to set the current temperature
+temperature_control.chamber.set_m_code           141                #
+temperature_control.chamber.set_and_wait_m_code  191                #
+temperature_control.chamber.designator           C                  #
+temperature_control.chamber.max_temp             75                 # Set maximum temperature - Will prevent heating above
+temperature_control.chamber.readings_per_second  1                  # Reduced sampling
+temperature_control.chamber.max_pwm              255                # max pwm, 64 is a good value if driving a 12v resistor with 24v.

--- a/src/modules/tools/temperaturecontrol/ExternalSensor.cpp
+++ b/src/modules/tools/temperaturecontrol/ExternalSensor.cpp
@@ -1,0 +1,21 @@
+#include "ExternalSensor.h"
+
+ExternalSensor::ExternalSensor()
+{
+    m_current_temperature = -1.0F;
+}
+
+ExternalSensor::~ExternalSensor()
+{
+}
+
+bool ExternalSensor::set_temperature(float p_temperature)
+{
+    m_current_temperature = p_temperature;
+    return true;
+}
+
+float ExternalSensor::get_temperature()
+{
+    return m_current_temperature;
+}

--- a/src/modules/tools/temperaturecontrol/ExternalSensor.h
+++ b/src/modules/tools/temperaturecontrol/ExternalSensor.h
@@ -1,0 +1,25 @@
+#ifndef EXTERNALSENSOR_H
+#define EXTERNALSENSOR_H
+
+#include "TempSensor.h"
+
+
+class ExternalSensor : public TempSensor
+{
+public:
+
+    ExternalSensor();
+    ~ExternalSensor();
+
+    // Return temperature in degrees Celsius.
+    float get_temperature();
+
+    // Set and store the internal temperature
+    bool set_temperature(float p_temperature);
+
+private:
+    float m_current_temperature;
+
+};
+
+#endif

--- a/src/modules/tools/temperaturecontrol/TempSensor.h
+++ b/src/modules/tools/temperaturecontrol/TempSensor.h
@@ -23,6 +23,7 @@ public:
     virtual float get_temperature() { return -1.0F; }
 
     typedef std::map<char, float> sensor_options_t;
+    virtual bool set_temperature (float p_temperature) {return false;}
     virtual bool set_optional(const sensor_options_t& options) { return false; }
     virtual bool get_optional(sensor_options_t& options) { return false; }
     virtual void get_raw() {}

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.h
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.h
@@ -79,6 +79,7 @@ class TemperatureControl : public Module {
             uint16_t set_m_code:10;
             uint16_t set_and_wait_m_code:10;
             uint16_t get_m_code:10;
+            uint16_t set_temp_m_code:10;
             RUNAWAY_TYPE runaway_state:2;
             // Temperature runaway config options
             uint8_t runaway_range:6; // max 63
@@ -93,6 +94,7 @@ class TemperatureControl : public Module {
             bool readonly:1;
             bool windup:1;
             bool sensor_settings:1;
+            bool emulated_sensor:1;
         };
 };
 


### PR DESCRIPTION
This feature adds the support to a new "remote" temperature sensor, not directly connectected to Smoothieboard.
If you, for some reason, need more temperature sensors or to use sensors not supported by Smoothieboard you can use the ExternalSensor type and push the temperature, read externally, to Smoothieboard using a configurable M-command.
With ExternalSensor you can still take advantage of all features and automatisms of temperature control system of smoothie firmware.

A new config, set_temp_m_code, has been added to temperature_control in order to configure the M-command to set the temperature on the sensor.

Set the temperature is simple, you only have to call the configured M-command with the float value of the temperature. 
You maybe want to call this command constantly, to update the value frequently.

**How to configure an External Sensor:**
> temperature_control.heater.enable                true              
> temperature_control.heater.sensor                ExternalSensor     
> temperature_control.heater.set_temp_m_code       933 

**How to set the temperature:** 
> M933 S37.1

**What changed:**
- Added the ExternalSensor class: it simply stores the float value and returns it on get_temperature
- Added the set_temp_m_code on TemperatureControl: default value 933
- Added the management of configurable M-Code on TemperatureControl: basically calls set_temperature on the sensor.
- An emulated_sensor flag has been added to TemperatureControl to avoid call set_temperature on internal sensors.
- Added the config snippets examples