### PR TITLE
Thermocouple Amp Board: Max6675

### DIFF
--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -29,6 +29,7 @@
 // Temp sensor implementations:
 #include "Thermistor.h"
 #include "max31855.h"
+#include "max6675.h"
 #include "AD8495.h"
 #include "PT100_E3D.h"
 
@@ -182,6 +183,8 @@ void TemperatureControl::load_config()
     sensor = nullptr; // In case we fail to create a new sensor.
     if(sensor_type.compare("thermistor") == 0) {
         sensor = new Thermistor();
+    } else if(sensor_type.compare("max6675") == 0) {
+        sensor = new Max6675();
     } else if(sensor_type.compare("max31855") == 0) {
         sensor = new Max31855();
     } else if(sensor_type.compare("ad8495") == 0) {

--- a/src/modules/tools/temperaturecontrol/max6675.cpp
+++ b/src/modules/tools/temperaturecontrol/max6675.cpp
@@ -1,0 +1,105 @@
+/*
+      This file is part of Smoothie (http://smoothieware.org/). The motion control part is heavily based on Grbl (https://github.com/simen/grbl).
+      Smoothie is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      Smoothie is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/Kernel.h"
+#include <math.h>
+#include "libs/Pin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+
+#include "max6675.h"
+
+#include "MRI_Hooks.h"
+
+#define chip_select_checksum CHECKSUM("chip_select_pin")
+#define spi_channel_checksum CHECKSUM("spi_channel")
+
+Max6675::Max6675() :
+    spi(nullptr)
+{
+}
+
+Max6675::~Max6675()
+{
+    delete spi;
+}
+
+// Get configuration from the config file
+void Max6675::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
+{
+    // Chip select
+    this->spi_cs_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, chip_select_checksum)->by_default("0.16")->as_string());
+    this->spi_cs_pin.set(true);
+    this->spi_cs_pin.as_output();
+    
+    // select which SPI channel to use
+    int spi_channel = THEKERNEL->config->value(module_checksum, name_checksum, spi_channel_checksum)->by_default(0)->as_number();
+    PinName miso;
+    PinName mosi;
+    PinName sclk;
+    if(spi_channel == 0) {
+        // Channel 0
+        mosi=P0_18; miso=P0_17; sclk=P0_15;
+    } else {
+        // Channel 1
+        mosi=P0_9; miso=P0_8; sclk=P0_7;
+    } 
+
+    delete spi;
+    spi = new mbed::SPI(mosi, miso, sclk);
+
+    // Spi settings: 1MHz (default), 16 bits, mode 0 (default)
+    spi->format(16);
+}
+
+float Max6675::get_temperature()
+{
+	// Return an average of the last readings
+    if (readings.size() >= readings.capacity()) {
+        readings.delete_tail();
+    }
+
+    float temp = read_temp();
+
+    // Discard occasional errors...
+    if(!isinf(temp)) {
+        readings.push_back(temp);
+    }
+
+    if(readings.size()==0) return infinityf();
+
+    float sum = 0;
+    for (int i=0; i<readings.size(); i++)
+        sum += *readings.get_ref(i);
+       
+    return sum / readings.size();
+}
+
+float Max6675::read_temp()
+{
+    this->spi_cs_pin.set(false);
+    wait_us(1); // Must wait for first bit valid
+
+    // Read 16 bits (writing something as well is required by the api)
+    uint16_t data = spi->write(0);
+
+    this->spi_cs_pin.set(true);
+    
+    float temperature;
+
+    //Process temp
+    if (data & 0x4) {
+        // uh oh, no thermocouple attached!
+        temperature = infinityf();
+    } else {
+        data >>= 3;
+        temperature = data*0.25;
+    }
+
+    return temperature;
+}

--- a/src/modules/tools/temperaturecontrol/max6675.h
+++ b/src/modules/tools/temperaturecontrol/max6675.h
@@ -21,12 +21,13 @@ public:
     ~Max6675();
     void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
     float get_temperature();
+    void on_idle();
 
 private:
-    float read_temp();
+    struct { bool read_flag:1; } ; //when true, the next call to on_idle will read a new temperature value
     Pin spi_cs_pin;
     mbed::SPI *spi;
-    RingBuffer<float,16> readings;
+    RingBuffer<float,4> readings;
 };
 
 #endif

--- a/src/modules/tools/temperaturecontrol/max6675.h
+++ b/src/modules/tools/temperaturecontrol/max6675.h
@@ -1,0 +1,32 @@
+/*
+      this file is part of smoothie (http://smoothieware.org/). the motion control part is heavily based on grbl (https://github.com/simen/grbl).
+      smoothie is free software: you can redistribute it and/or modify it under the terms of the gnu general public license as published by the free software foundation, either version 3 of the license, or (at your option) any later version.
+      smoothie is distributed in the hope that it will be useful, but without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose. see the gnu general public license for more details.
+      you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef max6675_h
+#define max6675_h
+
+#include "TempSensor.h"
+#include <string>
+#include <libs/Pin.h>
+#include <mbed.h>
+#include "RingBuffer.h"
+
+class Max6675 : public TempSensor
+{
+public:
+    Max6675();
+    ~Max6675();
+    void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
+    float get_temperature();
+
+private:
+    float read_temp();
+    Pin spi_cs_pin;
+    mbed::SPI *spi;
+    RingBuffer<float,16> readings;
+};
+
+#endif


### PR DESCRIPTION
Hot on the heels of #891, I've added support for max6675; an older, but popular chip with lots of inventory available. It reads a bit slower than the max31855, does not have compatible serial output, and doesn't support as wide a range of sub-zero temps.

The code in this PR has been tested with a max6675 up to 400c (when my solder gave up before the insulation). The new Max6675 class is a copy of Max31855 with updates for the shorter temperature range.

Additional notes:

1. The boards I have are not directly header pin compatible, but hooking up by pin label works fine.
2. readings_per_second must be set to 4; the chip will return the same old value if sampled faster. (see Conversion Time in chip datasheets for details; 0.22s for max6675)
3. The RingBuffer for this module is only 4 readings long to keep averaging to a reasonable 1-second.

Thinking ahead, it might be good to revisit and abstract these classes after #1166 is merged, but that's for another PR.