### PR TITLE
Fix Math for Arcs in XZ Plane - Issue  #1181

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1387,6 +1387,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     // Patch from GRBL Firmware - Christoph Baumann 04072015
     // CCW angle between position and target from circle center. Only one atan2() trig computation required.
     float angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+    if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is revere of other 2 planes
     if (is_clockwise) { // Correct atan2 output per direction
         if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
     } else {


### PR DESCRIPTION
The math for calculating angular travel needs to be reversed only for XZ arcs, this is because the arc is now starting and ending in different quadrants than a similar arc in the other 2 planes.

This is to resolve issue #1181 
[https://github.com/Smoothieware/Smoothieware/issues/1181]

The following test program was used to confirm a bug in the processing of G2/G3 Arcs generated in the XZ plane.  This program was generated with Vectorcam V15.

 G00 X-0.7071068 Y0.7071068
 G01 Z0.
 G17 G02 X0.7071068 Y0.7071068 I0.7071068 J-0.7071068
 G00 Z2.
 
 G0 X0.7071068 Y0.
 G01 Z0.7071068
 G18 G02 X-0.7071068 Z0.7071068 I-0.7071068 K-0.7071068
 G00 Z2.

 G0 X0. Y-0.7071068
 G01 Z0.7071068
 G19 G02 Y0.7071068 Z0.7071068 J0.7071068 K-0.7071068
 G00 Z3.

This program illustrates how the quadrants change, for both the XY and YZ arcs, we are starting from the -,+ quadrant and ending in the +,+ quadrant, but the XZ arc is starting in the +,+ quadrant and ending in the -,+ quadrant.  