### PR TITLE
Add M211.1 support for traditional endstop hard limit manipulation

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -1085,6 +1085,36 @@ void Endstops::on_gcode_received(void *argument)
                 gcode->stream->printf(" will take effect next home\n");
                 break;
 
+            case 211: { //Enable or disable endstop(s)               
+                    if(gcode->has_letter('S')) //Alter endstop behavior
+                    {
+                        bool enable = gcode->get_value('S')>0;
+    
+                        for(auto& h : homing_axis) {                            
+                            if(gcode->has_letter(h.axis))
+                            {
+                                if(h.home_direction == !gcode->get_value(h.axis)) //Are we configuring a min or max endstop?
+                                {
+                                    string name;
+                                    name.append(1, h.axis).append(h.home_direction ? "_min" : "_max");
+                                    h.pin_info->limit_enable = enable;
+                                    gcode->stream->printf("%s: %s ", name.c_str(), (h.pin_info->limit_enable?"enabled":"disabled"));                                
+                                }
+                            }
+                        }
+                    }
+                    else //Print current status
+                    {
+                        for(auto& h : homing_axis) {
+                            string name;
+                            name.append(1, h.axis).append(h.home_direction ? "_min" : "_max");                            
+                            gcode->stream->printf("%s: %s ", name.c_str(), (h.pin_info->limit_enable?"enabled":"disabled"));
+                        }               
+                    }
+                    gcode->add_nl = true;
+                }
+                break;
+
             case 306: // set homing offset based on current position
                 if(is_rdelta) return; // RotaryDeltaCalibration module will handle this
 

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -59,6 +59,7 @@ class Endstops : public Module{
                 uint8_t axis_index:3;
                 bool limit_enable:1;
                 bool triggered:1;
+                bool is_max_stop:1;
             };
         };
 
@@ -95,5 +96,6 @@ class Endstops : public Module{
             bool is_scara:1;
             bool home_z_first:1;
             bool move_to_origin_after_home:1;
+            bool limits_enabled:1;
         };
 };


### PR DESCRIPTION
# Add M211 support for traditional endstops.

This was needed for a machine I was converting (Stratasys Dimension Elite). The z probe is deployed by moving the head into specific positions at the back of the machine. This involves moving the probe towards X-min to deploy the probe, and X-max to retract it. The retract point lives just beyond the X-Max trigger area (optical sensor with a plate that triggers ~25mm before physical limits). So there was a need to temporarily disable the x-max check for every print, but only for this one function.

Usage example, partial g-code start script:
M80 ;power on
**M211 S1 X1 Y1 Z0** ;Ensure endstops are enabled before homing. Machine homes to X/Y max and Z min
G91 ;relative positioning
G0 Z10 F5000 ;move Z down from wherever it is
G90 ;absolute positioning
G28 X0; home X axes
G0 X100 F12000 ; center X to clear probe storage post if probe was left deployed
G28 Y0 Z0 ;home y
G1 X-30 Y240 F5000 ;deploy probe
G0 X100 F15000 ; center X
T0 ;Ensure we're using T0 offsets
G32 ;probe bed
G0 X100 Y240 F15000 ;center x, move y to probe storage area
**M211 S0 X1** ;Disable x-max endstop
G1 X235 F5000 ;Store probe (this is just beyond the xMax endstop)
G0 X100 F15000 ;center x
**M211 S1 X1** ;enable x-max endstop again
G28 Z0
