### PR TITLE
Remove conflicting bool spindle_on

### DIFF
--- a/src/modules/tools/spindle/PWMSpindleControl.h
+++ b/src/modules/tools/spindle/PWMSpindleControl.h
@@ -35,7 +35,6 @@ class PWMSpindleControl: public SpindleControl {
         bool vfd_spindle; // true if we have a VFD driven spindle
 
         // Current values, updated at runtime
-        bool spindle_on;
         float current_rpm;
         float target_rpm;
         float current_I_value;


### PR DESCRIPTION
Bool `spindle_on` is initialized in `SpindleControl` and is shared
between `SpindleControl` and whichever control method (PWM, Modbus,
Huanyang, or Analog) is configured.

Initializing `spindle_on` in `PWMSpindleControl` as well clobbers the
shared variable and leads to `SpindleControl` and `PWMSpingleControl`
having different values for `spindle_on` and thus the spindle is never
actually turned on when sending M3 commands.

This can be confirmed via M957 which will always show that the current
PWM is 0, no matter what the current and target RPM.

Removing this superfluous initializion causes `spindle_on` from
`SpindleControl` to be shared as expeced and the module then works as
can be confirmed with M957 showing appropriate PWM values responding to
current and target RPM.