### PR TITLE
Align get_pid_settings() with report_settings()

### DIFF
--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -34,7 +34,7 @@ void SpindleControl::on_gcode_received(void *argument)
             if (gcode->has_letter('D'))
                 set_p_term( gcode->get_value('D') );
             // report PID settings
-            get_pid_settings();
+            report_settings();
           
         }
         else if (gcode->m == 3) 

--- a/src/modules/tools/spindle/SpindleControl.h
+++ b/src/modules/tools/spindle/SpindleControl.h
@@ -29,7 +29,7 @@ class SpindleControl: public Module {
         virtual void set_p_term(float) {};
         virtual void set_i_term(float) {};
         virtual void set_d_term(float) {};
-        virtual void get_pid_settings(void) {};
+        virtual void report_settings(void) {};
 };
 
 #endif


### PR DESCRIPTION
In the handler for M958 in `SpindleControl`, a function,
`get_pid_settings()`, is called which does not appear to exist beyond
its virtual initialization also in `SpindleControl`.  Because this
function does not really exist, M958 does not return any PID data.

`PWMSpindleControl` contains a function `report_settings()`, which
prints the PID data one would expect from M958.  Replacing
`SpindleControl`'s references to the non-existent `get_pid_settings()`
with `report_settings()` causes M958 to return PID data as expected.