### PR TITLE
Feature/spindle max pwm

### DIFF
--- a/ConfigSamples/spindle.config
+++ b/ConfigSamples/spindle.config
@@ -1,0 +1,34 @@
+# Spindle control settings
+
+spindle.enable            true           # [Default false]   Set this to false to disable the spindle module
+
+# PWM spindle settings
+
+spindle.type              pwm            # [Default pwm]     Spindle module mode (pwm, analog, modbus)
+spindle.pwm_pin           2.3            # [Default nc]      PWM output pin.  Must be hardware PWM capable.  (See http://smoothieware.org/pinout)
+spindle.pwm_period        50000          # [Default 1000]    PWM period in microseconds.
+spindle.max_pwm           0.85           # [Default 1.0]     Max duty cycle.  MC2100 uses 85% duty cycle for max speed.
+spindle.feedback_pin      0.22           # [Default nc]      Tach input pin.  Must be interrupt capable.
+spindle.pulses_per_rev    1.0            # [Default 1]       Number of pulses per spindle revolution.
+spindle.default_rpm       60             # [Default 5000]    RPM value to use if no RPM is provided to initial M3.
+#spindle.control_P         0.1            # [Default 0.0001]  Proportional term for the PID controller.
+#spindle.control_I         0.1            # [Default 0.0001]  Integral term for the PID controller.
+#spindle.control_D         0.1            # [Default 0.0001]  Derivative term for the PID controller.
+#spindle.control_smoothing 0.1            # [Default 0.1]     Low pass filter time constant in seconds.
+
+# Analog spindle settings
+
+#spindle.type              analog         # [Default pwm]     Analog can also be used for ESC spindles controlled by a PWM.
+#spindle.pwm_pin           2.3            # [Default nc]      PWM output pin.  Must be hardware PWM capable.  (See http://smoothieware.org/pinout)
+#spindle.min_rpm           100            # [Default 100]     Minimum RPM when spindle is on.
+#spindle.max_rpm           24000          # [Default 5000]    Maximum RPM at 100% PWM.
+#spindle.pwm_period        50000          # [Default 1000]    PWM period in microseconds.
+#spindle.switch_on_pin     2.6            # [Default nc]      Optional output pin used to enable the VFD.
+
+# Modbus spindle settings
+
+#spindle.type              modbus         # [Default pwm]     Modbus / RS485.
+#spindle.vfd_type          huanyang       # [Default none]    Huanyang is currently the only supported VFD type.
+#spindle.rx_pin            2.6            # [Default nc]      TX pin for soft serial.
+#spindle.tx_pin            2.4            # [Default nc]      RX pin for soft serial.
+#spindle.dir_pin           2.5            # [Default nc]      RS485 is only half-duplex, so we need a pin to switch between sending and receiving.

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -27,6 +27,7 @@
 #define spindle_checksum                    CHECKSUM("spindle")
 #define spindle_pwm_pin_checksum            CHECKSUM("pwm_pin")
 #define spindle_pwm_period_checksum         CHECKSUM("pwm_period")
+#define spindle_max_pwm_checksum            CHECKSUM("max_pwm")
 #define spindle_feedback_pin_checksum       CHECKSUM("feedback_pin")
 #define spindle_pulses_per_rev_checksum     CHECKSUM("pulses_per_rev")
 #define spindle_default_rpm_checksum        CHECKSUM("default_rpm")
@@ -80,6 +81,8 @@ void PWMSpindleControl::on_module_loaded()
         delete this;
         return;
     }
+
+    max_pwm = THEKERNEL->config->value(spindle_checksum, spindle_max_pwm_checksum)->by_default(1.0f)->as_number();
     
     int period = THEKERNEL->config->value(spindle_checksum, spindle_pwm_period_checksum)->by_default(1000)->as_int();
     pwm_pin->period_us(period);
@@ -152,6 +155,10 @@ uint32_t PWMSpindleControl::on_update_speed(uint32_t dummy)
         prev_error = error;
 
         current_pwm_value = new_pwm;
+
+        if (current_pwm_value > max_pwm) {
+            current_pwm_value = max_pwm;
+        }
     } else {
         current_I_value = 0;
         current_pwm_value = 0;

--- a/src/modules/tools/spindle/PWMSpindleControl.h
+++ b/src/modules/tools/spindle/PWMSpindleControl.h
@@ -49,6 +49,7 @@ class PWMSpindleControl: public SpindleControl {
         float control_I_term;
         float control_D_term;
         float smoothing_decay;
+        float max_pwm;
 
         // These fields are updated by the interrupt
         uint32_t last_edge; // Timestamp of last edge


### PR DESCRIPTION
Treadmill motor controllers are becoming increasingly popular in DIY
machines.  One such popular controller is the mc2100 which expects a
duty cycle of 0-85% for 0-100% speed.  To keep the PWM signal below the
controller maximum and thus prevent the controller from going into an
error state when higher speeds than physically possible are requested,
we need a config option for the ceiling on the PWM signal.

I tested this for backwards compatibility with my original configuration
without this new parameter included and it works as expected, using 100%
as the maximum duty cycle.

I tested setting `spindle.max_pwm` to 0.85 (above the hard-coded 0.5
starting point) and 0.25 (below the hard-coded 0.5 starting point) and
confirmed expected function for both via M957 output and viewing the
physical PWM output with a scope.

I added a sample `spindle.config` showing this new parameter in context
with the other spindle parameters I could find with a quick grep of the
code and search through the docs.