### PR TITLE
Fix/spindle off on halt

### DIFF
--- a/ConfigSamples/Snippets/spindle.config
+++ b/ConfigSamples/Snippets/spindle.config
@@ -1,6 +1,7 @@
 # Spindle control settings
 
 spindle.enable            true           # [Default false]   Set this to false to disable the spindle module
+#spindle.ignore_on_halt    true           # [Default false]   Don't stop the spindle on HALT.  Not recommended unless you really know what you're doing.
 
 # PWM spindle settings
 

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -21,7 +21,6 @@
 #define spindle_pwm_pin_checksum            CHECKSUM("pwm_pin")
 #define spindle_pwm_period_checksum         CHECKSUM("pwm_period")
 #define spindle_switch_on_pin_checksum      CHECKSUM("switch_on_pin")
-#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 void AnalogSpindleControl::on_module_loaded()
 {
@@ -59,11 +58,6 @@ void AnalogSpindleControl::on_module_loaded()
     if(switch_on_pin.compare("nc") != 0) {
         switch_on = new Pin();
         switch_on->from_string(switch_on_pin)->as_output()->set(false);
-    }
-    // register for events
-    register_for_event(ON_GCODE_RECEIVED);
-    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
-        register_for_event(ON_HALT);
     }
 }
 

--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -21,6 +21,7 @@
 #define spindle_pwm_pin_checksum            CHECKSUM("pwm_pin")
 #define spindle_pwm_period_checksum         CHECKSUM("pwm_period")
 #define spindle_switch_on_pin_checksum      CHECKSUM("switch_on_pin")
+#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 void AnalogSpindleControl::on_module_loaded()
 {
@@ -61,6 +62,9 @@ void AnalogSpindleControl::on_module_loaded()
     }
     // register for events
     register_for_event(ON_GCODE_RECEIVED);
+    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
+        register_for_event(ON_HALT);
+    }
 }
 
 void AnalogSpindleControl::turn_on() 

--- a/src/modules/tools/spindle/ModbusSpindleControl.cpp
+++ b/src/modules/tools/spindle/ModbusSpindleControl.cpp
@@ -19,7 +19,6 @@
 #define spindle_rx_pin_checksum             CHECKSUM("rx_pin")
 #define spindle_tx_pin_checksum             CHECKSUM("tx_pin")
 #define spindle_dir_pin_checksum            CHECKSUM("dir_pin")
-#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 void ModbusSpindleControl::on_module_loaded()
 {
@@ -49,11 +48,5 @@ void ModbusSpindleControl::on_module_loaded()
 
     // setup the Modbus interface
     modbus = new Modbus(tx_pin, rx_pin, dir_pin);
-
-    // register for events
-    register_for_event(ON_GCODE_RECEIVED);
-    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
-        register_for_event(ON_HALT);
-    }
 }
 

--- a/src/modules/tools/spindle/ModbusSpindleControl.cpp
+++ b/src/modules/tools/spindle/ModbusSpindleControl.cpp
@@ -19,6 +19,7 @@
 #define spindle_rx_pin_checksum             CHECKSUM("rx_pin")
 #define spindle_tx_pin_checksum             CHECKSUM("tx_pin")
 #define spindle_dir_pin_checksum            CHECKSUM("dir_pin")
+#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 void ModbusSpindleControl::on_module_loaded()
 {
@@ -51,5 +52,8 @@ void ModbusSpindleControl::on_module_loaded()
 
     // register for events
     register_for_event(ON_GCODE_RECEIVED);
+    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
+        register_for_event(ON_HALT);
+    }
 }
 

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -11,7 +11,6 @@
 #include "Config.h"
 #include "checksumm.h"
 #include "ConfigValue.h"
-#include "Gcode.h"
 #include "StreamOutputPool.h"
 #include "SlowTicker.h"
 #include "Conveyor.h"
@@ -35,7 +34,6 @@
 #define spindle_control_I_checksum          CHECKSUM("control_I")
 #define spindle_control_D_checksum          CHECKSUM("control_D")
 #define spindle_control_smoothing_checksum  CHECKSUM("control_smoothing")
-#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 #define UPDATE_FREQ 1000
 
@@ -108,12 +106,6 @@ void PWMSpindleControl::on_module_loaded()
     }
     
     THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PWMSpindleControl::on_update_speed);
-
-    // register for events
-    register_for_event(ON_GCODE_RECEIVED);
-    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
-        register_for_event(ON_HALT);
-    }
 }
 
 void PWMSpindleControl::on_pin_rise()

--- a/src/modules/tools/spindle/PWMSpindleControl.cpp
+++ b/src/modules/tools/spindle/PWMSpindleControl.cpp
@@ -35,6 +35,7 @@
 #define spindle_control_I_checksum          CHECKSUM("control_I")
 #define spindle_control_D_checksum          CHECKSUM("control_D")
 #define spindle_control_smoothing_checksum  CHECKSUM("control_smoothing")
+#define spindle_ignore_on_halt_checksum     CHECKSUM("ignore_on_halt")
 
 #define UPDATE_FREQ 1000
 
@@ -108,7 +109,11 @@ void PWMSpindleControl::on_module_loaded()
     
     THEKERNEL->slow_ticker->attach(UPDATE_FREQ, this, &PWMSpindleControl::on_update_speed);
 
+    // register for events
     register_for_event(ON_GCODE_RECEIVED);
+    if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
+        register_for_event(ON_HALT);
+    }
 }
 
 void PWMSpindleControl::on_pin_rise()

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -63,3 +63,11 @@ void SpindleControl::on_gcode_received(void *argument)
 
 }
 
+void SpindleControl::on_halt(void *argument)
+{
+    if (argument == nullptr) {
+        if(spindle_on) {
+            turn_off();
+        }
+    }
+}

--- a/src/modules/tools/spindle/SpindleControl.h
+++ b/src/modules/tools/spindle/SpindleControl.h
@@ -21,6 +21,7 @@ class SpindleControl: public Module {
 
     private:
         void on_gcode_received(void *argument);
+        void on_halt(void *argument);
         
         virtual void turn_on(void) {};
         virtual void turn_off(void) {};

--- a/src/modules/tools/spindle/SpindleMaker.cpp
+++ b/src/modules/tools/spindle/SpindleMaker.cpp
@@ -17,10 +17,11 @@
 #include "ConfigValue.h"
 #include "StreamOutputPool.h"
 
-#define spindle_checksum            CHECKSUM("spindle")
-#define enable_checksum             CHECKSUM("enable")
-#define spindle_type_checksum       CHECKSUM("type")
-#define spindle_vfd_type_checksum   CHECKSUM("vfd_type")
+#define spindle_checksum                   CHECKSUM("spindle")
+#define enable_checksum                    CHECKSUM("enable")
+#define spindle_type_checksum              CHECKSUM("type")
+#define spindle_vfd_type_checksum          CHECKSUM("vfd_type")
+#define spindle_ignore_on_halt_checksum    CHECKSUM("ignore_on_halt")
 
 void SpindleMaker::load_spindle(){
 
@@ -55,6 +56,12 @@ void SpindleMaker::load_spindle(){
 
     // Add the spindle if we successfully initialized one
     if( spindle != NULL) {
+
+        spindle->register_for_event(ON_GCODE_RECEIVED);
+        if (!THEKERNEL->config->value(spindle_checksum, spindle_ignore_on_halt_checksum)->by_default(false)->as_bool()) {
+            spindle->register_for_event(ON_HALT);
+        }
+
         THEKERNEL->add_module( spindle );
     }
 


### PR DESCRIPTION
When a machine enters a `HALT` state for any reason, the spindle should
stop for safety along with everything else.  This commit changes the
default behavior to `turn_off` the spindle `on_halt`.  I added an
optional `spindle.ignore_on_halt` config parameter that defaults to
`false` in case anyone needs the previous less-safe behavior.

I believe this addresses #1069.

I confirmed functionality on `PWMSpindleControl` via `M957` as well as a
physical scope while causing `HALT` via `M112` or `^X` over the serial
interface.

I found some weirdness in `AnalogSpindleControl` around `report_speed`,
but I'll address that in another PR.  I did confirm that `turn_off` is
being called `on_halt` as it should be and the PWM duty cycle is reduced
to 0 even though `M957` (`report_speed`) continues to report that the
spindle is moving.

Without having the equipment for the other side of the RS485 connection,
I can't do much to test `ModbusSpindleContol`, but
`HuanyangSpindleControl`, the only supported Modbus VFD right now,
implements `turn_off`, so I don't see any reason it shouldn't work fine
with this change.