### PR TITLE
Report actual RPM and PWM instead of just target

### DIFF
--- a/src/modules/tools/spindle/AnalogSpindleControl.cpp
+++ b/src/modules/tools/spindle/AnalogSpindleControl.cpp
@@ -103,9 +103,10 @@ void AnalogSpindleControl::set_speed(int rpm)
 
 void AnalogSpindleControl::report_speed() 
 {
-    // report the current RPM value, calculate the current PWM value and report it as well
-    THEKERNEL->streams->printf("Current RPM: %d Analog value: %5.3f\n",
-                               target_rpm, (1.0f / max_rpm * target_rpm));
+    // report the current PWM value, calculate the current RPM value and report it as well
+    float current_pwm = pwm_pin->read();
+    THEKERNEL->streams->printf("Current RPM: %.0f Analog value: %5.3f Target RPM: %d\n",
+                               max_rpm * current_pwm, current_pwm, target_rpm);
 
 }
 


### PR DESCRIPTION
The way `report_speed` was implemented, `M957` shows `target_rpm` as the
"Current RPM" and then calculates the PWM "Analog value" from there.

Because `turn_off` uses `update_pwm(0)` to turn off the output signal
without clobbering the `target_rpm` set by `M3`, if you `turn_off` the
spindle (via `M5`, a `HALT` state, etc), `M957` (`report_speed`)
incorrectly continues to report the old "Current RPM" and calculated
"Analog value" even thought the PWM signal has actually been cut off.

I turned this around so `report_speed` reads the real PWM ("Analog
value") being sent out `pwm_pin` and then calculates the real "Current
RPM" from there.  I also appended a new "Target RPM" field to the
`report_speed` output containing `target_rpm`.

Tested over USB serial with `M597`, `M3`, `M5`, `M112`, `M999`, `^X`,
and `$X`.