### PR TITLE
Fix snprintf return value misunderstanding

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -204,7 +204,8 @@ std::string Kernel::get_query_string()
 
         char buf[128];
         // machine position
-        size_t n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(mpos[0]), robot->from_millimeters(mpos[1]), robot->from_millimeters(mpos[2]));
+        size_t n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(mpos[0]), robot->from_millimeters(mpos[1]), robot->from_millimeters(mpos[2]));
+        if(n > sizeof(buf)) n= sizeof(buf);
 
         if(new_status_format) {
             str.append("|MPos:").append(buf, n);
@@ -213,7 +214,8 @@ std::string Kernel::get_query_string()
             // deal with the ABC axis (E will be A)
             for (int i = A_AXIS; i < robot->get_number_registered_motors(); ++i) {
                 // current actuator position
-                n = snprintf(buf, sizeof(buf), ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                n = snprintf(buf, sizeof(buf)-1, ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                if(n > sizeof(buf)) n= sizeof(buf);
                 str.append(buf, n);
             }
 #endif
@@ -224,16 +226,19 @@ std::string Kernel::get_query_string()
 
         // work space position
         Robot::wcs_t pos = robot->mcs2wcs(mpos);
-        n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        if(n > sizeof(buf)) n= sizeof(buf);
 
         if(new_status_format) {
             str.append("|WPos:").append(buf, n);
             // current feedrate
             float fr= robot->from_millimeters(conveyor->get_current_feedrate()*60.0F);
-            n = snprintf(buf, sizeof(buf), "|F:%1.4f", fr);
+            n = snprintf(buf, sizeof(buf)-1, "|F:%1.4f", fr);
+            if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
             float sr= robot->get_s_value();
-            n = snprintf(buf, sizeof(buf), "|S:%1.4f", sr);
+            n = snprintf(buf, sizeof(buf)-1, "|S:%1.4f", sr);
+            if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
 
             // current Laser power
@@ -241,7 +246,8 @@ std::string Kernel::get_query_string()
                 Laser *plaser= nullptr;
                 if(PublicData::get_value(laser_checksum, (void *)&plaser) && plaser != nullptr) {
                    float lp= plaser->get_current_power();
-                    n = snprintf(buf, sizeof(buf), "|L:%1.4f", lp);
+                    n = snprintf(buf, sizeof(buf)-1, "|L:%1.4f", lp);
+                    if(n > sizeof(buf)) n= sizeof(buf);
                     str.append(buf, n);
                 }
             #endif
@@ -257,14 +263,16 @@ std::string Kernel::get_query_string()
         char buf[128];
         // machine position
         Robot::wcs_t mpos = robot->get_axis_position();
-        size_t n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(mpos)), robot->from_millimeters(std::get<Y_AXIS>(mpos)), robot->from_millimeters(std::get<Z_AXIS>(mpos)));
+        size_t n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(mpos)), robot->from_millimeters(std::get<Y_AXIS>(mpos)), robot->from_millimeters(std::get<Z_AXIS>(mpos)));
+        if(n > sizeof(buf)) n= sizeof(buf);
         if(new_status_format) {
             str.append("|MPos:").append(buf, n);
 #if MAX_ROBOT_ACTUATORS > 3
             // deal with the ABC axis (E will be A)
             for (int i = A_AXIS; i < robot->get_number_registered_motors(); ++i) {
                 // current actuator position
-                n = snprintf(buf, sizeof(buf), ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                n = snprintf(buf, sizeof(buf)-1, ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                if(n > sizeof(buf)) n= sizeof(buf);
                 str.append(buf, n);
             }
 #endif
@@ -275,7 +283,8 @@ std::string Kernel::get_query_string()
 
         // work space position
         Robot::wcs_t pos = robot->mcs2wcs(mpos);
-        n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        if(n > sizeof(buf)) n= sizeof(buf);
         if(new_status_format) {
             str.append("|WPos:").append(buf, n);
         }else{
@@ -284,7 +293,8 @@ std::string Kernel::get_query_string()
 
         if(new_status_format) {
             float fr= robot->from_millimeters(robot->get_feed_rate());
-            n = snprintf(buf, sizeof(buf), "|F:%1.4f", fr);
+            n = snprintf(buf, sizeof(buf)-1, "|F:%1.4f", fr);
+            if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
         }
 

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -204,7 +204,7 @@ std::string Kernel::get_query_string()
 
         char buf[128];
         // machine position
-        size_t n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(mpos[0]), robot->from_millimeters(mpos[1]), robot->from_millimeters(mpos[2]));
+        size_t n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(mpos[0]), robot->from_millimeters(mpos[1]), robot->from_millimeters(mpos[2]));
         if(n > sizeof(buf)) n= sizeof(buf);
 
         if(new_status_format) {
@@ -214,7 +214,7 @@ std::string Kernel::get_query_string()
             // deal with the ABC axis (E will be A)
             for (int i = A_AXIS; i < robot->get_number_registered_motors(); ++i) {
                 // current actuator position
-                n = snprintf(buf, sizeof(buf)-1, ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                n = snprintf(buf, sizeof(buf), ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
                 if(n > sizeof(buf)) n= sizeof(buf);
                 str.append(buf, n);
             }
@@ -226,18 +226,18 @@ std::string Kernel::get_query_string()
 
         // work space position
         Robot::wcs_t pos = robot->mcs2wcs(mpos);
-        n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
         if(n > sizeof(buf)) n= sizeof(buf);
 
         if(new_status_format) {
             str.append("|WPos:").append(buf, n);
             // current feedrate
             float fr= robot->from_millimeters(conveyor->get_current_feedrate()*60.0F);
-            n = snprintf(buf, sizeof(buf)-1, "|F:%1.4f", fr);
+            n = snprintf(buf, sizeof(buf), "|F:%1.4f", fr);
             if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
             float sr= robot->get_s_value();
-            n = snprintf(buf, sizeof(buf)-1, "|S:%1.4f", sr);
+            n = snprintf(buf, sizeof(buf), "|S:%1.4f", sr);
             if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
 
@@ -246,7 +246,7 @@ std::string Kernel::get_query_string()
                 Laser *plaser= nullptr;
                 if(PublicData::get_value(laser_checksum, (void *)&plaser) && plaser != nullptr) {
                    float lp= plaser->get_current_power();
-                    n = snprintf(buf, sizeof(buf)-1, "|L:%1.4f", lp);
+                    n = snprintf(buf, sizeof(buf), "|L:%1.4f", lp);
                     if(n > sizeof(buf)) n= sizeof(buf);
                     str.append(buf, n);
                 }
@@ -263,7 +263,7 @@ std::string Kernel::get_query_string()
         char buf[128];
         // machine position
         Robot::wcs_t mpos = robot->get_axis_position();
-        size_t n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(mpos)), robot->from_millimeters(std::get<Y_AXIS>(mpos)), robot->from_millimeters(std::get<Z_AXIS>(mpos)));
+        size_t n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(mpos)), robot->from_millimeters(std::get<Y_AXIS>(mpos)), robot->from_millimeters(std::get<Z_AXIS>(mpos)));
         if(n > sizeof(buf)) n= sizeof(buf);
         if(new_status_format) {
             str.append("|MPos:").append(buf, n);
@@ -271,7 +271,7 @@ std::string Kernel::get_query_string()
             // deal with the ABC axis (E will be A)
             for (int i = A_AXIS; i < robot->get_number_registered_motors(); ++i) {
                 // current actuator position
-                n = snprintf(buf, sizeof(buf)-1, ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
+                n = snprintf(buf, sizeof(buf), ",%1.4f", robot->from_millimeters(robot->actuators[i]->get_current_position()));
                 if(n > sizeof(buf)) n= sizeof(buf);
                 str.append(buf, n);
             }
@@ -283,7 +283,7 @@ std::string Kernel::get_query_string()
 
         // work space position
         Robot::wcs_t pos = robot->mcs2wcs(mpos);
-        n = snprintf(buf, sizeof(buf)-1, "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
+        n = snprintf(buf, sizeof(buf), "%1.4f,%1.4f,%1.4f", robot->from_millimeters(std::get<X_AXIS>(pos)), robot->from_millimeters(std::get<Y_AXIS>(pos)), robot->from_millimeters(std::get<Z_AXIS>(pos)));
         if(n > sizeof(buf)) n= sizeof(buf);
         if(new_status_format) {
             str.append("|WPos:").append(buf, n);
@@ -293,7 +293,7 @@ std::string Kernel::get_query_string()
 
         if(new_status_format) {
             float fr= robot->from_millimeters(robot->get_feed_rate());
-            n = snprintf(buf, sizeof(buf)-1, "|F:%1.4f", fr);
+            n = snprintf(buf, sizeof(buf), "|F:%1.4f", fr);
             if(n > sizeof(buf)) n= sizeof(buf);
             str.append(buf, n);
         }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -331,7 +331,7 @@ void Robot::print_position(uint8_t subcode, std::string& res, bool ignore_extrud
     // this does require a FK to get a machine position from the actuator position
     // and then invert all the transforms to get a workspace position from machine position
     // M114 just does it the old way uses machine_position and does inverse transforms to get the requested position
-    int n = 0;
+    uint32_t n = 0;
     char buf[64];
     if(subcode == 0) { // M114 print WCS
         wcs_t pos= mcs2wcs(machine_position);
@@ -372,6 +372,7 @@ void Robot::print_position(uint8_t subcode, std::string& res, bool ignore_extrud
         }
     }
 
+    if(n > sizeof(buf)) n= sizeof(buf);
     res.append(buf, n);
 
     #if MAX_ROBOT_ACTUATORS > 3
@@ -386,6 +387,7 @@ void Robot::print_position(uint8_t subcode, std::string& res, bool ignore_extrud
             // current actuator position
             n= snprintf(buf, sizeof(buf), " %c:%1.4f", 'A'+i-A_AXIS, actuators[i]->get_current_position());
         }
+        if(n > sizeof(buf)) n= sizeof(buf);
         if(n > 0) res.append(buf, n);
     }
     #endif

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -896,7 +896,8 @@ void SimpleShell::calc_thermistor_command( string parameters, StreamOutput *stre
             stream->printf("  Paste the above in the M305 S0 command, then save with M500\n");
         }else{
             char buf[80];
-            int n = snprintf(buf, sizeof(buf), "M305 S%d I%1.18f J%1.18f K%1.18f", saveto, c1, c2, c3);
+            size_t n = snprintf(buf, sizeof(buf), "M305 S%d I%1.18f J%1.18f K%1.18f", saveto, c1, c2, c3);
+            if(n > sizeof(buf)) n= sizeof(buf);
             string g(buf, n);
             Gcode gcode(g, &(StreamOutput::NullStream));
             THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode );


### PR DESCRIPTION
snprintf returns the number of characters that "would" have been written, not the actual number, and not he number limited by the buffer size.
As in some cases this is used to append the buf to a std::string it needs to be truncated to actual size of buf if bigger.