### PR TITLE
Allow tool temperature control on inactive tools (non-modal 'T')

### DIFF
--- a/src/modules/communication/GcodeDispatch.h
+++ b/src/modules/communication/GcodeDispatch.h
@@ -31,5 +31,6 @@ private:
     uint8_t modal_group_1;
     struct {
         bool uploading: 1;
+        bool modal_t: 1;
     };
 };

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -137,7 +137,7 @@ int Gcode::get_num_args() const
     int count = 0;
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         if( this->command[i] >= 'A' && this->command[i] <= 'Z' ) {
-            if(is_modal_t && this->command[i] == 'T') continue;
+            if(this->is_modal_t && this->command[i] == 'T') continue;
             count++;
         }
     }
@@ -150,7 +150,7 @@ std::map<char,float> Gcode::get_args() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            if(is_modal_t && c == 'T') continue;
+            if(this->is_modal_t && c == 'T') continue;
             m[c]= get_value(c);
         }
     }
@@ -163,7 +163,7 @@ std::map<char,int> Gcode::get_args_int() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            if(is_modal_t && c == 'T') continue;
+            if(this->is_modal_t && c == 'T') continue;
             m[c]= get_int(c);
         }
     }

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -47,6 +47,7 @@ Gcode::Gcode(const Gcode &to_copy)
     this->is_error              = to_copy.is_error;
     this->stream                = to_copy.stream;
     this->txt_after_ok.assign( to_copy.txt_after_ok );
+    this->is_modal_t            = to_copy.is_modal_t;
 }
 
 Gcode &Gcode::operator= (const Gcode &to_copy)
@@ -62,6 +63,7 @@ Gcode &Gcode::operator= (const Gcode &to_copy)
         this->is_error              = to_copy.is_error;
         this->stream                = to_copy.stream;
         this->txt_after_ok.assign( to_copy.txt_after_ok );
+        this->is_modal_t            = to_copy.is_modal_t;
     }
     return *this;
 }
@@ -135,7 +137,7 @@ int Gcode::get_num_args() const
     int count = 0;
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         if( this->command[i] >= 'A' && this->command[i] <= 'Z' ) {
-            //if(this->command[i] == 'T') continue;
+            if(is_modal_t && this->command[i] == 'T') continue;
             count++;
         }
     }
@@ -148,7 +150,7 @@ std::map<char,float> Gcode::get_args() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            //if(c == 'T') continue;
+            if(is_modal_t && c == 'T') continue;
             m[c]= get_value(c);
         }
     }
@@ -161,7 +163,7 @@ std::map<char,int> Gcode::get_args_int() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            //if(c == 'T') continue;
+            if(is_modal_t && c == 'T') continue;
             m[c]= get_int(c);
         }
     }

--- a/src/modules/communication/utils/Gcode.cpp
+++ b/src/modules/communication/utils/Gcode.cpp
@@ -135,7 +135,7 @@ int Gcode::get_num_args() const
     int count = 0;
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         if( this->command[i] >= 'A' && this->command[i] <= 'Z' ) {
-            if(this->command[i] == 'T') continue;
+            //if(this->command[i] == 'T') continue;
             count++;
         }
     }
@@ -148,7 +148,7 @@ std::map<char,float> Gcode::get_args() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            if(c == 'T') continue;
+            //if(c == 'T') continue;
             m[c]= get_value(c);
         }
     }
@@ -161,7 +161,7 @@ std::map<char,int> Gcode::get_args_int() const
     for(size_t i = stripped?0:1; i < strlen(command); i++) {
         char c= this->command[i];
         if( c >= 'A' && c <= 'Z' ) {
-            if(c == 'T') continue;
+            //if(c == 'T') continue;
             m[c]= get_int(c);
         }
     }

--- a/src/modules/communication/utils/Gcode.h
+++ b/src/modules/communication/utils/Gcode.h
@@ -43,6 +43,7 @@ class Gcode {
             bool has_g:1;
             bool stripped:1;
             bool is_error:1;
+            bool is_modal_t:1;
             uint8_t subcode:3;
         };
 

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -326,13 +326,13 @@ void TemperatureControl::on_gcode_received(void *argument)
             }
 
         } else if( ( gcode->m == this->set_m_code || gcode->m == this->set_and_wait_m_code ) && gcode->has_letter('S')) {
-            // this only gets handled if it is not controlled by the tool manager or is active in the toolmanager           
+            // this only gets handled if it is not controlled by the tool manager or is active in the toolmanager
 
-            // this is safe as old configs as well as single extruder configs the toolmanager will not be running so will return false
-            // this will also ignore anything that the tool manager is not controlling and return false, otherwise it returns the active tool
-            
             if(!gcode->has_letter('T') || gcode->is_modal_t) { //Default temperature handling, just test if we are the active tool head
                 
+                // this is safe as old configs as well as single extruder configs the toolmanager will not be running so will return false
+                // this will also ignore anything that the tool manager is not controlling and return false, otherwise it returns the active tool
+           
                 this->active = true;
 
                 void *returned_data;

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -145,7 +145,7 @@ void TemperatureControl::load_config()
 
     this->designator          = THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, designator_checksum)->by_default(string("T"))->as_string();
 
-      // Runaway parameters
+    // Runaway parameters
     uint32_t n= THEKERNEL->config->value(temperature_control_checksum, this->name_checksum, runaway_range_checksum)->by_default(20)->as_number();
     if(n > 63) n= 63;
     this->runaway_range= n;
@@ -590,7 +590,7 @@ void TemperatureControl::on_second_tick(void *argument)
                     tick= 0;
 
                 }else{
-                    uint16_t t= (runaway_state == HEATING_UP) ? this->runaway_heating_timeout : this->runaway_cooling_timeout;                   
+                    uint16_t t= (runaway_state == HEATING_UP) ? this->runaway_heating_timeout : this->runaway_cooling_timeout;
                     // we are still heating up see if we have hit the max time allowed
                     if(t > 0 && ++this->runaway_timer > t){
                         THEKERNEL->streams->printf("ERROR: Temperature took too long to be reached on %s, HALT asserted, TURN POWER OFF IMMEDIATELY - reset or M999 required\n", designator.c_str());

--- a/src/modules/tools/toolmanager/ToolManager.cpp
+++ b/src/modules/tools/toolmanager/ToolManager.cpp
@@ -44,7 +44,7 @@ void ToolManager::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode*>(argument);
 
-    if( gcode->has_letter('T') ) {
+    if( !gcode->has_m && !gcode->has_g && gcode->has_letter('T') ) { //Only switch tools on a T# command, not when altering a second tool state (M104 T1 S200, for example)
         int new_tool = gcode->get_value('T');
         if(new_tool >= (int)this->tools.size() || new_tool < 0) {
             // invalid tool

--- a/src/modules/tools/toolmanager/ToolManager.cpp
+++ b/src/modules/tools/toolmanager/ToolManager.cpp
@@ -44,7 +44,7 @@ void ToolManager::on_gcode_received(void *argument)
 {
     Gcode *gcode = static_cast<Gcode*>(argument);
 
-    if( !gcode->has_m && !gcode->has_g && gcode->has_letter('T') ) { //Only switch tools on a T# command, not when altering a second tool state (M104 T1 S200, for example)
+    if( (gcode->is_modal_t || (!gcode->has_m && !gcode->has_g)) && gcode->has_letter('T') ) {
         int new_tool = gcode->get_value('T');
         if(new_tool >= (int)this->tools.size() || new_tool < 0) {
             // invalid tool


### PR DESCRIPTION
### Why?
Multi extrusion 3D Printing (support material, multi-color, etc.). Mainstream slicers have adopted this style for some time. This change allows a number of slicers (Cura, and KISS, for example) to control innactive tool head temperatures during the print. This _dramatically_ reduces print time by bringing the next tool up to temperature as the current tool finishes it's work on the current layer.

### What does it do?
The default behavior is unchanged in smoothie. The user must add a configuration value to enable this non-modal T behavior with: **modal_t false** in their configuration. Then anytime a T command is included with a G or M on the line it is treated as a parameter rather than a tool change command.

**Previous/Default behavior example:**
T0 ;switch to tool 0
M104 S215 ;set the Tool0 temperature
G1 X150 Y150 E1.5 ;do some printing
M104 T1 S215 ;We just want to warm up our next tool **however this command will change the active tool, making Tool1 active**
G1 X183 Y111 E.5 ;do some more printing **This will begin printing with Tool1**

**New behavior with "modal_t false" in the configuration**
T0 ;switch to tool 0
M104 S215 ;set the Tool0 temperature
G1 X150 Y150 E1.5 ;do some printing
M104 T1 S215 ;Warm up our next tool
G1 X183 Y111 E.5 ;finish printing our layer without changing the tool until.....
T1 ;Switch to Tool1

### Limitations
Currently this supports 10 tools [0-9] due to the string storage of the tool designator. If this is unacceptable I'll update the parsing code to accommodate any tool number.

### Testing
This has several hundred hours of print time on my machines so far, with thousands of tool changes (and countless hours of time saved). I have only tested machines with 2 tools, though I don't foresee issues it has not yet been tested.