### PR TITLE
Fix M958 Set Spindle PID Parameters

### DIFF
--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -30,9 +30,9 @@ void SpindleControl::on_gcode_received(void *argument)
             if (gcode->has_letter('P'))
                 set_p_term( gcode->get_value('P') );
             if (gcode->has_letter('I'))
-                set_p_term( gcode->get_value('I') );
+                set_i_term( gcode->get_value('I') );
             if (gcode->has_letter('D'))
-                set_p_term( gcode->get_value('D') );
+                set_d_term( gcode->get_value('D') );
             // report PID settings
             report_settings();
           


### PR DESCRIPTION
Original code sets the P term to any values provided for P, I, or D with
no way to set I or D terms.  This change sets I and D correctly as one
would expect when I and D are passed to M958.  The set_i_term() and
set_d_term() functions already existed, so the layout in
on_gcode_received() was likely a simple oversight.

I tested this change on the bench with a Smoothieboard driving an MC2100
DC controller hooked up to a 2HP treadmill motor.  Prior to the change,
M958 would only set the P term.  After the change, M958 works as
expected and the PID controller can be tuned live.