### PR TITLE
Add M115 Get Firmware Version

### DIFF
--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -25,6 +25,7 @@
 #include "SimpleShell.h"
 #include "utils.h"
 #include "LPC17xx.h"
+#include "version.h"
 
 #define panel_display_message_checksum CHECKSUM("display_message")
 #define panel_checksum             CHECKSUM("panel")
@@ -257,6 +258,26 @@ try_again:
                                 THEKERNEL->call_event(ON_HALT, nullptr);
                                 THEKERNEL->streams->printf("ok Emergency Stop Requested - reset or M999 required to exit HALT state\r\n");
                                 delete gcode;
+                                return;
+
+                            case 115: // M115 Get firmware version and capabilities
+                                Version vers;
+
+                                new_message.stream->printf("FIRMWARE_NAME:Smoothieware, FIRMWARE_URL:http://smoothieware.org, SOURCE_CODE_URL:https://github.com/Smoothieware/Smoothieware, FIRMWARE_VERSION:%s, BUILD_DATE:%s, SYSTEM_CLOCK:%ldMHz, AXES:%d", vers.get_build(), vers.get_build_date(), SystemCoreClock / 1000000, MAX_ROBOT_ACTUATORS);
+
+                                #ifdef CNC
+                                new_message.stream->printf(", CNC:1");
+                                #else
+                                new_message.stream->printf(", CNC:0");
+                                #endif
+
+                                #ifdef DISABLEMSD
+                                new_message.stream->printf(", MSD:0");
+                                #else
+                                new_message.stream->printf(", MSD:1");
+                                #endif
+
+                                new_message.stream->printf("\r\nok\r\n");
                                 return;
 
                             case 117: // M117 is a special non compliant Gcode as it allows arbitrary text on the line following the command


### PR DESCRIPTION
I based this implementation on the existing `version` command in
SimpleShell as well as looking what the other players are doing with
M115:

http://reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities

http://marlinfw.org/docs/gcode/M115.html

https://duet3d.com/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities

I did not bring MCU over from `version` as I felt there would be too
much code duplication / complexity for too little gain.  The M115 output
from my test branch looks like this:

FIRMWARE_NAME:Smoothieware, FIRMWARE_URL:http://smoothieware.org,
SOURCE_CODE_URL:https://github.com/Smoothieware/Smoothieware,
FIRMWARE_VERSION:feature/m115_get_firmware_version-8d5ff26,
BUILD_DATE:Feb 16 2018 17:11:15, SYSTEM_CLOCK:100MHz, AXES:3, CNC:1,
MSD:1
ok

Of course FIRMWARE_VERSION will look better when it's `edge` as opposed
to my overly long branch name.

I arbitrarily followed Marlin's example of leaving colons in the value
of the k-v pair as a problem for the parser instead of URL encoding them
like RepRap or avoiding them entirely like Duet3d.  I'm not married to
this, so if there's a preference for another direction, I'm open.

If accepted, I believe this fixes #279.