### PR TITLE
Add more safety to laser testing by optional duration parameter and s…

### DIFF
--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -113,7 +113,8 @@ void Laser::on_module_loaded()
     this->register_for_event(ON_CONSOLE_LINE_RECEIVED);
     this->register_for_event(ON_GET_PUBLIC_DATA);
 
-    // no point in updating the power more than the PWM frequency, but no more than 1KHz
+    // no point in updating the power more than the PWM frequency, but not faster than 1KHz
+    ms_per_tick = 1000 / std::min(1000UL, 1000000/period);
     THEKERNEL->slow_ticker->attach(std::min(1000UL, 1000000/period), this, &Laser::set_proportional_power);
 }
 
@@ -155,9 +156,15 @@ void Laser::on_console_line_received( void *argument )
             if(!duration.empty()) {
                 fire_duration=atoi(duration.c_str());
                 // Avoid negative values, its just incorrect
-                if(fire_duration < 0)
-                  fire_duration = 0;
-                msgp->stream->printf("WARNING: Firing laser at %1.2f%% power, for %ld ms, use fire off to return to auto mode\n", p, fire_duration);
+                if (fire_duration < ms_per_tick) {
+                  msgp->stream->printf("WARNING: Minimal duration is %d ms, not firing\n", ms_per_tick);
+                  return;
+                }
+                // rounding to minimal value
+                if (fire_duration % ms_per_tick != 0) {
+                  fire_duration = (fire_duration / ms_per_tick) * ms_per_tick;
+                }
+                msgp->stream->printf("WARNING: Firing laser at %1.2f%% power, for %ld ms, use fire off to stop test fire earlier\n", p, fire_duration);
             } else {
                 msgp->stream->printf("WARNING: Firing laser at %1.2f%% power, entering manual mode use fire off to return to auto mode\n", p);
             }
@@ -242,9 +249,9 @@ uint32_t Laser::set_proportional_power(uint32_t dummy)
       // If we have fire duration set
       if (fire_duration) {
         // Decrease it each ms
-        fire_duration--;
+        fire_duration -= ms_per_tick;
         // And if it turned 0, disable laser and manual fire mode
-        if (!fire_duration) {
+        if (fire_duration <= 0) {
           set_laser_power(0);
           manual_fire = false;
         }

--- a/src/modules/tools/laser/Laser.cpp
+++ b/src/modules/tools/laser/Laser.cpp
@@ -157,7 +157,7 @@ void Laser::on_console_line_received( void *argument )
                 fire_duration=atoi(duration.c_str());
                 // Avoid negative values, its just incorrect
                 if (fire_duration < ms_per_tick) {
-                  msgp->stream->printf("WARNING: Minimal duration is %d ms, not firing\n", ms_per_tick);
+                  msgp->stream->printf("WARNING: Minimal duration is %ld ms, not firing\n", ms_per_tick);
                   return;
                 }
                 // rounding to minimal value

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -51,5 +51,5 @@ class Laser : public Module{
             bool manual_fire:1;     // set when manually firing
         };
         int32_t fire_duration; // manual fire command duration
-        uint32_t ms_per_tick; // ms between each ticks, depends on PWM frequency
+        int32_t ms_per_tick; // ms between each ticks, depends on PWM frequency
 };

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -50,5 +50,6 @@ class Laser : public Module{
             bool ttl_inverting:1;   // stores whether the TTL output should be inverted
             bool manual_fire:1;     // set when manually firing
         };
-        int32_t fire_duration;
+        int32_t fire_duration; // manual fire command duration
+        uint32_t ms_per_tick; // ms between each ticks, depends on PWM frequency
 };

--- a/src/modules/tools/laser/Laser.h
+++ b/src/modules/tools/laser/Laser.h
@@ -50,4 +50,5 @@ class Laser : public Module{
             bool ttl_inverting:1;   // stores whether the TTL output should be inverted
             bool manual_fire:1;     // set when manually firing
         };
+        int32_t fire_duration;
 };


### PR DESCRIPTION
After doing various tests i noticed that "fire" command might be quite dangerous, if host pc got disconnected due software glitch. Adding duration parameter is backward compatible, as it's optional, but we can make it much safer, and this parameter can be used also for laser power and focus calibration, as precisely measured duration of firing highly useful for this.
I tested this on my K40, and it worked well.