### PR TITLE
Improvements to G2/G3 Arcs

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1461,11 +1461,8 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float r_axis1 = -offset[this->plane_axis_1];
     float rt_axis0 = target[this->plane_axis_0] - center_axis0;
     float rt_axis1 = target[this->plane_axis_1] - center_axis1;
+    float angular_travel = 0;
 
-    // Patch from GRBL Firmware - Christoph Baumann 04072015
-    // CCW angle between position and target from circle center. Only one atan2() trig computation required.
-
-    float angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
     gcode->stream->printf("Mpos Plane_Axis_0: %8.34f\r\n", machine_position[this->plane_axis_0]);
     gcode->stream->printf("Mpos Plane_Axis_1: %8.34f\r\n", machine_position[this->plane_axis_1]);
     gcode->stream->printf("Offset Plane_Axis_0: %8.34f\r\n", offset[this->plane_axis_0]);
@@ -1474,21 +1471,47 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     gcode->stream->printf("Target Plane_Axis_1: %8.34f\r\n", target[this->plane_axis_1]);
     gcode->stream->printf("center_axis0: %8.34f\r\n", center_axis0);
     gcode->stream->printf("center_axis1: %8.34f\r\n", center_axis1);
-    gcode->stream->printf("Radius:%8.34f\r\n",radius);
-    gcode->stream->printf("r_axis0:%8.34f\r\n",r_axis0);
-    gcode->stream->printf("rt_axis0:%8.34f\r\n",rt_axis0);
-    gcode->stream->printf("r_axis1:%8.34f\r\n",r_axis1);
-    gcode->stream->printf("rt_axis1:%8.34f\r\n",rt_axis1);
-    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON:%8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
-    gcode->stream->printf("angular_travel1:%8.34f\r\n",angular_travel);
-    if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-    if (is_clockwise) { // Correct atan2 output per direction
-        if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
-    } else {
-        if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
-    }
-    gcode->stream->printf("angular_travel2:%8.34f\r\n",angular_travel);
+    gcode->stream->printf("Radius: %8.34f\r\n",radius);
+    gcode->stream->printf("r_axis0: %8.34f\r\n",r_axis0);
+    gcode->stream->printf("rt_axis0: %8.34f\r\n",rt_axis0);
+    gcode->stream->printf("r_axis1: %8.34f\r\n",r_axis1);
+    gcode->stream->printf("rt_axis1: %8.34f\r\n",rt_axis1);
+    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON: %8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
 
+    if((this->machine_position[this->plane_axis_0]==target[this->plane_axis_0]) and(this->machine_position[this->plane_axis_1]==target[this->plane_axis_1])) {
+        gcode->stream->printf("Full Circle: True\r\n");
+        if (is_clockwise) {
+           angular_travel = (-2 * PI);
+        } else {
+           angular_travel = (2 * PI);
+        }
+        gcode->stream->printf("Full Circle angular_travel: %8.34f\r\n",angular_travel);
+    } else {
+        gcode->stream->printf("Full Circle: False\r\n");
+        // Patch from GRBL Firmware - Christoph Baumann 04072015
+        // CCW angle between position and target from circle center. Only one atan2() trig computation required.
+        // Only run if not a full circle
+        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+        gcode->stream->printf("initial angular_travel1: %8.34f\r\n",angular_travel);
+        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
+        if (is_clockwise) { // Correct atan2 output per direction
+           if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
+        } else {
+           if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
+        }
+        gcode->stream->printf("old angular_travel2: %8.34f\r\n",angular_travel);
+     
+        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+     
+        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
+        if (is_clockwise) { // Correct atan2 output per direction
+           if (angular_travel > 0) { angular_travel -= (2 * PI); }
+        } else {
+           if (angular_travel < 0) { angular_travel += (2 * PI); }
+        }
+        gcode->stream->printf("new angular_travel2: %8.34f\r\n",angular_travel);
+    } 
+     
     
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1463,59 +1463,30 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float rt_axis1 = target[this->plane_axis_1] - center_axis1;
     float angular_travel = 0;
 
-    gcode->stream->printf("Mpos Plane_Axis_0: %8.34f\r\n", machine_position[this->plane_axis_0]);
-    gcode->stream->printf("Mpos Plane_Axis_1: %8.34f\r\n", machine_position[this->plane_axis_1]);
-    gcode->stream->printf("Offset Plane_Axis_0: %8.34f\r\n", offset[this->plane_axis_0]);
-    gcode->stream->printf("Offset Plane_Axis_1: %8.34f\r\n", offset[this->plane_axis_1]);
-    gcode->stream->printf("Target Plane_Axis_0: %8.34f\r\n", target[this->plane_axis_0]);
-    gcode->stream->printf("Target Plane_Axis_1: %8.34f\r\n", target[this->plane_axis_1]);
-    gcode->stream->printf("center_axis0: %8.34f\r\n", center_axis0);
-    gcode->stream->printf("center_axis1: %8.34f\r\n", center_axis1);
-    gcode->stream->printf("Radius: %8.34f\r\n",radius);
-    gcode->stream->printf("r_axis0: %8.34f\r\n",r_axis0);
-    gcode->stream->printf("rt_axis0: %8.34f\r\n",rt_axis0);
-    gcode->stream->printf("r_axis1: %8.34f\r\n",r_axis1);
-    gcode->stream->printf("rt_axis1: %8.34f\r\n",rt_axis1);
-    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON: %8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
-
-    if((this->machine_position[this->plane_axis_0]==target[this->plane_axis_0]) and(this->machine_position[this->plane_axis_1]==target[this->plane_axis_1])) {
-        gcode->stream->printf("Full Circle: True\r\n");
+    //Check to see if we have a full circle, and if so, set angualr_travel.   
+    if ((this->machine_position[this->plane_axis_0]==target[this->plane_axis_0]) and
+    (this->machine_position[this->plane_axis_1]==target[this->plane_axis_1])) {
         if (is_clockwise) {
            angular_travel = (-2 * PI);
         } else {
            angular_travel = (2 * PI);
         }
-        gcode->stream->printf("Full Circle angular_travel: %8.34f\r\n",angular_travel);
     } else {
-        gcode->stream->printf("Full Circle: False\r\n");
         // Patch from GRBL Firmware - Christoph Baumann 04072015
         // CCW angle between position and target from circle center. Only one atan2() trig computation required.
-        // Only run if not a full circle
-        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
-        gcode->stream->printf("initial angular_travel1: %8.34f\r\n",angular_travel);
-        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-        if (is_clockwise) { // Correct atan2 output per direction
-           if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
-        } else {
-           if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
-        }
-        gcode->stream->printf("old angular_travel2: %8.34f\r\n",angular_travel);
-     
+        // Only run if not a full circle.
         angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
      
         if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-        if (is_clockwise) { // Correct atan2 output per direction
-           if (angular_travel > 0) { angular_travel -= (2 * PI); }
+        if (is_clockwise) { // Adjust atan2 output per direction
+           if (angular_travel > 0) { angular_travel -= (2 * PI); }  //Adjust angular_travel to be between 0 and -2Pi
         } else {
-           if (angular_travel < 0) { angular_travel += (2 * PI); }
+           if (angular_travel < 0) { angular_travel += (2 * PI); }  //Adjust angular_travel to be between 0 and 2Pi
         }
-        gcode->stream->printf("new angular_travel2: %8.34f\r\n",angular_travel);
     } 
-     
     
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
-    gcode->stream->printf("millimeters_of_travel:%8.34f\r\n",millimeters_of_travel);
 
     // We don't care about non-XYZ moves ( for example the extruder produces some of those )
     if( millimeters_of_travel < 0.000001F ) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1464,16 +1464,35 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
 
     // Patch from GRBL Firmware - Christoph Baumann 04072015
     // CCW angle between position and target from circle center. Only one atan2() trig computation required.
+
     float angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+    gcode->stream->printf("Mpos Plane_Axis_0: %8.34f\r\n", machine_position[this->plane_axis_0]);
+    gcode->stream->printf("Mpos Plane_Axis_1: %8.34f\r\n", machine_position[this->plane_axis_1]);
+    gcode->stream->printf("Offset Plane_Axis_0: %8.34f\r\n", offset[this->plane_axis_0]);
+    gcode->stream->printf("Offset Plane_Axis_1: %8.34f\r\n", offset[this->plane_axis_1]);
+    gcode->stream->printf("Target Plane_Axis_0: %8.34f\r\n", target[this->plane_axis_0]);
+    gcode->stream->printf("Target Plane_Axis_1: %8.34f\r\n", target[this->plane_axis_1]);
+    gcode->stream->printf("center_axis0: %8.34f\r\n", center_axis0);
+    gcode->stream->printf("center_axis1: %8.34f\r\n", center_axis1);
+    gcode->stream->printf("Radius:%8.34f\r\n",radius);
+    gcode->stream->printf("r_axis0:%8.34f\r\n",r_axis0);
+    gcode->stream->printf("rt_axis0:%8.34f\r\n",rt_axis0);
+    gcode->stream->printf("r_axis1:%8.34f\r\n",r_axis1);
+    gcode->stream->printf("rt_axis1:%8.34f\r\n",rt_axis1);
+    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON:%8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
+    gcode->stream->printf("angular_travel1:%8.34f\r\n",angular_travel);
     if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
     if (is_clockwise) { // Correct atan2 output per direction
         if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
     } else {
         if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
     }
+    gcode->stream->printf("angular_travel2:%8.34f\r\n",angular_travel);
 
+    
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
+    gcode->stream->printf("millimeters_of_travel:%8.34f\r\n",millimeters_of_travel);
 
     // We don't care about non-XYZ moves ( for example the extruder produces some of those )
     if( millimeters_of_travel < 0.000001F ) {
@@ -1586,7 +1605,6 @@ bool Robot::compute_arc(Gcode * gcode, const float offset[], const float target[
 
     // Find the radius
     float radius = hypotf(offset[this->plane_axis_0], offset[this->plane_axis_1]);
-
     // Set clockwise/counter-clockwise sign for mc_arc computations
     bool is_clockwise = false;
     if( motion_mode == CW_ARC ) {


### PR DESCRIPTION
This PR is to fix the issue documented #1291.  It was found that the atan2 function has limitations which can cause a full circle to be ignored.  The conversion after it could sometimes fix it, however the conversion also had the possibility of creating a full circle when a tiny arc segment was intended, and it also was unable to fix all occurrences.   
Both these issues are solved by first detecting if the command is a true full circle, and if so, simply setting the angular_travel  to the correct value.  By eliminating full circles from the atan2 formula, it now is very reliable, anything from the tiniest arc segment to the largest imaginable arc that is not a full circle calculate accurately.  
Since the atan2 formula is now reliable, the section after it that was used as a correction after it now simply needs to perform an adjustment to shift the output of atan2.  atan2 can produce a result from pi to -pi (excluding -pi) however for our purposes, we need counterclockwise arcs to be from 0 to 2pi and clockwise arcs to be from -2pi to 0.  The adjustment is able now achieve this without errors because the atan2 calculation works fine if there are no full circles (full circles have identical start and end points and everything cancels out).  With massively extreme input like a start and end point only 0.00001mm apart with a radius over 2000 for example, the atan2 formula will produce a result of 0, it is important that if it produces 0, it stays 0, otherwise one would get a gigantic full circle.  The current adjustment makes sure that a 0 result from the atan2 formula will remain 0 for these extreme edge cases.