### PR TITLE
Use arc_milestone

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1464,19 +1464,61 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float r_axis1 = -offset[this->plane_axis_1];
     float rt_axis0 = target[this->plane_axis_0] - center_axis0;
     float rt_axis1 = target[this->plane_axis_1] - center_axis1;
+    float angular_travel = 0;
 
-    // Patch from GRBL Firmware - Christoph Baumann 04072015
-    // CCW angle between position and target from circle center. Only one atan2() trig computation required.
-    float angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
-    if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-    if (is_clockwise) { // Correct atan2 output per direction
-        if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
+    gcode->stream->printf("Mpos Plane_Axis_0: %8.34f\r\n", machine_position[this->plane_axis_0]);
+    gcode->stream->printf("Mpos Plane_Axis_1: %8.34f\r\n", machine_position[this->plane_axis_1]);
+    gcode->stream->printf("Offset Plane_Axis_0: %8.34f\r\n", offset[this->plane_axis_0]);
+    gcode->stream->printf("Offset Plane_Axis_1: %8.34f\r\n", offset[this->plane_axis_1]);
+    gcode->stream->printf("Target Plane_Axis_0: %8.34f\r\n", target[this->plane_axis_0]);
+    gcode->stream->printf("Target Plane_Axis_1: %8.34f\r\n", target[this->plane_axis_1]);
+    gcode->stream->printf("center_axis0: %8.34f\r\n", center_axis0);
+    gcode->stream->printf("center_axis1: %8.34f\r\n", center_axis1);
+    gcode->stream->printf("Radius: %8.34f\r\n",radius);
+    gcode->stream->printf("r_axis0: %8.34f\r\n",r_axis0);
+    gcode->stream->printf("rt_axis0: %8.34f\r\n",rt_axis0);
+    gcode->stream->printf("r_axis1: %8.34f\r\n",r_axis1);
+    gcode->stream->printf("rt_axis1: %8.34f\r\n",rt_axis1);
+    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON: %8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
+
+    if((this->machine_position[this->plane_axis_0]==target[this->plane_axis_0]) and(this->machine_position[this->plane_axis_1]==target[this->plane_axis_1])) {
+        gcode->stream->printf("Full Circle: True\r\n");
+        if (is_clockwise) {
+           angular_travel = (-2 * PI);
+        } else {
+           angular_travel = (2 * PI);
+        }
+        gcode->stream->printf("Full Circle angular_travel: %8.34f\r\n",angular_travel);
     } else {
-        if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
-    }
-
+        gcode->stream->printf("Full Circle: False\r\n");
+        // Patch from GRBL Firmware - Christoph Baumann 04072015
+        // CCW angle between position and target from circle center. Only one atan2() trig computation required.
+        // Only run if not a full circle
+        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+        gcode->stream->printf("initial angular_travel1: %8.34f\r\n",angular_travel);
+        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
+        if (is_clockwise) { // Correct atan2 output per direction
+           if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
+        } else {
+           if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
+        }
+        gcode->stream->printf("old angular_travel2: %8.34f\r\n",angular_travel);
+     
+        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
+     
+        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
+        if (is_clockwise) { // Correct atan2 output per direction
+           if (angular_travel > 0) { angular_travel -= (2 * PI); }
+        } else {
+           if (angular_travel < 0) { angular_travel += (2 * PI); }
+        }
+        gcode->stream->printf("new angular_travel2: %8.34f\r\n",angular_travel);
+    } 
+     
+    
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
+    gcode->stream->printf("millimeters_of_travel:%8.34f\r\n",millimeters_of_travel);
 
     // We don't care about non-XYZ moves ( for example the extruder produces some of those )
     if( millimeters_of_travel < 0.000001F ) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1466,51 +1466,17 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float rt_axis1 = target[this->plane_axis_1] - this->arc_milestone[this->plane_axis_1] - offset[this->plane_axis_1];
     float angular_travel = 0;
 
-    gcode->stream->printf("Machine_Position Plane_Axis_0: %8.34f\r\n", machine_position[this->plane_axis_0]);
-    gcode->stream->printf("Machine_Position Plane_Axis_1: %8.34f\r\n", machine_position[this->plane_axis_1]);
-    gcode->stream->printf("Arc Milestone Plane_Axis_0: %8.34f\r\n", arc_milestone[this->plane_axis_0]);
-    gcode->stream->printf("Arc_Milestone Plane_Axis_1: %8.34f\r\n", arc_milestone[this->plane_axis_1]);
-    gcode->stream->printf("Offset Plane_Axis_0: %8.34f\r\n", offset[this->plane_axis_0]);
-    gcode->stream->printf("Offset Plane_Axis_1: %8.34f\r\n", offset[this->plane_axis_1]);
-    gcode->stream->printf("Target Plane_Axis_0: %8.34f\r\n", target[this->plane_axis_0]);
-    gcode->stream->printf("Target Plane_Axis_1: %8.34f\r\n", target[this->plane_axis_1]);
-    gcode->stream->printf("center_axis0: %8.34f\r\n", center_axis0);
-    gcode->stream->printf("center_axis1: %8.34f\r\n", center_axis1);
-    gcode->stream->printf("Radius: %8.34f\r\n",radius);
-    gcode->stream->printf("r_axis0: %8.34f\r\n",r_axis0);
-    gcode->stream->printf("r_axis1: %8.34f\r\n",r_axis1);
-    gcode->stream->printf("rt2_axis0: %8.34f\r\n",rt_axis0);
-    gcode->stream->printf("rt2_axis1: %8.34f\r\n",rt_axis1);
-    gcode->stream->printf("Old rt_axis0: %8.34f\r\n",target[this->plane_axis_0] - center_axis0);
-    gcode->stream->printf("Old rt_axis1: %8.34f\r\n",target[this->plane_axis_1] - center_axis1);
-    gcode->stream->printf("ARC_ANGULAR_TRAVEL_EPSILON: %8.64f\r\n",ARC_ANGULAR_TRAVEL_EPSILON);
-
     if((this->arc_milestone[this->plane_axis_0]==target[this->plane_axis_0]) && (this->arc_milestone[this->plane_axis_1]==target[this->plane_axis_1])) {
-        gcode->stream->printf("Full Circle: True\r\n");
         if (is_clockwise) {
            angular_travel = (-2 * PI);
         } else {
            angular_travel = (2 * PI);
         }
-        gcode->stream->printf("Full Circle angular_travel: %8.34f\r\n",angular_travel);
     } else {
-        gcode->stream->printf("Full Circle: False\r\n");
-
         // Patch from GRBL Firmware - Christoph Baumann 04072015
         // CCW angle between position and target from circle center. Only one atan2() trig computation required.
         // Only run if not a full circle
         angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
-        gcode->stream->printf("initial angular_travel1: %8.34f\r\n",angular_travel);
-        if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-        if (is_clockwise) { // Correct atan2 output per direction
-           if (angular_travel >= -ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel -= (2 * PI); }
-        } else {
-           if (angular_travel <= ARC_ANGULAR_TRAVEL_EPSILON) { angular_travel += (2 * PI); }
-        }
-        gcode->stream->printf("old angular_travel2: %8.34f\r\n",angular_travel);
-     
-        angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
-     
         if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
         if (is_clockwise) { // Correct atan2 output per direction
            if (angular_travel > 0) { angular_travel -= (2 * PI); }
@@ -1518,12 +1484,9 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
            if (angular_travel < 0) { angular_travel += (2 * PI); }
         }
     }
-        gcode->stream->printf("new angular_travel2: %8.34f\r\n",angular_travel);
-
     
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
-    gcode->stream->printf("millimeters_of_travel:%8.34f\r\n",millimeters_of_travel);
 
     // We don't care about non-XYZ moves ( for example the extruder produces some of those )
     if( millimeters_of_travel < 0.000001F ) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1460,31 +1460,31 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     float center_axis0 = this->arc_milestone[this->plane_axis_0] + offset[this->plane_axis_0];
     float center_axis1 = this->arc_milestone[this->plane_axis_1] + offset[this->plane_axis_1];
     float linear_travel = target[this->plane_axis_2] - this->arc_milestone[this->plane_axis_2];
-    float r_axis0 = -offset[this->plane_axis_0]; // Radius vector from center to current location
+    float r_axis0 = -offset[this->plane_axis_0]; // Radius vector from center to start position
     float r_axis1 = -offset[this->plane_axis_1];
-    float rt_axis0 = target[this->plane_axis_0] - this->arc_milestone[this->plane_axis_0] - offset[this->plane_axis_0];
+    float rt_axis0 = target[this->plane_axis_0] - this->arc_milestone[this->plane_axis_0] - offset[this->plane_axis_0]; // Radius vector from center to target position
     float rt_axis1 = target[this->plane_axis_1] - this->arc_milestone[this->plane_axis_1] - offset[this->plane_axis_1];
     float angular_travel = 0;
-
+    //check for condition where atan2 formula will fail due to everything canceling out exactly
     if((this->arc_milestone[this->plane_axis_0]==target[this->plane_axis_0]) && (this->arc_milestone[this->plane_axis_1]==target[this->plane_axis_1])) {
-        if (is_clockwise) {
+        if (is_clockwise) { // set angular_travel to -2pi for a clockwise full circle
            angular_travel = (-2 * PI);
-        } else {
+        } else { // set angular_travel to 2pi for a counterclockwise full circle
            angular_travel = (2 * PI);
         }
     } else {
         // Patch from GRBL Firmware - Christoph Baumann 04072015
         // CCW angle between position and target from circle center. Only one atan2() trig computation required.
-        // Only run if not a full circle
+        // Only run if not a full circle or angular travel will incorrectly result in 0.0f
         angular_travel = atan2f(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
         if (plane_axis_2 == Y_AXIS) { is_clockwise = !is_clockwise; }  //Math for XZ plane is reverse of other 2 planes
-        if (is_clockwise) { // Correct atan2 output per direction
+        if (is_clockwise) { // adjust angular_travel to be in the range of -2pi to 0 for clockwise arcs
            if (angular_travel > 0) { angular_travel -= (2 * PI); }
-        } else {
+        } else {  // adjust angular_travel to be in the range of 0 to 2pi for counterclockwise arcs
            if (angular_travel < 0) { angular_travel += (2 * PI); }
         }
     }
-    
+
     // Find the distance for this gcode
     float millimeters_of_travel = hypotf(angular_travel * radius, fabsf(linear_travel));
 


### PR DESCRIPTION
This is another attempt to address the issues in #1291 

It uses arc_milestone to track the positions given in gcodes to calculate arcs, this prevents error due to tiny movements that do not cause motion.  It also incorporates the pervious changes made by PR #1293, as I have not found an alternative method as efficient as this code to handle the other issues... I keep ending up with less efficient code that ends up with the same limitations.

This method will makes a distinction between full circles because they are precisely defined that way in Gcode accurate to floating point precision, and false full circles that are really microscopic arc segments that are further than float precision away, but less than machine resolution away.  It is important that the gcode file is generated with enough precision to be clear whether it is a tiny arc segment or a full circle as in this example:

Exporting 4 decimal places gives us this:
G1 X406.1208 Y172.6107
G2 X406.1210 Y172.6111 I49.9647 J-17.0159
because the G1 point is not exactly the same as the G2 defined end point, this is a very small arc segment.

if we only export 3 decimal places we would have:
G1 X406.121 Y172.611
G2 X406.121 Y172.611 I49.965 J-17.016
this is a full circle by definition because both start and end are identical, there is no possible way to distinguish this.

There is still a possibility that points smaller than floating point precision could be considered a full circle, because we have floating point variables.  Users should be careful with simulators, as many of them use doubles.  If there is an option in the simulator for precision to use, single floating point accuracy should be used for 100% compatibility.   I do not expect an issue due to this, because floating point accuracy can distinguish between 1000 and 1000.0001 and if you are generating arc segments smaller than 0.0001mm then you need to learn to clean up your CAD drawing before generating Gcodes... even if smoothie could process files with that small of an arc segment, it would run very poorly as it would be throttled by the sheer massive amount of coordinates being shoved into it.

One additional change was made in the calculation of  rt_axis0 and rt_axis1.  It is a minor change that improves accuracy of these values and catches some extreme edge cases operating a near float resolution.  The formula has not changed, but it is simply done all in one operation now
`float rt_axis0 = target[this->plane_axis_0] - this->arc_milestone[this->plane_axis_0] - offset[this->plane_axis_0];`
this does the calculation and stores the result with float precision
the original code calculated the center first, stored it as a float, then used the center to find  rt_axis0.  this resulted in a possible compound float resolution issue and had the possibility of resulting in a float other than expected.  The current formula seems to always produce the expected result, because it is only stored as a float once.  This very small change was necessary to correctly process a few extreme edge cases, and will not affect anything else.