### PR TITLE
save some memory in endstops

### DIFF
--- a/src/modules/communication/SerialConsole.cpp
+++ b/src/modules/communication/SerialConsole.cpp
@@ -67,6 +67,11 @@ void SerialConsole::on_idle(void * argument)
     if(halt_flag) {
         halt_flag= false;
         THEKERNEL->call_event(ON_HALT, nullptr);
+        if(THEKERNEL->is_grbl_mode()) {
+            puts("ALARM: Abort during cycle\r\n");
+        } else {
+            puts("HALTED, M999 or $X to exit HALT state\r\n");
+        }
     }
 }
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -202,6 +202,9 @@ bool Endstops::load_old_config()
     // if no pins defined then disable the module
     if(endstops.empty()) return false;
 
+    homing_axis.shrink_to_fit();
+    endstops.shrink_to_fit();
+
     get_global_configs();
 
     if(limit_enabled) {
@@ -361,6 +364,10 @@ bool Endstops::load_config()
             homing_axis.push_back(temp_axis_array[i]);
         }
     }
+
+    // saves some memory
+    homing_axis.shrink_to_fit();
+    endstops.shrink_to_fit();
 
     // sets some endstop global configs applicable to all endstops
     get_global_configs();


### PR DESCRIPTION
only saves about 30 bytes, but still.