### PR TITLE
Suppresses sending GCode comments to printer with smoothie-stream.

### DIFF
--- a/smoothie-stream.py
+++ b/smoothie-stream.py
@@ -26,6 +26,8 @@ parser.add_argument('-q','--quiet',action='store_true', default=False,
         help='suppress output text')
 parser.add_argument('-l','--log',action='store_true', default=False,
         help='suppress output text and output to file (gcode file with .log appended)')
+parser.add_argument('-c','--comment',action='store_true', default=False,
+        help='Send gcode comments to printer (text after ;)')
 args = parser.parse_args()
 
 f = args.gcode_file
@@ -47,19 +49,16 @@ tn.read_until("Smoothie command shell")
 okcnt= 0
 linecnt= 0
 for line in f:
-    tn.write(line)
-    linecnt+=1
-    rep= tn.read_eager()
-    okcnt += rep.count("ok")
-    if verbose: print("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt))
-    if args.log: outlog.write("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt) + "\n" )
-print("Waiting for complete...")
-
-while okcnt < linecnt:
-    rep= tn.read_some()
-    okcnt += rep.count("ok")
-    if verbose: print(str(linecnt) + " - " + str(okcnt) )
-    if args.log: outlog.write(str(linecnt) + " - " + str(okcnt) + "\n" )
+    if not args.comment:
+        line = re.sub("[ ]*;.*", '', line) # remove everything after ;
+        line = line.strip() #send only the bare necessity.
+    if len(line) > 0:
+        tn.write(line)
+        linecnt+=1
+        rep= tn.read_eager()
+        okcnt += rep.count("ok")
+        if verbose: print("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt))
+        if args.log: outlog.write("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt) + "\n" )
 
 
 if args.log: outlog.close()

--- a/smoothie-stream.py
+++ b/smoothie-stream.py
@@ -59,6 +59,13 @@ for line in f:
         okcnt += rep.count("ok")
         if verbose: print("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt))
         if args.log: outlog.write("SND " + str(linecnt) + ": " + line.strip() + " - " + str(okcnt) + "\n" )
+print("Waiting for complete...")
+
+while okcnt < linecnt:
+    rep= tn.read_some()
+    okcnt += rep.count("ok")
+    if verbose: print(str(linecnt) + " - " + str(okcnt) )
+    if args.log: outlog.write(str(linecnt) + " - " + str(okcnt) + "\n" )
 
 
 if args.log: outlog.close()


### PR DESCRIPTION
I tend to leave the verbose option in my gcode comments, and smoothie-stream will by default send all of that extra data (that the smoothieboard has to also read in before it can process).

Since it tends to be longer than the commands themselves, a lot of I/O time can be saved by stripping them out of the data to be sent to Smoothie. It also avoids a lot of wasted no-op lines being sent to the board if the slicer dumps things like configurations in its output gcode (as comments). 

I've added an option to control this behavior via a command-line switch. If it's desired to maintain the original behavior and make the switch suppress sending comments, then I would be happy to do that.