### PR TITLE
Update sample configs for proper debounce entry

### DIFF
--- a/ConfigSamples/AzteegX5Mini.delta/Version2/config
+++ b/ConfigSamples/AzteegX5Mini.delta/Version2/config
@@ -201,7 +201,7 @@ gamma_trim                                   0                 # software trim f
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/AzteegX5Mini.delta/Version3/config
+++ b/ConfigSamples/AzteegX5Mini.delta/Version3/config
@@ -206,7 +206,7 @@ gamma_trim                                   0                 # software trim f
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/AzteegX5Mini.delta/config
+++ b/ConfigSamples/AzteegX5Mini.delta/config
@@ -201,7 +201,7 @@ gamma_trim                                   0                 # software trim f
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/AzteegX5Mini/Version2/config
+++ b/ConfigSamples/AzteegX5Mini/Version2/config
@@ -198,7 +198,7 @@ gamma_homing_retract_mm                      1                # "
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate mm/sec
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/AzteegX5Mini/Version3/config
+++ b/ConfigSamples/AzteegX5Mini/Version3/config
@@ -188,7 +188,7 @@ gamma_homing_retract_mm                      1                # "
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate mm/sec
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/AzteegX5Mini/config
+++ b/ConfigSamples/AzteegX5Mini/config
@@ -194,7 +194,7 @@ gamma_homing_retract_mm                      1                # "
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.29!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate mm/sec
 zprobe.probe_height                          5               # how much above bed to start probe
 

--- a/ConfigSamples/Smoothieboard.delta/config
+++ b/ConfigSamples/Smoothieboard.delta/config
@@ -255,7 +255,7 @@ gamma_trim                                    0                # Software trim f
 zprobe.enable                                false           # Set to true to enable a zprobe
 zprobe.probe_pin                             1.28!^          # Pin probe is attached to, if NC remove the !
 zprobe.slow_feedrate                         5               # Mm/sec probe feed rate
-#zprobe.debounce_count                       100             # Set if noisy
+#zprobe.debounce_ms                          1               # Set if noisy
 zprobe.fast_feedrate                         100             # Move feedrate mm/sec
 zprobe.probe_height                          5               # How much above bed to start probe
 #gamma_min_endstop                           nc              # Normally 1.28. Change to nc to prevent conflict,

--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -260,7 +260,7 @@ gamma_homing_retract_mm                      1                # Distance to retr
 zprobe.enable                                false           # Set to true to enable a zprobe
 zprobe.probe_pin                             1.28!^          # Pin probe is attached to, if NC remove the !
 zprobe.slow_feedrate                         5               # Mm/sec probe feed rate
-#zprobe.debounce_count                       100             # Set if noisy
+#zprobe.debounce_ms                          1               # Set if noisy
 zprobe.fast_feedrate                         100             # Move feedrate mm/sec
 zprobe.probe_height                          5               # How much above bed to start probe
 #gamma_min_endstop                           nc              # Normally 1.28. Change to nc to prevent conflict,

--- a/ConfigSamples/rotary.delta/config
+++ b/ConfigSamples/rotary.delta/config
@@ -281,7 +281,7 @@ gamma_trim                                   0                 # software trim f
 zprobe.enable                                false           # set to true to enable a zprobe
 zprobe.probe_pin                             1.28!^          # pin probe is attached to if NC remove the !
 zprobe.slow_feedrate                         5               # mm/sec probe feed rate
-#zprobe.debounce_count                       100             # set if noisy
+#zprobe.debounce_ms                          1               # set if noisy
 zprobe.fast_feedrate                         100             # move feedrate mm/sec
 zprobe.probe_height                          5               # how much above bed to start probe
 #gamma_min_endstop                           nc              # normally 1.28. Change to nc to prevent conflict,


### PR DESCRIPTION
While the Endstop module supports both `debounce_count` and
`debounce_ms`, the ZProbe module supports only `debounce_count`.

https://github.com/Smoothieware/Smoothieware/blob/edge/src/modules/tools/endstops/Endstops.cpp

https://github.com/Smoothieware/Smoothieware/blob/edge/src/modules/tools/zprobe/ZProbe.cpp

This commit updates all of the sample config files that included
`zprobe.debounce_count` to use `zprobe.debounce_ms` instead.