### PR TITLE
Add G38.4 & G38.5

### DIFF
--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -73,6 +73,7 @@ void ZProbe::on_module_loaded()
 
     // we read the probe in this timer
     probing= false;
+    invert_probe= false;
     THEKERNEL->slow_ticker->attach(1000, this, &ZProbe::read_probe);
 }
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -370,6 +370,8 @@ void ZProbe::on_gcode_received(void *argument)
 
         probe_XYZ(gcode, x, y, z);
 
+        invert_probe = false;
+
         return;
 
     } else if(gcode->has_m) {

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -370,14 +370,12 @@ void ZProbe::on_gcode_received(void *argument)
         }
 
         if(gcode->subcode == 4 || gcode->subcode == 5) {
-            gcode->stream->printf("Inverting pin\n");
             pin.set_inverting(pin.is_inverting() != 1);
         }
 
         probe_XYZ(gcode, x, y, z);
 
         if(gcode->subcode == 4 || gcode->subcode == 5) {
-            gcode->stream->printf("Inverting pin back\n");
             pin.set_inverting(pin.is_inverting() != 1);
         }
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -255,7 +255,8 @@ void ZProbe::on_gcode_received(void *argument)
     Gcode *gcode = static_cast<Gcode *>(argument);
 
     if( gcode->has_g && gcode->g >= 29 && gcode->g <= 32) {
-
+        
+        invert_probe = false;
         // make sure the probe is defined and not already triggered before moving motors
         if(!this->pin.connected()) {
             gcode->stream->printf("ZProbe pin not configured.\n");

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -326,6 +326,7 @@ void ZProbe::on_gcode_received(void *argument)
 
     } else if(gcode->has_g && gcode->g == 38 ) { // G38.2 Straight Probe with error, G38.3 straight probe without error
         // linuxcnc/grbl style probe http://www.linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe
+        invert_probe = false;
         if(gcode->subcode < 2 || gcode->subcode > 5) {
             gcode->stream->printf("error:Only G38.2 to G38.5 are supported\n");
             return;
@@ -368,10 +369,6 @@ void ZProbe::on_gcode_received(void *argument)
         }
 
         probe_XYZ(gcode, x, y, z);
-
-        if(gcode->subcode == 4 || gcode->subcode == 5) {
-            invert_probe = false;
-        }
 
         return;
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -326,7 +326,6 @@ void ZProbe::on_gcode_received(void *argument)
 
     } else if(gcode->has_g && gcode->g == 38 ) { // G38.2 Straight Probe with error, G38.3 straight probe without error
         // linuxcnc/grbl style probe http://www.linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe
-        invert_probe = false;
         if(gcode->subcode < 2 || gcode->subcode > 5) {
             gcode->stream->printf("error:Only G38.2 to G38.5 are supported\n");
             return;
@@ -366,6 +365,8 @@ void ZProbe::on_gcode_received(void *argument)
 
         if(gcode->subcode == 4 || gcode->subcode == 5) {
             invert_probe = true;
+        } else {
+            invert_probe = false;
         }
 
         probe_XYZ(gcode, x, y, z);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -336,7 +336,7 @@ void ZProbe::on_gcode_received(void *argument)
             return;
         }
 
-        if (((gcode->subcode == 4 || gcode->subcode == 5) && (!this->pin.get())) || ((gcode->subcode == 2 || gcode->subcode == 3) && (this->pin.get()))){
+        if(this->pin.get() ^ (gcode->subcode >= 4)) {
             gcode->stream->printf("error:ZProbe triggered before move, aborting command.\n");
             return;
         }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -365,9 +365,8 @@ void ZProbe::on_gcode_received(void *argument)
 
         if(gcode->subcode == 4 || gcode->subcode == 5) {
             invert_probe = true;
-        } else {
-            invert_probe = false;   // not sure this is needed since it is always reset to 0 below
         }
+
         probe_XYZ(gcode, x, y, z);
 
         if(gcode->subcode == 4 || gcode->subcode == 5) {

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -67,6 +67,7 @@ private:
         bool probing:1;
         bool reverse_z:1;
         bool invert_override:1;
+        bool invert_probe:1;
         volatile bool probe_detected:1;
     };
 };

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -26,7 +26,7 @@ class ZProbe: public Module
 {
 
 public:
-    ZProbe() : invert_override(false) {};
+    ZProbe() : invert_override(false),invert_probe(false) {};
     virtual ~ZProbe() {};
 
     void on_module_loaded();


### PR DESCRIPTION
This is to implement G38.4 and G38.5 as defined at [http://www.linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe]

G38.4 and G38.5 are very useful for several probing operations.  

Many autoprobe schemes require that you probe again in a new direction from the probe recorded position, however you can't probe in any direction while the probe is engaged.  G38.4 & G38.5 solve this issue by backing away just enough to not be touching anymore, therefore a probe in the new direction can happen with a minimum of movement away from the part.  This is critical when probing shapes with tight inside angles where any excess backoff move could hit the opposite side of the angle

Also if you are probing at a fairly high speed, you will always over travel slightly due to debounce settings.  G38.4/G38.5 allows you do read the probe as you back away from the part very slowly until loss of probe contact, this is significantly faster than backing away a fixed distance and re-probing slowly and double probing every point, and then still needing to back away again so you can probe again.

Instead of:
`G91
G38.3X1F10
G0X-0.05
G38.3X0.1F1
G0X-0.05`

One could run:
`G38.3X1F10
G38.5X-0.1F1`
and record the points at which the probe looses contact with the part.   Notice now the probe is released so we can probe again without doing any relative movements.

These are just a few reasons why there is such a thing as G38.4 and G38.5, and I think smoothie would benefit by their inclusion.