### PR TITLE
Improve axis definitions to allow dual-motor axes

### DIFF
--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -10,6 +10,8 @@
 #include "Module.h"
 #include "Pin.h"
 
+#define AXIS_EXTRUDER 255
+
 class StepperMotor  : public Module {
     public:
         StepperMotor(Pin& step, Pin& dir, Pin& en);
@@ -53,6 +55,8 @@ class StepperMotor  : public Module {
         void set_selected(bool b) { selected= b; }
         bool is_extruder() const { return extruder; }
         void set_extruder(bool b) { extruder= b; }
+        uint8_t get_axis(void) { return axis; }
+        void set_axis(uint8_t a) { axis = a; }
 
         int32_t steps_to_target(float);
 
@@ -73,6 +77,7 @@ class StepperMotor  : public Module {
         volatile int32_t current_position_steps;
         int32_t last_milestone_steps;
         float   last_milestone_mm;
+        uint8_t axis;       // which axis this motor belongs to or 255 if extruder
 
         volatile struct {
             uint8_t motor_id:8;

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -61,6 +61,7 @@ class Robot : public Module {
         bool delta_move(const float delta[], float rate_mm_s, uint8_t naxis);
         uint8_t register_motor(StepperMotor*);
         uint8_t get_number_registered_motors() const {return n_motors; }
+        StepperMotor* get_motor_for_axis(uint8_t axis_index);   // find a motor for this axis
 
         BaseSolution* arm_solution;                           // Selected Arm solution ( millimeters to step calculation )
 

--- a/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
@@ -1,0 +1,102 @@
+#include "MappableCartesianSolution.h"
+#include "ActuatorCoordinates.h"
+#include "checksumm.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+
+
+// see the header for module documentatation
+// Example:
+//
+// # Arm solution configuration : MappableCartesian robot. Translates mm positions into stepper positions
+// # set up for dual Y using the B motor (X=0, Y=1, Z=2, A=3, B=4, C=5)
+// arm_solution                                 mappable_cartesian
+// axis_slave_y                                  4
+
+#define NO_STEPPER 255
+
+#define axis_map_x_checksum    CHECKSUM("axis_map_x")
+#define axis_map_y_checksum    CHECKSUM("axis_map_y")
+#define axis_map_z_checksum    CHECKSUM("axis_map_z")
+#define axis_slave_x_checksum    CHECKSUM("axis_slave_x")
+#define axis_slave_y_checksum    CHECKSUM("axis_slave_y")
+#define axis_slave_z_checksum    CHECKSUM("axis_slave_z")
+
+// set up default configuration for mapper
+void MappableCartesianSolution::map_default_axes()
+{
+    THEKERNEL->streams->printf("Map default coords\r\n");
+    // the default mapping of X->alpha, Y->beta, etc.
+    axis_map[X_AXIS] = ALPHA_STEPPER;
+    axis_map[Y_AXIS] = BETA_STEPPER;
+    axis_map[Z_AXIS] = GAMMA_STEPPER;
+    axis_dual_map[X_AXIS] = NO_STEPPER;
+    axis_dual_map[Y_AXIS] = NO_STEPPER;
+    axis_dual_map[Z_AXIS] = NO_STEPPER;
+}
+
+MappableCartesianSolution::MappableCartesianSolution()
+{
+    THEKERNEL->streams->printf("Mappable cartesian default build");
+    map_default_axes();
+}
+
+MappableCartesianSolution::MappableCartesianSolution(Config* config)
+{
+    THEKERNEL->streams->printf("Mappable cartesian config build");
+    map_default_axes();
+    // read optional overrides
+    axis_map[X_AXIS] = config->value(axis_map_x_checksum)->by_default(axis_map[X_AXIS])->as_int();
+    axis_map[Y_AXIS] = config->value(axis_map_y_checksum)->by_default(axis_map[Y_AXIS])->as_int();
+    axis_map[Z_AXIS] = config->value(axis_map_z_checksum)->by_default(axis_map[Z_AXIS])->as_int();
+    axis_dual_map[X_AXIS] = config->value(axis_slave_x_checksum)->by_default(axis_dual_map[X_AXIS])->as_int();
+    axis_dual_map[Y_AXIS] = config->value(axis_slave_y_checksum)->by_default(axis_dual_map[Y_AXIS])->as_int();
+    axis_dual_map[Z_AXIS] = config->value(axis_slave_z_checksum)->by_default(axis_dual_map[Z_AXIS])->as_int();
+    // display the remapping on theconsole
+    if(THEKERNEL->streams != NULL)
+    {
+        std::string axs[3];
+        for(int i=0; i<3; i++)
+        {
+            if(axis_dual_map[i] == NO_STEPPER)
+                axs[i] = std::to_string(axis_map[i]);
+            else
+            {
+                axs[i] = std::to_string(axis_map[i]) + "&" + std::to_string(axis_dual_map[i]);
+            }
+        }
+        THEKERNEL->streams->printf("Actuator mapping-> X=%s, Y=%s, Z=%s\r\n", axs[0].c_str(), axs[1].c_str(), axs[2].c_str());
+        THEKERNEL->streams->printf("Maximum actuators = %d\r\n", (int)k_max_actuators);
+    }
+
+}
+
+void MappableCartesianSolution::cartesian_to_actuator(const float cartesian_mm[], ActuatorCoordinates &actuator_mm ) const
+{
+    THEKERNEL->streams->printf("Start coords %f %f %f %f %f\r\n", actuator_mm[0], actuator_mm[1], actuator_mm[2], actuator_mm[3], actuator_mm[4]);
+    actuator_mm[axis_map[X_AXIS]] = cartesian_mm[X_AXIS];
+    actuator_mm[axis_map[Y_AXIS]] = cartesian_mm[Y_AXIS];
+    actuator_mm[axis_map[Z_AXIS]] = cartesian_mm[Z_AXIS];
+    if(axis_dual_map[X_AXIS] != NO_STEPPER)
+    {
+        actuator_mm[axis_dual_map[X_AXIS]] = cartesian_mm[X_AXIS];
+    }
+    if(axis_dual_map[Y_AXIS] != NO_STEPPER)
+    {
+        actuator_mm[axis_dual_map[Y_AXIS]] = cartesian_mm[Y_AXIS];
+    }
+    if(axis_dual_map[Z_AXIS] != NO_STEPPER)
+    {
+        actuator_mm[axis_dual_map[Z_AXIS]] = cartesian_mm[Z_AXIS];
+    }
+    THEKERNEL->streams->printf("End coords %f %f %f %f %f\r\n", actuator_mm[0], actuator_mm[1], actuator_mm[2], actuator_mm[3], actuator_mm[4]);
+}
+
+void MappableCartesianSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ) const
+{
+    cartesian_mm[axis_map[X_AXIS]] = actuator_mm[X_AXIS];
+    cartesian_mm[axis_map[Y_AXIS]] = actuator_mm[Y_AXIS];
+    cartesian_mm[axis_map[Z_AXIS]] = actuator_mm[Z_AXIS];
+}
+
+

--- a/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
@@ -94,7 +94,7 @@ void MappableCartesianSolution::cartesian_to_actuator(const float cartesian_mm[]
 
 void MappableCartesianSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ) const
 {
-    cartesian_mm[X_AXIS]] = actuator_mm[axis_map[X_AXIS];
+    cartesian_mm[X_AXIS] = actuator_mm[axis_map[X_AXIS]];
     cartesian_mm[Y_AXIS] = actuator_mm[axis_map[Y_AXIS]];
     cartesian_mm[Z_AXIS] = actuator_mm[axis_map[Z_AXIS]];
 }

--- a/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
+++ b/src/modules/robot/arm_solutions/MappableCartesianSolution.cpp
@@ -94,9 +94,9 @@ void MappableCartesianSolution::cartesian_to_actuator(const float cartesian_mm[]
 
 void MappableCartesianSolution::actuator_to_cartesian(const ActuatorCoordinates &actuator_mm, float cartesian_mm[] ) const
 {
-    cartesian_mm[axis_map[X_AXIS]] = actuator_mm[X_AXIS];
-    cartesian_mm[axis_map[Y_AXIS]] = actuator_mm[Y_AXIS];
-    cartesian_mm[axis_map[Z_AXIS]] = actuator_mm[Z_AXIS];
+    cartesian_mm[X_AXIS]] = actuator_mm[axis_map[X_AXIS];
+    cartesian_mm[Y_AXIS] = actuator_mm[axis_map[Y_AXIS]];
+    cartesian_mm[Z_AXIS] = actuator_mm[axis_map[Z_AXIS]];
 }
 
 

--- a/src/modules/robot/arm_solutions/MappableCartesianSolution.h
+++ b/src/modules/robot/arm_solutions/MappableCartesianSolution.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "libs/Module.h"
+#include "libs/Kernel.h"
+#include "BaseSolution.h"
+#include "libs/nuts_bolts.h"
+#include "libs/Config.h"
+
+
+// This supports standard X,Y,Z cartesian coordinates but allows
+// Each axis to map to any desired actuator (whoopee) and 
+// More importantly allows for slave motors so you can run dual X and dual Y axes
+// The slave is sent commands that should be in synch with the master
+// So for microstepping the slave physical motor and driver should be the same as the master I think
+// Position is read from the master
+// use axis_map_x and axis_slave_x for the two motors. 
+// Default slave is none. Default master is X=0,Y=1,Z=2.
+// In keeping with the board labels, the argument is X, Y, Z, A, B, C
+
+class MappableCartesianSolution : public BaseSolution {
+    public:
+        MappableCartesianSolution();
+        MappableCartesianSolution(Config*);
+        void cartesian_to_actuator( const float millimeters[], ActuatorCoordinates &steps ) const override;
+        void actuator_to_cartesian( const ActuatorCoordinates &steps, float millimeters[] ) const override;
+    private:
+        void map_default_axes(void);
+        uint8_t axis_map[3];            // X, Y, Z axes
+        uint8_t axis_dual_map[3];       // possible dual controllers
+};

--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -121,6 +121,7 @@ void Extruder::config_load()
     stepper_motor->change_steps_per_mm(steps_per_millimeter);
     stepper_motor->set_selected(false); // not selected by default
     stepper_motor->set_extruder(true);  // indicates it is an extruder
+    stepper_motor->set_axis(AXIS_EXTRUDER); // this motor isn't associated with an axis
 }
 
 void Extruder::select()


### PR DESCRIPTION
Add an optional axis parameter to each motor to define which axis the motor is on

Also add a MappableCartesianSolution that supports dual-motor axes

Over time this should allow creating an axis<->motor map for supporting extruders and non-cartesian axes and dual motor axes in a natural fashion. This also enables a cleaner axis <-> actuator translation than using cartesian something for X,Y,Z and special casing A,B,C.
