### PR TITLE
Feature/Microsoft Visual Studio Tasks

### DIFF
--- a/.vs/tasks.vs.json
+++ b/.vs/tasks.vs.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.2.1",
+  "outDir": "\"${workspaceRoot}\\LPC1768\"",
+  "tasks": [
+    {
+      "taskName": "makefile-build",
+      "appliesTo": "/makefile",
+      "type": "launch",
+      "contextType": "build",
+      "command": "BuildShell.cmd",
+      "args": [ "make", "all" ],
+      "envVars": {
+        "VSCMD_START_DIR": "\"${workspaceRoot}\""
+      }
+    },
+    {
+      "taskName": "makefile-clean",
+      "appliesTo": "/makefile",
+      "type": "launch",
+      "contextType": "clean",
+      "command": "BuildShell.cmd",
+      "args": [ "make", "clean" ],
+      "envVars": {
+        "VSCMD_START_DIR": "\"${workspaceRoot}\""
+      }
+    },
+    {
+      "taskName": "makefile-rebuild",
+      "appliesTo": "/makefile",
+      "type": "launch",
+      "contextType": "rebuild",
+      "command": "BuildShell.cmd",
+      "args": [ "make", "clean", "all" ],
+      "envVars": {
+        "VSCMD_START_DIR": "\"${workspaceRoot}\""
+      }
+    }
+  ]
+}

--- a/win_install.cmd
+++ b/win_install.cmd
@@ -67,7 +67,8 @@ echo REM Uncomment next line and set destination drive to match mbed device>>%BU
 echo REM SET LPC_DEPLOY=copy PROJECT.bin f:\>>%BUILDENV_CMD%
 echo.>>%BUILDENV_CMD%
 echo SET PATH=%%~dp0;%%~dp0..\..\build\win32;%%PATH%%>>%BUILDENV_CMD%
-echo REM execute given commands if any >>%BUILDENV_CMD%
+echo.>>%BUILDENV_CMD%
+echo REM execute given command if any >>%BUILDENV_CMD%
 echo %%*>>%BUILDENV_CMD%
 rem
 echo @cmd.exe /K %%~dp0\gcc-arm-none-eabi\bin\buildenv.cmd %%*>%BUILDSHELL_CMD%

--- a/win_install.cmd
+++ b/win_install.cmd
@@ -67,8 +67,10 @@ echo REM Uncomment next line and set destination drive to match mbed device>>%BU
 echo REM SET LPC_DEPLOY=copy PROJECT.bin f:\>>%BUILDENV_CMD%
 echo.>>%BUILDENV_CMD%
 echo SET PATH=%%~dp0;%%~dp0..\..\build\win32;%%PATH%%>>%BUILDENV_CMD%
+echo REM execute given commands if any >>%BUILDENV_CMD%
+echo %%*>>%BUILDENV_CMD%
 rem
-echo @cmd.exe /K %%~dp0\gcc-arm-none-eabi\bin\buildenv.cmd>%BUILDSHELL_CMD%
+echo @cmd.exe /K %%~dp0\gcc-arm-none-eabi\bin\buildenv.cmd %%*>%BUILDSHELL_CMD%
 
 rem Place GNU Tool for ARM Embedded Processors in the path before building gcc4mbed code.
 set path=%GCC4ARM_BINDIR%;%ROOTDIR%build\win32;%PATH%


### PR DESCRIPTION
# Microsoft Visual Studio Build Tasks

Adds simple Build tasks to Microsoft Visual Studio "Open Folder" development. This is the new cool way to edit almost any type of cross platform project:

> In Visual Studio 2017, you can open code from nearly any type of directory-based project into Visual Studio without the need for a solution or project file. This means you can, for example, clone a repo on GitHub, open it directly into Visual Studio, and begin developing, without having to create a solution or project. If needed, you can specify custom build tasks and launch parameters through simple JSON files.
> 
> After you open your code files in Visual Studio, Solution Explorer displays all the files in the folder. You can click on any file to begin editing it. In the background, Visual Studio starts indexing the files to enable IntelliSense, navigation, and refactoring features. As you edit, create, move, or delete files, Visual Studio tracks the changes automatically and continuously updates its IntelliSense index. Code will appear with syntax colorization and, in many cases, include basic IntelliSense statement completion.

https://docs.microsoft.com/en-us/visualstudio/ide/develop-code-in-visual-studio-without-projects-or-solutions

You can simply open the Smoothieware project using `File` / `Open Folder...` and choose the Smoothieware folder. You'll get all the nice stuff described above. 

This pull request adds simple `Build`, `Rebuild`, `Clean ` tasks as described here.

https://docs.microsoft.com/en-us/visualstudio/ide/customize-build-and-debug-tasks-in-visual-studio

You can then right-click on the `makefile` in the Smoothieware root folder and choose one of the tasks in the context menu (see Screenshot):
![grafik](https://user-images.githubusercontent.com/9963310/39528722-29c4a316-4e25-11e8-9740-4cc1bff48e57.png)

**NOTE**: In order for this to work, you need to re-install the build tools using `win_install.cmd` and this will only succeed if you delete your existing `gcc-arm-none-eabi` folder first, otherwise `win_install.cmd` will fail trying to recreate that directory.

 ### Why is re-installing needed?

I needed to modify `win_install.cmd` to slightly change the generated `BuildCommand.cmd` and `buildenv.cmd` to propagate and execute a command line passed as arguments. This way Visual Studio can send the build commands into the proper build environment. I have tried recreating the environment directly in the task, but failed. But calling the **central** `BuildShell.cmd` may be more future proof anyway. 

**NOTE 2**: as per Visual Studio's [standard](https://docs.microsoft.com/en-us/visualstudio/ide/customize-build-and-debug-tasks-in-visual-studio), `tasks.vs.json` is in the `.vs` subdirectory so it might be hidden from some directory views. 

In Visual Studio use the Show all Files Button to see it:
![grafik](https://user-images.githubusercontent.com/9963310/39529204-67b9af6c-4e26-11e8-871a-f2605a7d4d40.png)
