### PR TITLE
Fix/Problems with mixed primary+secondary axis moves

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1381,11 +1381,12 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         // as all limits are relative to the feedrate along the euclidean distance, the limits applicable to a single actuator 
         // can be multiplied by the distance travelled per actuator motion 
         float limit_factor = distance / d;
-        // NOTE that for arm_solutions other than cartesian and for secondary axes in mixed motion, the 
+        // NOTE: many times d is a part of the (XYZ) vector making up the euclidean distance, so it follows that
+        // d <= distance and limit_factor >= 1.  
+        // But for arm_solutions other than cartesian and for secondary axes (ABC) in mixed motion, the 
         // delta (d) may be larger than the euclidean distance, so the limit_factor can be smaller
-        // than 1 meaning that the actuator rate and acceleration limits apply more stringently to the 
-        // euclidean motion than to the actuator itself.
-        
+        // than 1 meaning that the actuator rate and acceleration limits apply more stringently. 
+
         // adjust rate to lowest found
         float actuator_rate = limit_factor * actuators[actuator]->get_max_rate();
         if (rate_mm_s > actuator_rate) {

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1241,32 +1241,33 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     //    elapsed time from the start to the end of the motion is T plus any time required for
     //    acceleration or deceleration.
 
-    // Rule C covers rule B so only two cases have to be distinguished. B/C rule moves are called "auxilliary". 
+    // Rule C is equivalent to rule B so only two cases have to be distinguished. Rule B/C moves are called "auxilliary". 
     // Note that for mixed moves under rule A the secondary axes ABC are allowed to move as fast as they can 
-    // (up to the config limit). This is relevant when deltas on ABC are numerically much larger than those 
+    // (up to the actuator limits). This is relevant when the motion on ABC is numerically much larger than the one 
     // on XYZ. This is often the case with rotation angles in degrees vs. small mm dimensions. Feedrates in 
-    // millimeters per minute should not be applied to rotations in degrees. With other applications (i.e. 
+    // millimeters per minute should not be mixed with rotation speeds in degrees per minute. With other applications (i.e. 
     // extruders), the same may be true. 
     
     // see if this is a primary axis move or not
     bool auxilliary_move = !primary_move;
     
-    // total movement, use XYZ if a primary axis otherwise we calculate distance for ABC after 
-    // scaling to mm for extruders
+    // total movement, use XYZ if a primary axis otherwise we calculate distance for ABC after scaling to mm for extruders
     float distance = auxilliary_move ? 0 : sqrtf(sos);
-    bool limit_by_given_feedrate = true;
+    bool override_feedrate = false;
+    bool override_acceleration = false;
 
     // it is unlikely but we need to protect against divide by zero, so ignore insanely small moves here
     if (!auxilliary_move && distance < 0.00001F) {
         // we're skipping the primary actuators but there might still be secondary motion
         if (secondary_move) {
-            // with effetive (but not really) zero primary motion, we handle this as an auxiliary move
+            // with near zero primary motion, we handle this as an auxiliary move
             auxilliary_move = true;
-            // NOTE: the NIST RS274NGC section 2.1.2.5 rule A still applies, so we must not apply the feedrate 
+            // NOTE: the NIST RS274NGC section 2.1.2.5 rule A still applies, so we must NOT apply the feedrate 
             // to the secondary axes (i.e. not interprete millimeters/min as degrees/min). This is important as otherwise there 
-            // might be a glitch (sudden dip) in effective feedrate for one tiny segment, causing the 
-            // planner to painfully slow down moves before and after.
-            limit_by_given_feedrate = false;
+            // might be a glitch (a sudden dip) in effective feedrate for one tiny segment, causing the planner to painfully 
+            // slow down moves before and after.
+            override_feedrate = true;
+            override_acceleration = true;
         }
         else {
             // as the last milestone won't be updated we do not actually lose any moves as they will be accounted for in the next move
@@ -1306,26 +1307,23 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         }
     }
     else {
-        // this is an auxiliary move, so we just copy the last XYZ actuator positions 
-        // -> no need to do a new coordinate transformation.
-        // NOTE just keeping the old positions is also needed to correctly support skipped 
-        // near zero distance primary moves (see above).
+        // this is an auxiliary move, so we just copy the last XYZ actuator positions, 
+        // no need to do a new cartesian_to_actuator transformation.
+        // NOTE when we skipped a near zero distance primary axes move (see above) we really must keep the old position.
         for (size_t i = X_AXIS; i <= Z_AXIS; i++) {
             actuator_pos[i] = actuators[i]->get_last_milestone();
         }
     }
 
-    // use default acceleration to start with
-    float acceleration = default_acceleration;
-
 #if MAX_ROBOT_ACTUATORS > 3
     sos= 0;
-    float t_longest = 0;
-    float d_longest = 0;
     // for the secondary axes just copy the position, and possibly scale extruders from mm³ to mm
     for (size_t i = E_AXIS; i < n_motors; i++) {
         if (auxilliary_move && i < N_PRIMARY_AXIS) {
-            // we want no primary axis move (might be skipped near-zero move), just copy the old location
+            // only with N_PRIMARY_AXIS > 3 :
+            // this is an auxiliary move, so we just copy the last primary axis actuator positions, 
+            // no need to do a new get_e_scale_fnc.
+            // NOTE when we skipped a near zero distance primary axes move (see above) we really must keep the old position.
             actuator_pos[i] = actuators[i]->get_last_milestone();
         }
         else { 
@@ -1339,49 +1337,28 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             }
             if(auxilliary_move) {
                 // for secondary axes only moves we need to use the scaled positions to calculate the distance
-                float d = fabsf(actuator_pos[i] - actuators[i]->get_last_milestone());
-                sos += powf(d, 2);
-                if (!limit_by_given_feedrate) {
-                    // we skipped a near zero primary axes move - NIST RS274NGC rule A still applies!
-                    // the feedrate must only be limited by the actuators themselves.
-
-                    // calculate the minimum time needed to determine the longest taking - and 
-                    // therefore governing - axis
-                    float t = d/actuators[i]->get_max_rate();
-                    if (t > t_longest) {
-                        t_longest = t;
-                        d_longest = d;
-                        // also override the acceleration to start with
-                        float ma = actuators[i]->get_acceleration(); // in mm/sec²
-                        if (!isnan(ma)) { 
-                            acceleration = ma;
-                        }
-                    }
-                }
+                sos += powf(actuator_pos[i] - actuators[i]->get_last_milestone(), 2);
             }
         }
     }
     if(auxilliary_move) {
-        if (t_longest == 0) {
-            distance= sqrtf(sos); // distance in mm of the auxilliary move
-        }
-        else {
-            distance= d_longest;
-            rate_mm_s = d_longest/t_longest;
-        }
+        distance= sqrtf(sos); // distance in mm of the auxilliary move
         if(distance < 0.00001F) return false;
     }
 #endif
+
+    // use default acceleration to start with
+    float acceleration = default_acceleration;
 
     // check per-actuator speed and acceleration limits
     for (size_t actuator = 0; actuator < n_motors; actuator++) {
         float d = fabsf(actuator_pos[actuator] - actuators[actuator]->get_last_milestone());
         if(d == 0 || !actuators[actuator]->is_selected()) continue; // no movement for this actuator
 
-        // as all limits are relative to the feedrate along the euclidean distance, the limits applicable to a single actuator 
-        // can be multiplied by the distance travelled per actuator motion 
+        // as all limits are applied relative to the euclidean distance, the limits applicable to a single actuator 
+        // can be multiplied by euclidean distance per actuator motion 
         float limit_factor = distance / d;
-        // NOTE: many times d is a part of the (XYZ) vector making up the euclidean distance, so it follows that
+        // NOTE: many times d is a part of the cartesian (XYZ or ABC) vector making up the euclidean distance, so it follows that
         // d <= distance and limit_factor >= 1.  
         // But for arm_solutions other than cartesian and for secondary axes (ABC) in mixed motion, the 
         // delta (d) may be larger than the euclidean distance, so the limit_factor can be smaller
@@ -1389,19 +1366,22 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
 
         // adjust rate to lowest found
         float actuator_rate = limit_factor * actuators[actuator]->get_max_rate();
-        if (rate_mm_s > actuator_rate) {
+        if (rate_mm_s > actuator_rate || override_feedrate) {
             rate_mm_s = actuator_rate;
+            // the first we find overrides the default; subsequent ones only limit if smaller
+            override_feedrate = false;
         }
 
         // adjust acceleration to lowest found
         // NOTE: we need to do all of them, check if any axis won't limit XYZ.. it does on long moves, but not checking it could exceed the axis acceleration.
         float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
-        if(isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-            ma = default_acceleration;
-        }
-        ma *= limit_factor;
-        if (acceleration > ma) {
-            acceleration = ma;
+        if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
+            ma *= limit_factor;
+            if (acceleration > ma || override_acceleration) {
+                acceleration = ma;
+                // the first we find overrides the default; subsequent ones only limit if smaller
+                override_acceleration = false;
+            }
         }
     }
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1201,7 +1201,8 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     }
 
 
-    bool move= false;
+    bool primary_move= false;
+    bool secondary_move = false;
     float sos= 0; // sum of squares for just primary axis (XYZ usually)
 
     // find distance moved by each axis, use transformed target from the current compensated machine position
@@ -1209,30 +1210,72 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         deltas[i] = transformed_target[i] - compensated_machine_position[i];
         if(deltas[i] == 0) continue;
         // at least one non zero delta
-        move = true;
         if(i < N_PRIMARY_AXIS) {
             sos += powf(deltas[i], 2);
+            primary_move = true;
+        }
+        else {
+            secondary_move = true;
         }
     }
 
     // nothing moved
-    if(!move) return false;
+    if(!(primary_move||secondary_move)) return false;
 
+
+    // NIST RS274NGC Interpreter - Version 3, Section 2.1.2.5 applies feedrates as follows:
+    //
+    // A. For motion involving one or more of the X, Y, and Z axes (with or without simultaneous
+    //    rotational axis motion), the feed rate means length units per minute along the
+    //    programmed XYZ path, as if the rotational axes were not moving.
+    //
+    // B. For motion of one rotational axis with X, Y, and Z axes not moving, the feed rate means
+    //    degrees per minute rotation of the rotational axis.
+    //
+    // C. For motion of two or three rotational axes with X, Y, and Z axes not moving, the rate is
+    //    applied as follows.Let dA, dB, and dC be the angles in degrees through which the A, B,
+    //    and C axes, respectively, must move. Let D = sqrt((dA)^2 + (dB)^2 + (dC)^2). Conceptually, 
+    //    D is a measure of total angular motion, using the usual Euclidean metric. Let T be the 
+    //    amount of time required to move through D degrees at the current feed rate in degrees per
+    //    minute. The rotational axes should be moved in coordinated linear motion so that the
+    //    elapsed time from the start to the end of the motion is T plus any time required for
+    //    acceleration or deceleration.
+
+    // Rule C covers rule B so only two cases have to be distinguished. B/C rule moves are called "auxilliary". 
+    // Note that for mixed moves under rule A the secondary axes ABC are allowed to move as fast as they can 
+    // (up to the config limit). This is relevant when deltas on ABC are numerically much larger than those 
+    // on XYZ. This is often the case with rotation angles in degrees vs. small mm dimensions. Feedrates in 
+    // millimeters per minute should not be applied to rotations in degrees. With other applications (i.e. 
+    // extruders), the same may be true. 
+    
     // see if this is a primary axis move or not
-    bool auxilliary_move= true;
-    for (int i = 0; i < N_PRIMARY_AXIS; ++i) {
-        if(deltas[i] != 0) {
-            auxilliary_move= false;
-            break;
+    bool auxilliary_move = !primary_move;
+    
+    // total movement, use XYZ if a primary axis otherwise we calculate distance for ABC after 
+    // scaling to mm for extruders
+    float distance = auxilliary_move ? 0 : sqrtf(sos);
+    bool limit_by_given_feedrate = true;
+
+    // it is unlikely but we need to protect against divide by zero, so ignore insanely small moves here
+    if (!auxilliary_move && distance < 0.00001F) {
+        // we're skipping the primary actuators but there might still be secondary motion
+        if (secondary_move) {
+            // with effetive (but not really) zero primary motion, we handle this as an auxiliary move
+            auxilliary_move = true;
+            // NOTE: the NIST RS274NGC section 2.1.2.5 rule A still applies, so we must not apply the feedrate 
+            // to the secondary axes (i.e. not interprete millimeters/min as degrees/min). This is important as otherwise there 
+            // might be a glitch (sudden dip) in effective feedrate for one tiny segment, causing the 
+            // planner to painfully slow down moves before and after.
+            limit_by_given_feedrate = false;
+        }
+        else {
+            // as the last milestone won't be updated we do not actually lose any moves as they will be accounted for in the next move
+            return false;
         }
     }
 
-    // total movement, use XYZ if a primary axis otherwise we calculate distance for E after scaling to mm
-    float distance= auxilliary_move ? 0 : sqrtf(sos);
-
-    // it is unlikely but we need to protect against divide by zero, so ignore insanely small moves here
-    // as the last milestone won't be updated we do not actually lose any moves as they will be accounted for in the next move
-    if(!auxilliary_move && distance < 0.00001F) return false;
+    // find actuator position given the machine position, use actual adjusted target
+    ActuatorCoordinates actuator_pos;
 
     if(!auxilliary_move) {
          for (size_t i = X_AXIS; i < N_PRIMARY_AXIS; i++) {
@@ -1247,73 +1290,117 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
                     rate_mm_s *= ( max_speeds[i] / axis_speed );
             }
         }
-
+        
         if(this->max_speed > 0 && rate_mm_s > this->max_speed) {
             rate_mm_s= this->max_speed;
         }
+
+        if(!disable_arm_solution) {
+            arm_solution->cartesian_to_actuator( transformed_target, actuator_pos );
+
+        }else{
+            // basically the same as cartesian, would be used for special homing situations like for scara
+            for (size_t i = X_AXIS; i <= Z_AXIS; i++) {
+                actuator_pos[i] = transformed_target[i];
+            }
+        }
     }
-
-    // find actuator position given the machine position, use actual adjusted target
-    ActuatorCoordinates actuator_pos;
-    if(!disable_arm_solution) {
-        arm_solution->cartesian_to_actuator( transformed_target, actuator_pos );
-
-    }else{
-        // basically the same as cartesian, would be used for special homing situations like for scara
+    else {
+        // this is an auxiliary move, so we just copy the last XYZ actuator positions 
+        // -> no need to do a new coordinate transformation.
+        // NOTE just keeping the old positions is also needed to correctly support skipped 
+        // near zero distance primary moves (see above).
         for (size_t i = X_AXIS; i <= Z_AXIS; i++) {
-            actuator_pos[i] = transformed_target[i];
+            actuator_pos[i] = actuators[i]->get_last_milestone();
         }
     }
-
-#if MAX_ROBOT_ACTUATORS > 3
-    sos= 0;
-    // for the extruders just copy the position, and possibly scale it from mm³ to mm
-    for (size_t i = E_AXIS; i < n_motors; i++) {
-        actuator_pos[i]= transformed_target[i];
-        if(actuators[i]->is_extruder() && get_e_scale_fnc) {
-            // NOTE this relies on the fact only one extruder is active at a time
-            // scale for volumetric or flow rate
-            // TODO is this correct? scaling the absolute target? what if the scale changes?
-            // for volumetric it basically converts mm³ to mm, but what about flow rate?
-            actuator_pos[i] *= get_e_scale_fnc();
-        }
-        if(auxilliary_move) {
-            // for E only moves we need to use the scaled E to calculate the distance
-            sos += powf(actuator_pos[i] - actuators[i]->get_last_milestone(), 2);
-        }
-    }
-    if(auxilliary_move) {
-        distance= sqrtf(sos); // distance in mm of the e move
-        if(distance < 0.00001F) return false;
-    }
-#endif
 
     // use default acceleration to start with
     float acceleration = default_acceleration;
 
-    float isecs = rate_mm_s / distance;
+#if MAX_ROBOT_ACTUATORS > 3
+    sos= 0;
+    float t_longest = 0;
+    float d_longest = 0;
+    // for the secondary axes just copy the position, and possibly scale extruders from mm³ to mm
+    for (size_t i = E_AXIS; i < n_motors; i++) {
+        if (auxilliary_move && i < N_PRIMARY_AXIS) {
+            // we want no primary axis move (might be skipped near-zero move), just copy the old location
+            actuator_pos[i] = actuators[i]->get_last_milestone();
+        }
+        else { 
+            actuator_pos[i]= transformed_target[i];
+            if(actuators[i]->is_extruder() && get_e_scale_fnc) {
+                // NOTE this relies on the fact only one extruder is active at a time
+                // scale for volumetric or flow rate
+                // TODO is this correct? scaling the absolute target? what if the scale changes?
+                // for volumetric it basically converts mm³ to mm, but what about flow rate?
+                actuator_pos[i] *= get_e_scale_fnc();
+            }
+            if(auxilliary_move) {
+                // for secondary axes only moves we need to use the scaled positions to calculate the distance
+                float d = fabsf(actuator_pos[i] - actuators[i]->get_last_milestone());
+                sos += powf(d, 2);
+                if (!limit_by_given_feedrate) {
+                    // we skipped a near zero primary axes move - NIST RS274NGC rule A still applies!
+                    // the feedrate must only be limited by the actuators themselves.
 
-    // check per-actuator speed limits
+                    // calculate the minimum time needed to determine the longest taking - and 
+                    // therefore governing - axis
+                    float t = d/actuators[i]->get_max_rate();
+                    if (t > t_longest) {
+                        t_longest = t;
+                        d_longest = d;
+                        // also override the acceleration to start with
+                        float ma = actuators[i]->get_acceleration(); // in mm/sec²
+                        if (!isnan(ma)) { 
+                            acceleration = ma;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if(auxilliary_move) {
+        if (t_longest == 0) {
+            distance= sqrtf(sos); // distance in mm of the auxilliary move
+        }
+        else {
+            distance= d_longest;
+            rate_mm_s = d_longest/t_longest;
+        }
+        if(distance < 0.00001F) return false;
+    }
+#endif
+
+    // check per-actuator speed and acceleration limits
     for (size_t actuator = 0; actuator < n_motors; actuator++) {
         float d = fabsf(actuator_pos[actuator] - actuators[actuator]->get_last_milestone());
         if(d == 0 || !actuators[actuator]->is_selected()) continue; // no movement for this actuator
 
-        float actuator_rate= d * isecs;
-        if (actuator_rate > actuators[actuator]->get_max_rate()) {
-            rate_mm_s *= (actuators[actuator]->get_max_rate() / actuator_rate);
-            isecs = rate_mm_s / distance;
+        // as all limits are relative to the feedrate along the euclidean distance, the limits applicable to a single actuator 
+        // can be multiplied by the distance travelled per actuator motion 
+        float limit_factor = distance / d;
+        // NOTE that for arm_solutions other than cartesian and for secondary axes in mixed motion, the 
+        // delta (d) may be larger than the euclidean distance, so the limit_factor can be smaller
+        // than 1 meaning that the actuator rate and acceleration limits apply more stringently to the 
+        // euclidean motion than to the actuator itself.
+        
+        // adjust rate to lowest found
+        float actuator_rate = limit_factor * actuators[actuator]->get_max_rate();
+        if (rate_mm_s > actuator_rate) {
+            rate_mm_s = actuator_rate;
         }
 
-        // adjust acceleration to lowest found, for now just primary axis unless it is an auxiliary move
-        // TODO we may need to do all of them, check E won't limit XYZ.. it does on long E moves, but not checking it could exceed the E acceleration.
-        if(auxilliary_move || actuator < N_PRIMARY_AXIS) {
-            float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
-            if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-                float ca = fabsf((d/distance) * acceleration);
-                if (ca > ma) {
-                    acceleration *= ( ma / ca );
-                }
-            }
+        // adjust acceleration to lowest found
+        // NOTE: we need to do all of them, check if any axis won't limit XYZ.. it does on long moves, but not checking it could exceed the axis acceleration.
+        float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
+        if(isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
+            ma = default_acceleration;
+        }
+        ma *= limit_factor;
+        if (acceleration > ma) {
+            acceleration = ma;
         }
     }
 


### PR DESCRIPTION
# Problems with mixed primary+secondary axis moves

## Introduction

When moving both primary axes (usually XYZ) and secondary axes (usually ABC) at the same time, the feedrate is solely to be interpreted along the primary axes [euclidean distance](https://en.wikipedia.org/wiki/Euclidean_distance). The secondary axes' feedrates are only _indirectly_ specified in the sense that the move must be coordinated.

See NIST RS274NGC Interpreter - Version 3, Section 2.1.2.5 rule A:

> A. For motion involving one or more of the X, Y, and Z axes (with or without simultaneous
rotational axis motion), the feed rate means length units per minute along the
programmed XYZ path, as if the rotational axes were not moving.

> B. For motion of one rotational axis with X, Y, and Z axes not moving, the feed rate means
degrees per minute rotation of the rotational axis.

> C. For motion of two or three rotational axes with X, Y, and Z axes not moving, the rate is
applied as follows. Let dA, dB, and dC be the angles in degrees through which the A, B,
and C axes, respectively, must move. Let D = . Conceptually, D is a
measure of total angular motion, using the usual Euclidean metric. Let T be the amount
of time required to move through D degrees at the current feed rate in degrees per
minute. The rotational axes should be moved in coordinated linear motion so that the
elapsed time from the start to the end of the motion is T plus any time required for
acceleration or deceleration.

https://www.nist.gov/publications/nist-rs274ngc-interpreter-version-3

## Applying actuator specific limits

When the primary move is very small  (relatively speaking), the actuators of the secondary axes might reach their speed limit. The overall move is then slowed down. Unfortunately the same is not true for accelerations as is documented by a TODO in the current code. 

> // TODO we may need to do all of them, check E won't limit XYZ.. it does on long E moves, but not checking it could exceed the E acceleration.

See:
https://github.com/Smoothieware/Smoothieware/blob/bb37b309f88646fe803fd463d1596124a25b9b8d/src/modules/robot/Robot.cpp#L1307-L1317

## Scope of the pull request

The pull request resolves the TODO. While doing so, it also fixes a second bug in mixed axis motion, where a secondary move is not executed at all, if the primary move distance is near zero. 

It does so conformant to NIST RS274NGC Section 2.1.2.5. rule A to avoid glitches in the feedrate interpretation. 

The limitation loop is slightly simplified, eliminating unnecessary calculations. 

## Steps to reproduce the acceleration problem

Take a machine with X and A axis. Let A be a rotation axis. 

Practical example (my case): a [Pick and Place machine doing bottom vision part alignment](https://www.youtube.com/watch?v=1niQJZvoYlw). 

Assume the machine is tuned for speed, so acceleration limits are set to the highest reliable value. 

Execute
```
G90 ; relative mode
G1 X0.1 A180 F600; adjust part offset and rotate to PCB orientation
G91 ; absolute mode
```
### Expected outcome

Offset correction and rotation of part by 180°.

### Observed outcome 

Screeching sound (stall of rotation stepper).

### Analysis

The acceleration limit of the A axis is not applied. If the A move is large compared to the move in X, the A speed limit slows down the overall move. X will then move _very_ slowly. This means that the acceleration time for X is also _very_ short. The A axis has no chance to speed up in the same _very_ short time and is stalling.  

This is exactly what the TODO meant.

## Steps to reproduce the swallowed secondary axis move 

Experimentation with the above exposed a second bug. This one can very easily be reproduced on all 4+ axis machines. 

Execute 
```
G91 G1 X0.000009 A180 G90
```

### Expected outcome

Rotation of A by 180°. 

### Observed outcome 

No motion.

### Analysis

The source code reveals that moves are always cancelled when the primary move alone is near zero. The secondary axis move is simply ignored. 

https://github.com/Smoothieware/Smoothieware/blob/bb37b309f88646fe803fd463d1596124a25b9b8d/src/modules/robot/Robot.cpp#L1233-L1235

This G-code example might be considered "exotic" but the same can happen internally i.e. through a `compensationTransform` or through rounding errors after switching absolute/relative mode, switching coordinate systems, homing etc.. 

This is demonstrated by the following, perfectly realistic example: 

```
G1 X100 A0 G91 G1 X-99.9 G90 G1 X0.1 A180 
```

Because 100-99.9 is not exactly 0.1 in the single precision `float` representation, the final G1 leads to a near zero move in X. Again the 180° rotation of the A axis is swallowed.

# Fixing the issues

## Implementing the acceleration limit

The TODO is quickly implemented. Mainly just remove the `if`. However the code can also be simplified to make it more understandable. There is no need to calculate the time inverse `isecs`. Also the `*=` approach is not needed as the old value can be eliminated from both sides of the equation. This may also increase numeric stability, when some d values are (again) near zero. 

## Fixing the swallowed secondary axis move 

When the primary move distance is near-zero, but secondary axis moves are still present, the milestone must still be appended. The solution is to proceed as if this were an auxiliary (secondary only) move. There are two pitfalls to avoid. 

### Pitfall 1: Feedrate interpretation

Feedrates must **still** be handled as if this were a primary move, according to rule A of the NIST RS274NGC Section 2.1.2.5 (see above). Basically this means that feedrates and acceleration are only limited by the actuators, **not** by the given rate_mm_s. Because  secondary axes often are rotation axes the mm/min rate must not suddenly be interpreted as °/min. Otherwise this would typically result in a harsh dip in the feedrate for this line segment, forcing the planner to painfully slow down moves before and after. 

Consider our example:

```
G90 G1 X0.000009 A180 F600 G91
```

If we were to simply apply the feedrate to the rotation, just because X is near zero, it would take 180/600 = 0.3 minutes (!) just to half-rotate the A axis. 

### Pitfall 2: Actuator position update

The primary move is near-zero but not altogether zero. We must avoid performing the near zero move in transformations and actuator position updates (as the current code just relies on the assumption that the deltas are _exactly_ zero). We must also take into account that N_PRIMARY_AXIS might be greater than 3. 

## Tests

The changes have been tested as follows:

- confirmation that the erroneous behaviour has been fixed (see reproduction steps above)
- the changed build performs reliably in test pick and place patterns using OpenPNP, including delicate nozzle tip changer moves
- built with `make PAXIS=4` and confirmed that A axis is now handled as a primary axis 
- all tests formerly performed with axis A now behave the same with axis B 

