### PR TITLE
Allow G92 A0 to change A axis, ditto for B C

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -592,6 +592,17 @@ void Robot::on_gcode_received(void *argument)
                         actuators[selected_extruder]->change_last_milestone(get_e_scale_fnc ? e*get_e_scale_fnc() : e);
                     }
                 }
+                if(gcode->subcode == 0 && gcode->get_num_args() > 0) {
+                    for (int i = A_AXIS; i < n_motors; i++) {
+                        // ABC just need to set machine_position and compensated_machine_position if specified
+                        char axis= 'A'+i-3;
+                        if(!actuators[i]->is_extruder() && gcode->has_letter(axis)) {
+                            float ap= gcode->get_value(axis);
+                            machine_position[i]= compensated_machine_position[i]= ap;
+                            actuators[i]->change_last_milestone(ap); // this updates the last_milestone in the actuator
+                        }
+                    }
+                }
                 #endif
 
                 return;


### PR DESCRIPTION
**NOTE** this is **NOT** NIST compliant for ABC as it does not set the WCS, however it is similar to the reprap hack which just sets E to 0. This allows someone to set the ABC axis if there are no endstops defined for them. (If there are then G28.3 should be used).

Also **NOTE** that this goes into effect immediately the G92 is read, and is not synchronous with a G0 or G1, so should not be used in a gcode file as one would use G92 X... (which does use WCS and is effectively synchronous)