### PR TITLE
show hold in panel status

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -314,6 +314,7 @@ void Kernel::call_event(_EVENT_ENUM id_event, void * argument)
     bool was_idle = true;
     if(id_event == ON_HALT) {
         this->halted = (argument == nullptr);
+        if(!this->halted && this->feed_hold) this->feed_hold= false; // also clear feed hold
         was_idle = conveyor->is_idle(); // see if we were doing anything like printing
     }
 

--- a/src/modules/communication/GcodeDispatch.cpp
+++ b/src/modules/communication/GcodeDispatch.cpp
@@ -270,7 +270,7 @@ try_again:
                             case 115: { // M115 Get firmware version and capabilities
                                 Version vers;
 
-                                new_message.stream->printf("FIRMWARE_NAME:Smoothieware, FIRMWARE_URL:http%%3A//smoothieware.org, X-SOURCE_CODE_URL:https://github.com/Smoothieware/Smoothieware, FIRMWARE_VERSION:%s, X-FIRMWARE_BUILD_DATE:%s, X-SYSTEM_CLOCK:%ldMHz, X-AXES:%d", vers.get_build(), vers.get_build_date(), SystemCoreClock / 1000000, MAX_ROBOT_ACTUATORS);
+                                new_message.stream->printf("FIRMWARE_NAME:Smoothieware, FIRMWARE_URL:http%%3A//smoothieware.org, X-SOURCE_CODE_URL:https://github.com/Smoothieware/Smoothieware, FIRMWARE_VERSION:%s, X-FIRMWARE_BUILD_DATE:%s, X-SYSTEM_CLOCK:%ldMHz, X-AXES:%d, X-GRBL_MODE:%d", vers.get_build(), vers.get_build_date(), SystemCoreClock / 1000000, MAX_ROBOT_ACTUATORS, THEKERNEL->is_grbl_mode());
 
                                 #ifdef CNC
                                 new_message.stream->printf(", X-CNC:1");

--- a/src/modules/utils/panel/screens/cnc/MainMenuScreen.cpp
+++ b/src/modules/utils/panel/screens/cnc/MainMenuScreen.cpp
@@ -113,7 +113,9 @@ void MainMenuScreen::display_menu_line(uint16_t line)
 {
     switch ( line ) {
         case 0: THEPANEL->lcd->printf("DRO"); break;
-        case 1: if(THEKERNEL->is_halted()) THEPANEL->lcd->printf("Clear HALT"); else THEPANEL->lcd->printf(THEPANEL->is_playing() ? "Abort" : "Play"); break;
+        case 1: if(THEKERNEL->is_halted()) THEPANEL->lcd->printf("Clear HALT");
+                else if(THEKERNEL->get_feed_hold()) THEPANEL->lcd->printf("Clear Hold");
+                else THEPANEL->lcd->printf(THEPANEL->is_playing() ? "Abort" : "Play"); break;
         case 2: THEPANEL->lcd->printf("Jog"); break;
         case 3: THEPANEL->lcd->printf("Prepare"); break;
         case 4: THEPANEL->lcd->printf("Custom"); break;
@@ -129,7 +131,10 @@ void MainMenuScreen::clicked_menu_entry(uint16_t line)
         case 0: THEPANEL->enter_screen(this->watch_screen); break;
         case 1:
             if(THEKERNEL->is_halted()){
-                send_command("M999");
+                THEKERNEL->call_event(ON_HALT, (void *)1); // clears on_halt
+                THEPANEL->enter_screen(this->watch_screen);
+            }else if(THEKERNEL->get_feed_hold()){
+                THEKERNEL->set_feed_hold(false);
                 THEPANEL->enter_screen(this->watch_screen);
             }else if(THEPANEL->is_playing()) abort_playing();
              else THEPANEL->enter_screen(this->file_screen); break;

--- a/src/modules/utils/panel/screens/cnc/WatchScreen.cpp
+++ b/src/modules/utils/panel/screens/cnc/WatchScreen.cpp
@@ -207,7 +207,10 @@ const char *WatchScreen::get_status()
     if (THEKERNEL->is_halted())
         return "ALARM";
 
-    if (THEPANEL->is_suspended() /*|| THEKERNEL->get_feed_hold()*/)
+    if (THEKERNEL->get_feed_hold())
+        return "Hold";
+
+    if (THEPANEL->is_suspended())
         return "Suspended";
 
     if (THEPANEL->is_playing())


### PR DESCRIPTION
(Mainly for CNC builds)...

Allow clear hold in panel
Clear feed hold when ALARM is cleared (for bCNC)
Add grbl mode status to M115