### PR TITLE
CartGridStrategy: Always calculate target Z scaling using target Z, not current Z

### DIFF
--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -583,18 +583,14 @@ void CartGridStrategy::doCompensation(float *target, bool inverse)
     float scale = 1.0;
 
     if (!isnan(this->damping_interval)) {
-        // first let's find out our 'world coordinate' positions for checking the limits:
-        Robot::wcs_t world_coordinates = THEROBOT->mcs2wcs(THEROBOT->get_axis_position());
-        float current_z = std::get<Z_AXIS>(world_coordinates); // no need to convert to mm, if machine is in inches; so is config!
-        // THEKERNEL->streams->printf("//DEBUG: Current Z: %f\n", current_z);
         // if the height is below our compensation limit:
-        if(current_z <= this->height_limit) {
+        if(target[Z_AXIS] <= this->height_limit) {
             // scale the offset as necessary:
-            if( current_z >= this->dampening_start) {
-                scale = ( 1- ( (current_z - this->dampening_start ) / this->damping_interval) );
+            if(target[Z_AXIS] >= this->dampening_start) {
+                scale = (1 - ((target[Z_AXIS] - this->dampening_start ) / this->damping_interval));
             } // else leave scale at 1.0;
         } else {
-            scale = 0.0; // if Z is higher than max, no compensation
+            return; // if Z is higher than max, no compensation
         }
     }
 

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -554,6 +554,19 @@ bool CartGridStrategy::doProbe(Gcode *gc)
 void CartGridStrategy::doCompensation(float *target, bool inverse)
 {
     // Adjust print surface height by linear interpolation over the bed_level array.
+    // offset scale: 1 for default (use offset as is)
+    float scale = 1.0;
+    if (!isnan(this->damping_interval)) {
+        // if the height is below our compensation limit:
+        if(target[Z_AXIS] <= this->height_limit) {
+            // scale the offset as necessary:
+            if(target[Z_AXIS] >= this->dampening_start) {
+                scale = (1.0 - ((target[Z_AXIS] - this->dampening_start) / this->damping_interval));
+            } // else leave scale at 1.0;
+        } else {
+            return; // if Z is higher than max, no compensation
+        }
+    }
 
     // find min/maxes, and handle the case where size is negative (assuming this is possible? Legacy code supported this)
     float min_x = std::min(this->x_start, this->x_start + this->x_size);
@@ -579,20 +592,6 @@ void CartGridStrategy::doCompensation(float *target, bool inverse)
     float left = (1 - ratio_y) * z1 + ratio_y * z2;
     float right = (1 - ratio_y) * z3 + ratio_y * z4;
     float offset = (1 - ratio_x) * left + ratio_x * right;
-    // offset scale: 1 for default (use offset as is)
-    float scale = 1.0;
-
-    if (!isnan(this->damping_interval)) {
-        // if the height is below our compensation limit:
-        if(target[Z_AXIS] <= this->height_limit) {
-            // scale the offset as necessary:
-            if(target[Z_AXIS] >= this->dampening_start) {
-                scale = (1 - ((target[Z_AXIS] - this->dampening_start ) / this->damping_interval));
-            } // else leave scale at 1.0;
-        } else {
-            return; // if Z is higher than max, no compensation
-        }
-    }
 
     if (inverse) {
         target[Z_AXIS] -= offset * scale;


### PR DESCRIPTION
This code is the result of the thread in the Smoothieware-Support group post "Bonkers retraction recovery when using CartGridStrategy's new dampening and Z-hop". I found that the diminishing scaling of the Z offset was calculated using the current Z position instead of the target one. This created some weird issues where my retract recoveries didn't recover (causing a weird noise on the extruder stepper and leaving the filament retracted). I feel like the correct way to scale the compensation is always on the target Z, why would we care where we were before the move we're planning to make?

The left is compensating scaling based on current Z, the right is based on target Z. You can see on the left how it underextrudes the first segment after Z change right up to the point the scaling turns off.
![dsc05643](https://user-images.githubusercontent.com/677183/43612861-952eb1de-967b-11e8-91ff-27959a48f746.JPG)

Full discussion is in the Support thread, but I also added an optimization to not do all the math calculations to compensate if we are past the `height_limit` set in the config. Moving it to the top and bailing out runs in the same amount of time in the case where we're doing compensation but drastically reduces CPU cycle count once the Z height has progressed past the compensation area. However, the important change is swapping `THEROBOT->mcs2wcs(THEROBOT->get_axis_position());` for `target[Z_AXIS]`.