### PR TITLE
Feature/zprobe m48

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ debug
 /win_install.log
 /linux_install.log
 /src/default_excludes.mk
+/.cproject
+/.project

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,3 @@
+/ilg.gnuarmeclipse.managedbuild.cross.prefs
+/language.settings.xml
+/org.eclipse.cdt.codan.core.prefs

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -550,11 +550,11 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
   sum = 0.0;
   for (int i = 0; i < nb_point_read; i++) {
       sum += sample[i];
-      mean = sum / nb_point_read;
 
       min = (sample[i] < min)? sample[i] : min);
       max = (max < sample[i])? sample[i] : max);
   }
+  mean = sum / nb_point_read;
 
   // compute standard deviation for the probed value
   sum = 0.0;

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -558,7 +558,7 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point, float x, floa
   }
 
   // compute mean for the probed value
-  sum = 0.0;
+  sum = 0.0f;
   for (int i = 0; i < nb_point_read; i++) {
       sum += sample[i];
 
@@ -568,9 +568,9 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point, float x, floa
   mean = sum / nb_point_read;
 
   // compute standard deviation for the probed value
-  sum = 0.0;
+  sum = 0.0f;
   for (int i = 0; i < nb_point_read; i++) sum += pow(sample[i] - mean, 2);
-  sigma = sqrt(sum / nb_point_read);
+  sigma = sqrtf(sum / nb_point_read);
 
   stream->printf("Finished with %d samples :\n", nb_point_read);
   stream->printf(" min %1.3f, max %1.3f, range %1.3f\n", min, max, max-min);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -569,7 +569,7 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point, float x, floa
 
   // compute standard deviation for the probed value
   sum = 0.0f;
-  for (int i = 0; i < nb_point_read; i++) sum += pow(sample[i] - mean, 2);
+  for (int i = 0; i < nb_point_read; i++) sum += powf(sample[i] - mean, 2.0f);
   sigma = sqrtf(sum / nb_point_read);
 
   stream->printf("Finished with %d samples :\n", nb_point_read);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -521,7 +521,7 @@ void ZProbe::home()
 void ZProbe::repeatability(StreamOutput *stream, int number_point, float x, float y) {
   bool probe_result;
   float mm;
-  float sum = 0.0, mean = 0.0, sigma = 0.0, min = 99999.9, max = -99999.9, sample[number_point];
+  float sum = 0.0f, mean = 0.0f, sigma = 0.0f, min = 99999.9f, max = -99999.9f, sample[number_point];
   int nb_point_read = 0;
 
   // some sanity checking

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -534,7 +534,7 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
       // if not setting Z then return probe to where it started, otherwise leave it where it is
       probe_result = run_probe_return(mm, this->slow_feedrate, -1, false);
 
-      if(!probe_result) {
+      if(probe_result) {
         // the result is in actuator coordinates moved
         sample[i] = THEKERNEL->robot->from_millimeters(mm);
         stream->printf(" sample %d, Z=%1.4f\n", i, sample[i]);
@@ -558,7 +558,7 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
 
   // compute standard deviation for the probed value
   sum = 0.0;
-  for (int i = 0; i <= nb_point_read; i++) sum += pow(sample[i] - mean, 2);
+  for (int i = 0; i < nb_point_read; i++) sum += pow(sample[i] - mean, 2);
   sigma = sqrt(sum / nb_point_read);
 
   stream->printf("Finished with %d samples :\n", nb_point_read);

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -379,12 +379,12 @@ void ZProbe::on_gcode_received(void *argument)
         // M code processing here
         int c;
         switch (gcode->m) {
-            case 48:
+            case 48: {
                 int pointNumber = 3;
                 if (gcode->has_letter('P')) pointNumber = gcode->get_value('P');
                 this->repeatability(gcode->stream, pointNumber);
                 break;
-
+}
             case 119:
                 c = this->pin.get();
                 gcode->stream->printf(" Probe: %d", c);
@@ -522,25 +522,25 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
   int nb_point_read = 0;
 
   // some sanity checking
-  if (numberPoint<0) {
-    gcode->stream->printf("Wrong number point (P) !");
+  if (number_point<0) {
+    stream->printf("Wrong number point (P) !");
     return;
   }
 
   // probe the bed and store result until the number point is reached or an error is occured
-  gcode->stream->printf("Probe repeatability with %d sample, start sampling :\n", number_point);
+  stream->printf("Probe repeatability with %d sample, start sampling :\n", number_point);
   for (int i = 0; i < number_point; i++) {
 
       // if not setting Z then return probe to where it started, otherwise leave it where it is
-      probe_result = run_probe_return(mm, this->slow_feedrate, -1, false));
+      probe_result = run_probe_return(mm, this->slow_feedrate, -1, false);
 
       if(!probe_result) {
         // the result is in actuator coordinates moved
         sample[i] = THEKERNEL->robot->from_millimeters(mm);
-        gcode->stream->printf(" sample %d, Z=%1.4f\n", sample[i]);
+        stream->printf(" sample %d, Z=%1.4f\n", i, sample[i]);
         nb_point_read++;
       } else {
-        gcode->stream->printf(" sample %d, can't probe !\n");
+        stream->printf(" sample %d, can't probe !\n", i);
         break;
       }
 
@@ -551,8 +551,8 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
   for (int i = 0; i < nb_point_read; i++) {
       sum += sample[i];
 
-      min = (sample[i] < min)? sample[i] : min);
-      max = (max < sample[i])? sample[i] : max);
+      min = (sample[i] < min)? sample[i] : min;
+      max = (max < sample[i])? sample[i] : max;
   }
   mean = sum / nb_point_read;
 
@@ -561,7 +561,7 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point) {
   for (int i = 0; i <= nb_point_read; i++) sum += pow(sample[i] - mean, 2);
   sigma = sqrt(sum / nb_point_read);
 
-  gcode->stream->printf("Finished with %d samples :\n", nb_point_read);
-  gcode->stream->printf(" min %1.3f, max %1.3f, range %1.3f\n", min, max, max-min);
-  gcode->stream->printf(" standard deviation %1.6f, mean %1.4f\n", sigma, mean);
+  stream->printf("Finished with %d samples :\n", nb_point_read);
+  stream->printf(" min %1.3f, max %1.3f, range %1.3f\n", min, max, max-min);
+  stream->printf(" standard deviation %1.6f, mean %1.4f\n", sigma, mean);
 }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -557,6 +557,11 @@ void ZProbe::repeatability(StreamOutput *stream, int number_point, float x, floa
 
   }
 
+  // if no data probe, can't compute statistic, so end method
+  if (nb_point_read == 0) {
+    return;
+  }
+
   // compute mean for the probed value
   sum = 0.0f;
   for (int i = 0; i < nb_point_read; i++) {

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -35,7 +35,7 @@ public:
     bool run_probe(float& mm, float feedrate, float max_dist= -1, bool reverse= false);
     bool run_probe_return(float& mm, float feedrate, float max_dist= -1, bool reverse= false);
     bool doProbeAt(float &mm, float x, float y);
-    void repeatability(StreamOutput *stream, int number_point);
+    void repeatability(StreamOutput *stream, int number_point, float x, float y);
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);
     void home();

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -35,6 +35,7 @@ public:
     bool run_probe(float& mm, float feedrate, float max_dist= -1, bool reverse= false);
     bool run_probe_return(float& mm, float feedrate, float max_dist= -1, bool reverse= false);
     bool doProbeAt(float &mm, float x, float y);
+    void repeatability(StreamOutput *stream, int number_point);
 
     void coordinated_move(float x, float y, float z, float feedrate, bool relative=false);
     void home();


### PR DESCRIPTION
Measure Z-Probe repeatability : implement M48 GCode function

[The specification of the functionality is here](https://reprap.org/wiki/G-code#M48:_Measure_Z-Probe_repeatability)
Parameters implemented : 
- Pnnn : number of points
- Xnnn : position on the X axis
- Ynnn : position on the Y axis
Without parameter, do 3 points at the current position.

Sample used : 
M48 P5 X50 Y50