### PR TITLE
Z-Homing of rack and pinion head configuration "Peter's Head"

### DIFF
--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -94,6 +94,7 @@ class Endstops : public Module{
             bool is_rdelta:1;
             bool is_scara:1;
             bool home_z_first:1;
+            bool home_z_rack_and_pinion:1;
             bool move_to_origin_after_home:1;
         };
 };


### PR DESCRIPTION
This pull request features an option "home_z_rack_and_pinion" to be able to home the Z-axis of an rack and pinion head also known as "Peter's Head" (http://www.betztechnik.ca/store/p34/Pick_and_Place_head_-_dual_nozzle_-_OpenPnP_compatible.html). To home this head it is necessary to dynamically set the homing direction and endstop configuration depending on the current status of the sensor.