### PR TITLE
Update cartesian grid levelling

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -59,6 +59,7 @@ Kernel::Kernel()
     halted = false;
     feed_hold = false;
     enable_feed_hold = false;
+    bad_mcu= true;
 
     instance = this; // setup the Singleton instance of the kernel
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -565,6 +565,13 @@ void Robot::on_gcode_received(void *argument)
                     // reset G92 offsets to 0
                     g92_offset = wcs_t(0, 0, 0);
 
+                } else if(gcode->subcode == 4) {
+                    // G92.4 is a smoothie special it sets manual homing for X,Y,Z
+                    // do a manual homing based on given coordinates, no endstops required
+                    if(gcode->has_letter('X')){ THEROBOT->reset_axis_position(gcode->get_value('X'), X_AXIS); }
+                    if(gcode->has_letter('Y')){ THEROBOT->reset_axis_position(gcode->get_value('Y'), Y_AXIS); }
+                    if(gcode->has_letter('Z')){ THEROBOT->reset_axis_position(gcode->get_value('Z'), Z_AXIS); }
+
                 } else if(gcode->subcode == 3) {
                     // initialize G92 to the specified values, only used for saving it with M500
                     float x= 0, y= 0, z= 0;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -433,6 +433,16 @@ Robot::wcs_t Robot::mcs2wcs(const Robot::wcs_t& pos) const
     );
 }
 
+// converts a position in work coordinate system to machine coordinate system (machine position)
+Robot::wcs_t Robot::wcs2mcs(const Robot::wcs_t& pos) const
+{
+    return std::make_tuple(
+        std::get<X_AXIS>(pos) + std::get<X_AXIS>(wcs_offsets[current_wcs]) - std::get<X_AXIS>(g92_offset) + std::get<X_AXIS>(tool_offset),
+        std::get<Y_AXIS>(pos) + std::get<Y_AXIS>(wcs_offsets[current_wcs]) - std::get<Y_AXIS>(g92_offset) + std::get<Y_AXIS>(tool_offset),
+        std::get<Z_AXIS>(pos) + std::get<Z_AXIS>(wcs_offsets[current_wcs]) - std::get<Z_AXIS>(g92_offset) + std::get<Z_AXIS>(tool_offset)
+    );
+}
+
 // this does a sanity check that actuator speeds do not exceed steps rate capability
 // we will override the actuator max_rate if the combination of max_rate and steps/sec exceeds base_stepping_frequency
 void Robot::check_max_actuator_speeds()

--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -75,6 +75,8 @@ class Robot : public Module {
         // Workspace coordinate systems
         wcs_t mcs2wcs(const wcs_t &pos) const;
         wcs_t mcs2wcs(const float *pos) const { return mcs2wcs(wcs_t(pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS])); }
+        wcs_t wcs2mcs(const wcs_t &pos) const;
+        wcs_t wcs2mcs(const float *pos) const { return wcs2mcs(wcs_t(pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS])); }
 
         struct {
             bool inch_mode:1;                                 // true for inch mode, false for millimeter mode ( default )

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -368,7 +368,7 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
         }
 
     } else if(gcode->has_m) {
-        if(gcode->m == 370 || gcode->m == 561) { // M370: Clear bed, M561: Set Identity Transform
+        if(gcode->m == 370 || gcode->m == 561) { // M370, M561: Clear bed
             // delete the compensationTransform in robot
             setAdjustFunction(false);
             reset_bed_level();

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -538,6 +538,9 @@ bool CartGridStrategy::doProbe(Gcode *gc, bool scanonly)
     float z_reference = zprobe->getProbeHeight() - mm; // this should be zero
     gc->stream->printf("probe at 0,0 is %f mm\n", z_reference);
 
+    // keep track of worst case delta
+    float max_delta= z_reference;
+
     // probe all the points of the grid
     for (int yCount = 0; yCount < this->current_grid_y_size; yCount++) {
         float yProbe = this->y_start + (this->y_size / (this->current_grid_y_size - 1)) * yCount;
@@ -564,10 +567,13 @@ bool CartGridStrategy::doProbe(Gcode *gc, bool scanonly)
             if(!scanonly) {
                 grid[xCount + (this->current_grid_x_size * yCount)] = measured_z;
             }
+            if(measured_z > max_delta) max_delta= measured_z;
         }
     }
 
     print_bed_level(gc->stream);
+
+    gc->stream->printf("Maximum delta: %1.4f\n", max_delta);
 
     if (do_manual_attach) {
         // Move to the attachment point defined for removal of probe

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -541,6 +541,11 @@ bool CartGridStrategy::doProbe(Gcode *gc)
         if(gc->has_letter('Y')) this->y_size = gc->get_value('Y'); // override default probe length, will get saved
     }
 
+    if(x_size == 0 || y_size == 0) {
+        gc->stream->printf("ERROR: Probe Size cannot be 0\n");
+        return false;
+    }
+
     setAdjustFunction(false);
     reset_bed_level();
 
@@ -578,7 +583,7 @@ bool CartGridStrategy::doProbe(Gcode *gc)
         return false;
     }
 
-    gc->stream->printf("Probe start ht: %f mm, start x,y: %f,%f, rectangular bed width,height in mm: %f,%f, grid size: %dx%d\n", zprobe->getProbeHeight(), x_start, y_start, x_size, y_size, current_grid_x_size, current_grid_y_size);
+    gc->stream->printf("Probe start ht: %0.4f mm, start MCS x,y: %0.4f,%0.4f, rectangular bed width,height in mm: %0.4f,%0.4f, grid size: %dx%d\n", zprobe->getProbeHeight(), x_start, y_start, x_size, y_size, current_grid_x_size, current_grid_y_size);
 
     // do first probe for 0,0
     float mm;

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -449,7 +449,7 @@ bool CartGridStrategy::doProbe(Gcode *gc, bool scanonly)
 {
     bool use_wcs= false;
     gc->stream->printf("Rectangular Grid Probe...\n");
-    if(scanonly) gc->stream->printf("Scan Only\n");
+    if(scanonly) gc->stream->printf("NOTE Scan Only\n");
 
     // if R1 then force only_by_two_corners using current position for start point
     // R0 turns off two corners mode

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -31,12 +31,12 @@ private:
     bool probe_grid(int n, int m, float _x_start, float _y_start, float _x_size, float _y_size, StreamOutput *stream);
 
     float initial_height;
-    float tolerance; 
-	
+    float tolerance;
+
     float height_limit;
-    float dampening_start; 
+    float dampening_start;
     float damping_interval;
-	
+
     float *grid;
     std::tuple<float, float, float> probe_offsets;
     std::tuple<float, float, float> m_attach;
@@ -56,5 +56,6 @@ private:
         bool do_manual_attach:1;
         bool only_by_two_corners:1;
         bool human_readable:1;
+        bool new_file_format:1;
     };
 };

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -20,7 +20,7 @@ public:
 
 private:
 
-    bool doProbe(Gcode *gc);
+    bool doProbe(Gcode *gc, bool scanonly);
     bool findBed();
     void setAdjustFunction(bool on);
     void print_bed_level(StreamOutput *stream);
@@ -28,7 +28,6 @@ private:
     void reset_bed_level();
     void save_grid(StreamOutput *stream);
     bool load_grid(StreamOutput *stream);
-    bool probe_grid(int n, int m, float _x_start, float _y_start, float _x_size, float _y_size, StreamOutput *stream);
 
     float initial_height;
     float tolerance;


### PR DESCRIPTION
Add G92.4 set allow manual setting of MCS (home).
Refactor grid strategy to make G30 use the same code as G32.
Add a G32 R1 mode to force into two corners mode, and use current MCS as start.
Fix some file naming issues in cart grid.