### PR TITLE
Fix tiny moves in relative mode

### DIFF
--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -73,7 +73,8 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
     // sometimes even though there is a detectable movement it turns out there are no steps to be had from such a small move
     if(!has_steps) {
         block->clear();
-        return false;
+        // we still return true so the tiny move will still be accumulated and eventually create steps
+        return true;
     }
 
     // info needed by laser

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1369,7 +1369,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         return true;
     }
 
-    // no actual move
+    // no actual move, should never happen
     return false;
 }
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1211,13 +1211,12 @@ void SimpleShell::jog(string parameters, StreamOutput *stream)
         scale= strtof(parameters.substr(npos+1).c_str(), NULL);
     }
 
-    THEROBOT->push_state();
     float rate_mm_s= THEROBOT->actuators[a]->get_max_rate() * scale;
     THEROBOT->delta_move(delta, rate_mm_s, n_motors);
 
     // turn off queue delay and run it now
     THECONVEYOR->force_queue();
-    THEROBOT->pop_state();
+
     //stream->printf("Jog: %c%f F%f\n", ax, d, scale);
 }
 


### PR DESCRIPTION
If a relative move was so small so that it did not cause a step it would not accumulate in the machine position meaning it would just be rejected no matter how many were issued.
Now it will accumulate in the machine position and eventually will be a big enough delta move to generate some steps. This does mean that actual position calculated from the actuator steps sometimes will not match the machine position. On most machines this is sub 0.001mm differences, depending on the steps/mm