### PR TITLE
Change the way suspend/resume saves current position

### DIFF
--- a/src/libs/USBDevice/USBSerial/USBSerial.cpp
+++ b/src/libs/USBDevice/USBSerial/USBSerial.cpp
@@ -208,7 +208,7 @@ bool USBSerial::USBEvent_EPOut(uint8_t bEP, uint8_t bEPStatus)
             continue;
         }
 
-        if(THEKERNEL->is_grbl_mode() || THEKERNEL->is_feed_hold_enabled()) {
+        if(THEKERNEL->is_feed_hold_enabled()) {
             if(c[i] == '!') { // safe pause
                 THEKERNEL->set_feed_hold(true);
                 continue;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -640,6 +640,7 @@ void Robot::on_gcode_received(void *argument)
             case 2: // M2 end of program
                 current_wcs = 0;
                 absolute_mode = true;
+                seconds_per_minute= 60;
                 break;
             case 17:
                 THEKERNEL->call_event(ON_ENABLE, (void*)1); // turn all enable pins on

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -654,6 +654,7 @@ void Robot::on_gcode_received(void *argument)
                         char axis= (i <= Z_AXIS ? 'X'+i : 'A'+(i-3));
                         if(gcode->has_letter(axis)) bm |= (0x02<<i); // set appropriate bit
                     }
+
                     // handle E parameter as currently selected extruder ABC
                     if(gcode->has_letter('E')) {
                         // find first selected extruder

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -43,7 +43,10 @@
 
       Then when M500 is issued it will save M375 which will cause the grid to be loaded on boot. The default is to not autoload the grid on boot
 
-    Optionally an initial_height can be set that tell the initial probe where to stop the fast decent before it probes, this should be around 5-10mm above the bed
+    An initial_height can be set that moves the Z to that Z position before the initial probe, this should be around 5-10mm above the bed.
+    NOTE this is the ABSOLUTE Z machine position and presumes the Z axis home has been set correctly. The default is disabled.
+    If this is not set the probe will start from the current position.
+
       leveling-strategy.rectangular-grid.initial_height  10
 
     If two corners rectangular mode activated using "leveling-strategy.rectangular-grid.only_by_two_corners true" then G29/31/32 will not work without providing XYAB parameters
@@ -166,7 +169,8 @@ bool CartGridStrategy::handleConfig()
 
     // the initial height above the bed we stop the intial move down after home to find the bed
     // this should be a height that is enough that the probe will not hit the bed and is an offset from max_z (can be set to 0 if max_z takes into account the probe offset)
-    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, initial_height_checksum)->by_default(10)->as_number();
+    this->initial_height = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, initial_height_checksum)->by_default(NAN)->as_number();
+    if(initial_height <= 0) initial_height= NAN;
 
     // Probe offsets xxx,yyy,zzz
     {
@@ -438,8 +442,9 @@ void CartGridStrategy::setAdjustFunction(bool on)
 bool CartGridStrategy::findBed(float x, float y)
 {
     if (do_home && !only_by_two_corners && !do_manual_attach) zprobe->home();
-    float z = initial_height;
-    zprobe->coordinated_move(NAN, NAN, z, zprobe->getFastFeedrate()); // move Z only to initial_height
+    if(!isnan(initial_height)) {
+        zprobe->coordinated_move(NAN, NAN, initial_height, zprobe->getFastFeedrate()); // move Z only to initial_height
+    }
     zprobe->coordinated_move(x - X_PROBE_OFFSET_FROM_EXTRUDER, y - Y_PROBE_OFFSET_FROM_EXTRUDER, NAN, zprobe->getFastFeedrate()); // move at initial_height to x, y
 
     // find bed at 0,0 run at slow rate so as to not hit bed hard

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -52,7 +52,7 @@
     If two corners rectangular mode activated using "leveling-strategy.rectangular-grid.only_by_two_corners true" then G29/31/32 will not work without providing XYAB parameters
         XY - start point, AB rectangle size from starting point
         "Two corners"" not absolutely correct name for this mode, because it use only one corner and rectangle size.
-        can be turned off with G32 R0
+        can be turned off with G32 R0 and turned on with G32 R1.
 
     Display mode of current grid can be changed to human readable mode (table with coordinates) by using
        leveling-strategy.rectangular-grid.human_readable  true

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -437,7 +437,7 @@ void CartGridStrategy::setAdjustFunction(bool on)
 
 bool CartGridStrategy::findBed(float x, float y)
 {
-    if (do_home && !do_manual_attach) zprobe->home();
+    if (do_home && !only_by_two_corners && !do_manual_attach) zprobe->home();
     float z = initial_height;
     zprobe->coordinated_move(NAN, NAN, z, zprobe->getFastFeedrate()); // move Z only to initial_height
     zprobe->coordinated_move(x - X_PROBE_OFFSET_FROM_EXTRUDER, y - Y_PROBE_OFFSET_FROM_EXTRUDER, NAN, zprobe->getFastFeedrate()); // move at initial_height to x, y

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -337,13 +337,13 @@ void ZProbe::on_gcode_received(void *argument)
             return;
         }
 
+        // first wait for all moves to finish
+        THEKERNEL->conveyor->wait_for_idle();
+
         if(this->pin.get() ^ (gcode->subcode >= 4)) {
             gcode->stream->printf("error:ZProbe triggered before move, aborting command.\n");
             return;
         }
-
-        // first wait for all moves to finish
-        THEKERNEL->conveyor->wait_for_idle();
 
         float x= NAN, y=NAN, z=NAN;
         if(gcode->has_letter('X')) {

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -484,8 +484,6 @@ void ZProbe::coordinated_move(float x, float y, float z, float feedrate, bool re
         snprintf(&cmd[n], CMDLEN-n, " F%1.1f", feedrate * 60); // feed rate is converted to mm/min
     }
 
-    if(relative) strcat(cmd, " G90");
-
     //THEKERNEL->streams->printf("DEBUG: move: %s: %u\n", cmd, strlen(cmd));
 
     // send as a command line as may have multiple G codes in it

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -47,7 +47,7 @@ public:
 
 private:
     void config_load();
-    void probe_XYZ(Gcode *gc, float x, float y, float z);
+    void probe_XYZ(Gcode *gc);
     uint32_t read_probe(uint32_t dummy);
 
     float slow_feedrate;

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -691,8 +691,9 @@ void Player::resume_command(string parameters, StreamOutput *stream )
     THEROBOT->absolute_mode= true;
     {
         // NOTE position was saved in WCS (for tool change which may change WCS expecially the Z)
+        // we also move Z first incase tool is in the workpiece
         char buf[128];
-        snprintf(buf, sizeof(buf), "G0 X%f Y%f Z%f", saved_position[0], saved_position[1], saved_position[2]);
+        snprintf(buf, sizeof(buf), "G0 Z%f G0 X%f Y%f", saved_position[2], saved_position[0], saved_position[1]);
         struct SerialMessage message;
         message.message = buf;
         message.stream = &(StreamOutput::NullStream);

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -691,9 +691,8 @@ void Player::resume_command(string parameters, StreamOutput *stream )
     THEROBOT->absolute_mode= true;
     {
         // NOTE position was saved in WCS (for tool change which may change WCS expecially the Z)
-        // we also move Z first incase tool is in the workpiece
         char buf[128];
-        snprintf(buf, sizeof(buf), "G0 Z%f G0 X%f Y%f", saved_position[2], saved_position[0], saved_position[1]);
+        snprintf(buf, sizeof(buf), "G0 X%f Y%f Z%f", saved_position[0], saved_position[1], saved_position[2]);
         struct SerialMessage message;
         message.message = buf;
         message.stream = &(StreamOutput::NullStream);


### PR DESCRIPTION
Currently suspend saves the current position in MCS. This can be an issue if in between suspend and resume the Z height is changed using G10 (or G92). This change will save the position in WCS and restore it using WCS. That way the relative height will be maintained on resume. As only CNC users are likely to use WCS and reset Z height, this should not affect 3d printer users.

This also fixes a bug in G38 where it was not waiting for queue to be empty.

Another fix is to rectangular grid/cart grid making the probe initial height optional and default to disabled. Also disables homing when only by two corners mode is enabled.

￼Other misc changes...
if feedhold is disabled don't consume !
refactor G38.n to use delta move
￼Handle inverted probe correctly in G38.n
