### PR TITLE
Add Soft PWM for bltouch and servos

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -29,7 +29,7 @@ x_axis_max_speed                             30000            # Maximum speed in
 y_axis_max_speed                             30000            # Maximum speed in mm/min
 z_axis_max_speed                             300              # Maximum speed in mm/min
 
-# Stepper module configuration 
+# Stepper module configuration
 # Pins are defined as  ports, and pin numbers, appending "!" to the number will invert a pin
 # See http://smoothieware.org/pin-configuration and http://smoothieware.org/pinout
 alpha_step_pin                               2.0              # Pin for alpha stepper step signal
@@ -98,7 +98,7 @@ delta_current                                    1.5          # First extruder s
 ## Laser module configuration
 # See http://smoothieware.org/laser
 laser_module_enable                           false           # Whether to activate the laser module at all
-laser_module_pwm_pin                          2.5             # This pin will be PWMed to control the laser. 
+laser_module_pwm_pin                          2.5             # This pin will be PWMed to control the laser.
                                                               # Only pins 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 1.18, 1.20, 1.21, 1.23, 1.24, 1.26, 3.25 and 3.26
                                                               # can be used since laser requires hardware PWM, see http://smoothieware.org/pinout
 #laser_module_ttl_pin 	                      1.30            # This pin turns on when the laser turns on, and off when the laser turns off.
@@ -130,7 +130,7 @@ temperature_control.hotend.designator        T                # Designator lette
 #temperature_control.hotend.runaway_cooling_timeout        0  # How long it can take to cool down if temp is set lower, max is 2040 seconds
 #temperature_control.hotend.runaway_range                20   # How far from the set temperature it can wander, max setting is 63°C
 
-# PID configuration 
+# PID configuration
 # See http://smoothieware.org/temperaturecontrol#pid
 #temperature_control.hotend.p_factor         13.7             # P ( proportional ) factor
 #temperature_control.hotend.i_factor         0.097            # I ( integral ) factor
@@ -184,6 +184,13 @@ switch.fan.output_type                       pwm              # PWM output setta
 #switch.misc.input_off_command               M43              # Command that will turn this switch off
 #switch.misc.output_pin                      2.4              # Pin this module controls
 #switch.misc.output_type                     digital          # Digital means this is just an on or off pin
+
+#switch.bltouch.enable                    true         #
+#switch.bltouch.output_pin                2.4          # sw pwm can use any digital pin
+#switch.bltouch.input_on_command          M280         #
+#switch.bltouch.input_off_command         M281         #
+#switch.bltouch.output_type               swpwm        # sw pwm must be low frequency
+#switch.bltouch.pwm_period_ms             20           # 50Hz
 
 ## Temperatureswitch
 # See http://smoothieware.org/temperatureswitch

--- a/src/libs/SoftPWM.cpp
+++ b/src/libs/SoftPWM.cpp
@@ -1,0 +1,85 @@
+#include "SoftPWM.h"
+#include "Pin.h"
+
+SoftPWM::SoftPWM(Pin *_outpin, bool _positive) : pulse(_outpin)    //constructa
+{
+    pulse->set(!_positive);
+    positive = _positive;
+    interval = 0.02F;
+    width = 0;
+    start();
+}
+
+float SoftPWM::read()
+{
+    if ( width <= 0 ) return 0;
+    if ( width > 1 )  return 1;
+    return width / interval;
+}
+
+void SoftPWM::write(float duty)
+{
+    width = interval * duty;
+    if ( duty <= 0 ) width =  0;
+    if ( duty > 1 )  width =  interval;
+}
+
+void SoftPWM::start()
+{
+    _ticker.attach(this, &SoftPWM::TickerInterrapt, interval);
+}
+
+void SoftPWM::stop()
+{
+    _ticker.detach();
+    pulse->set(!positive);
+    //wait(width);
+}
+
+void SoftPWM::period(float _period)
+{
+    interval = _period;
+    start();
+}
+
+void SoftPWM::period_ms(int _period)
+{
+    period((float)_period / 1000);
+    start();
+}
+
+void SoftPWM::period_us(int _period)
+{
+    period((float)_period / 1000000);
+    start();
+}
+
+void SoftPWM::pulsewidth(float _width)
+{
+    width = _width;
+    if ( width < 0.0F ) width = 0.0F;
+}
+
+void SoftPWM::pulsewidth_ms(int _width)
+{
+    pulsewidth((float)_width / 1000);
+}
+
+void SoftPWM::pulsewidth_us(int _width)
+{
+    pulsewidth((float)_width / 1000000);
+}
+
+void SoftPWM::TickerInterrapt()
+{
+    if ( width <= 0 ) return;
+    _timeout.attach(this, &SoftPWM::end, width);
+    pulse->set(positive);
+}
+
+void SoftPWM::end()
+{
+    pulse->set(!positive);
+}
+
+

--- a/src/libs/SoftPWM.h
+++ b/src/libs/SoftPWM.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#define POSITIVE true
+#define NEGATIVE false
+
+#include "mbed.h"
+
+class Pin;
+
+class SoftPWM
+{
+private:
+    Timeout _timeout;
+    Ticker _ticker;
+    Pin *pulse;
+    bool positive;
+    float width;
+    float interval;
+    void TickerInterrapt();
+    void end();
+public:
+    SoftPWM(Pin *pin, bool mode = true);
+    void start();
+    void write(float);
+    float read();
+    void pulsewidth(float);
+    void pulsewidth_ms(int);
+    void pulsewidth_us(int);
+    void period(float);
+    void period_ms(int);
+    void period_us(int);
+    void stop();
+    operator float() { return read(); }
+    SoftPWM& operator=(float duty) { write(duty); return *this; }
+
+};

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -204,7 +204,7 @@ void Switch::on_config_reload(void *argument)
         if(this->switch_state) {
             this->swpwm_pin->write(this->switch_value/100.0F);
         } else {
-            this->pwm_pin->write(0);
+            this->swpwm_pin->write(0);
         }
 
     } else if(this->output_type == DIGITAL){

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -65,6 +65,7 @@ void Switch::on_halt(void *arg)
             case DIGITAL: this->digital_pin->set(this->failsafe); break;
             case SIGMADELTA: this->sigmadelta_pin->set(this->failsafe); break;
             case HWPWM: this->pwm_pin->write(0); break;
+            case SWPWM: this->swpwm_pin->write(0); break;
             case NONE: break;
         }
         this->switch_state= this->failsafe;
@@ -150,6 +151,23 @@ void Switch::on_config_reload(void *argument)
             this->output_type= NONE;
         }
 
+    }else if(type == "swpwm"){
+        this->output_type= SWPWM;
+        Pin *pin= new Pin();
+        pin->from_string(THEKERNEL->config->value(switch_checksum, this->name_checksum, output_pin_checksum )->by_default("nc")->as_string())->as_output();
+        if(pin->connected()) {
+            this->swpwm_pin= new SoftPWM(pin, !pin->is_inverting());
+            if(failsafe == 1) {
+                set_high_on_debug(pin->port_number, pin->pin);
+            }else{
+                set_low_on_debug(pin->port_number, pin->pin);
+            }
+        }else{
+            this->output_type= NONE;
+            delete pin;
+        }
+
+
     } else {
         this->output_type= NONE;
     }
@@ -172,6 +190,19 @@ void Switch::on_config_reload(void *argument)
         this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(0)->as_number();
         if(this->switch_state) {
             this->pwm_pin->write(this->switch_value/100.0F);
+        } else {
+            this->pwm_pin->write(0);
+        }
+
+    } else if(this->output_type == SWPWM) {
+        // default is 50Hz
+        float p= THEKERNEL->config->value(switch_checksum, this->name_checksum, pwm_period_ms_checksum )->by_default(20)->as_number(); // ms fractions are not allowed
+        this->swpwm_pin->period_ms(p);
+
+        // default is 0% duty cycle
+        this->switch_value = THEKERNEL->config->value(switch_checksum, this->name_checksum, startup_value_checksum )->by_default(0)->as_number();
+        if(this->switch_state) {
+            this->swpwm_pin->write(this->switch_value/100.0F);
         } else {
             this->pwm_pin->write(0);
         }
@@ -281,6 +312,21 @@ void Switch::on_gcode_received(void *argument)
                 this->switch_state= (this->switch_value != 0);
             }
 
+       } else if (this->output_type == SWPWM) {
+            // drain queue
+            THEKERNEL->conveyor->wait_for_idle();
+            // PWM output pin set duty cycle 0 - 100
+            if(gcode->has_letter('S')) {
+                float v = gcode->get_value('S');
+                if(v > 100) v= 100;
+                else if(v < 0) v= 0;
+                this->swpwm_pin->write(v/100.0F);
+                this->switch_state= (v != 0);
+            } else {
+                this->swpwm_pin->write(this->switch_value);
+                this->switch_state= (this->switch_value != 0);
+            }
+
         } else if (this->output_type == DIGITAL) {
             // drain queue
             THEKERNEL->conveyor->wait_for_idle();
@@ -299,6 +345,9 @@ void Switch::on_gcode_received(void *argument)
 
         } else if (this->output_type == HWPWM) {
             this->pwm_pin->write(0);
+
+        } else if (this->output_type == HWPWM) {
+            this->swpwm_pin->write(0);
 
         } else if (this->output_type == DIGITAL) {
             // logic pin turn off
@@ -363,6 +412,9 @@ void Switch::on_main_loop(void *argument)
             } else if (this->output_type == HWPWM) {
                 this->pwm_pin->write(this->switch_value/100.0F);
 
+            } else if (this->output_type == SWPWM) {
+                this->swpwm_pin->write(this->switch_value/100.0F);
+
             } else if (this->output_type == DIGITAL) {
                 this->digital_pin->set(true);
             }
@@ -376,6 +428,9 @@ void Switch::on_main_loop(void *argument)
 
             } else if (this->output_type == HWPWM) {
                 this->pwm_pin->write(0);
+
+            } else if (this->output_type == SWPWM) {
+                this->swpwm_pin->write(0);
 
             } else if (this->output_type == DIGITAL) {
                 this->digital_pin->set(false);

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -5,13 +5,12 @@
       you should have received a copy of the gnu general public license along with smoothie. if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef SWITCH_H
-#define SWITCH_H
-
+#pragma once
 #include "Pin.h"
 #include "Pwm.h"
-#include <math.h>
+#include "SoftPWM.h"
 
+#include <math.h>
 #include <string>
 
 class Gcode;
@@ -35,7 +34,7 @@ class Switch : public Module {
         void on_halt(void *arg);
 
         uint32_t pinpoll_tick(uint32_t dummy);
-        enum OUTPUT_TYPE {NONE, SIGMADELTA, DIGITAL, HWPWM};
+        enum OUTPUT_TYPE {NONE, SIGMADELTA, DIGITAL, HWPWM, SWPWM};
 
     private:
         void flip();
@@ -50,6 +49,7 @@ class Switch : public Module {
             Pin          *digital_pin;
             Pwm          *sigmadelta_pin;
             mbed::PwmOut *pwm_pin;
+            SoftPWM      *swpwm_pin;
         };
         std::string    output_on_command;
         std::string    output_off_command;
@@ -68,5 +68,3 @@ class Switch : public Module {
             uint8_t   failsafe:1;
         };
 };
-
-#endif // SWITCH_H


### PR DESCRIPTION
Add a Soft PWM option for Switch. This is for low frequency PWM like the 50Hz servos or bltouch.
It can use any spare digital pin, and can of course be set to its own frequency, whereas the H/W PWM can only have one frequency making it hard to share with lasers for instance.