### PR TITLE
various minor switch changes

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -191,6 +191,9 @@ switch.fan.output_type                       pwm              # PWM output setta
 #switch.bltouch.input_off_command         M281         #
 #switch.bltouch.output_type               swpwm        # sw pwm must be low frequency
 #switch.bltouch.pwm_period_ms             20           # 50Hz
+#switch.bltouch.startup_state             true         #
+#switch.bltouch.startup_value             7.43         #  On boot it will go into stow mode
+
 
 ## Temperatureswitch
 # See http://smoothieware.org/temperatureswitch

--- a/src/modules/tools/switch/Switch.cpp
+++ b/src/modules/tools/switch/Switch.cpp
@@ -64,8 +64,8 @@ void Switch::on_halt(void *arg)
         switch(this->output_type) {
             case DIGITAL: this->digital_pin->set(this->failsafe); break;
             case SIGMADELTA: this->sigmadelta_pin->set(this->failsafe); break;
-            case HWPWM: this->pwm_pin->write(0); break;
-            case SWPWM: this->swpwm_pin->write(0); break;
+            case HWPWM: this->pwm_pin->write(switch_value); break;
+            case SWPWM: this->swpwm_pin->write(switch_value); break;
             case NONE: break;
         }
         this->switch_state= this->failsafe;

--- a/src/modules/tools/switch/Switch.h
+++ b/src/modules/tools/switch/Switch.h
@@ -65,6 +65,6 @@ class Switch : public Module {
             bool      input_pin_state:1;
             bool      switch_state:1;
             bool      ignore_on_halt:1;
-            uint8_t   failsafe:1;
+            bool      failsafe:1;
         };
 };

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -986,7 +986,11 @@ void SimpleShell::switch_command( string parameters, StreamOutput *stream)
             ok = PublicData::set_value( switch_checksum, get_checksum(type), state_checksum, &b );
         } else {
             float v = strtof(value.c_str(), NULL);
-            ok = PublicData::set_value( switch_checksum, get_checksum(type), value_checksum, &v );
+            bool b = v != 0;
+            ok = PublicData::set_value( switch_checksum, get_checksum(type), state_checksum, &b );
+            if(ok && b) {
+                ok = PublicData::set_value( switch_checksum, get_checksum(type), value_checksum, &v );
+            }
         }
         if (ok) {
             stream->printf("switch %s set to: %s\n", type.c_str(), value.c_str());


### PR DESCRIPTION
set startup_value on HALT in hwpwm and swpwm if set in config
clean up the way the command `switch servo 1.5` works (basically if not 0 will turn on and set the value.