### PR TITLE
 add before probe and after probe optional gcodes to cart grid

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1394,6 +1394,7 @@ bool Robot::delta_move(const float *delta, float rate_mm_s, uint8_t naxis)
         target[i] += delta[i];
     }
 
+    is_g123= false; // we don't want the laser to fire
     // submit for planning and if moved update machine_position
     if(append_milestone(target, rate_mm_s)) {
          memcpy(machine_position, target, n_motors*sizeof(float));

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -537,13 +537,18 @@ void Endstops::move_to_origin(axis_bitmap_t axis)
 {
     if(!is_delta && (!axis[X_AXIS] || !axis[Y_AXIS])) return; // ignore if X and Y not homing, unless delta
 
-    this->status = MOVE_TO_ORIGIN;
     if(park_after_home) {
         // do park instead of goto origin
+        this->status = MOVE_TO_ORIGIN;
         handle_park();
         this->status = NOT_HOMING;
         return;
     }
+
+    // ignore if disabled
+    if(!this->move_to_origin_after_home) return;
+
+    this->status = MOVE_TO_ORIGIN;
     // Do we need to check if we are already at 0,0? probably not as the G0 will not do anything if we are
     // float pos[3]; THEROBOT->get_axis_position(pos); if(pos[0] == 0 && pos[1] == 0) return;
 
@@ -937,7 +942,7 @@ void Endstops::process_home_command(Gcode* gcode)
     // default is off for cartesian on for deltas
     if(!is_delta) {
         // NOTE a rotary delta usually has optical or hall-effect endstops so it is safe to go past them a little bit
-        if(this->move_to_origin_after_home) move_to_origin(haxis);
+        move_to_origin(haxis);
         // if limit switches are enabled we must back off endstop after setting home
         back_off_home(haxis);
 
@@ -945,7 +950,7 @@ void Endstops::process_home_command(Gcode* gcode)
         // deltas are not left at 0,0 because of the trim settings, so move to 0,0 if requested, but we need to back off endstops first
         // also need to back off endstops if limits are enabled
         back_off_home(haxis);
-        if(this->move_to_origin_after_home) move_to_origin(haxis);
+        move_to_origin(haxis);
     }
 }
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -693,6 +693,7 @@ void Endstops::home(axis_bitmap_t a)
             if((axis_to_home[i] || this->is_delta || this->is_rdelta) && !homing_axis[i].pin_info->triggered) {
                 this->status = NOT_HOMING;
                 THEKERNEL->call_event(ON_HALT, nullptr);
+                THEROBOT->disable_segmentation= false;
                 return;
             }
         }
@@ -704,6 +705,7 @@ void Endstops::home(axis_bitmap_t a)
             if(axis_to_home[i] && !homing_axis[i].pin_info->triggered) {
                 this->status = NOT_HOMING;
                 THEKERNEL->call_event(ON_HALT, nullptr);
+                THEROBOT->disable_segmentation= false;
                 return;
             }
         }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -939,7 +939,7 @@ void Endstops::process_home_command(Gcode* gcode)
     }
 
     // on some systems where 0,0 is bed center it is nice to have home goto 0,0 after homing
-    // default is off for cartesian on for deltas
+    // default is off for cartesian and on for deltas
     if(!is_delta) {
         // NOTE a rotary delta usually has optical or hall-effect endstops so it is safe to go past them a little bit
         move_to_origin(haxis);

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -40,7 +40,7 @@ class Endstops : public Module{
         void process_home_command(Gcode* gcode);
         void set_homing_offset(Gcode* gcode);
         uint32_t read_endstops(uint32_t dummy);
-        void handle_park(Gcode * gcode);
+        void handle_park();
 
         // global settings
         float saved_position[3]{0}; // save G28 (in grbl mode)
@@ -95,5 +95,6 @@ class Endstops : public Module{
             bool is_scara:1;
             bool home_z_first:1;
             bool move_to_origin_after_home:1;
+            bool park_after_home:1;
         };
 };

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -258,8 +258,8 @@ void CartGridStrategy::save_grid(StreamOutput *stream)
         return;
     }
 
-    tmp_configured_grid_size = configured_grid_y_size;
     if(this->new_file_format){
+        tmp_configured_grid_size = configured_grid_y_size;
         if(fwrite(&tmp_configured_grid_size, sizeof(uint8_t), 1, fp) != 1) {
             stream->printf("error:Failed to write grid y size\n");
             fclose(fp);
@@ -388,11 +388,13 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
                 THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
             }
 
+            THEROBOT->disable_segmentation= true;
             if(!doProbe(gcode)) {
                 gcode->stream->printf("Probe failed to complete, check the initial probe height and/or initial_height settings\n");
             } else {
                 gcode->stream->printf("Probe completed. Enter M374 to save this grid\n");
             }
+            THEROBOT->disable_segmentation= false;
 
             if(!after_probe.empty()) {
                 Gcode gc(after_probe, &(StreamOutput::NullStream));

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -443,7 +443,9 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
                 remove(filename);
                 gcode->stream->printf("%s deleted\n", filename);
             } else {
+                __disable_irq();
                 save_grid(gcode->stream);
+                __enable_irq();
             }
 
             return true;

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -201,6 +201,10 @@ bool CartGridStrategy::handleConfig()
     this->before_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, before_probe_gcode_checksum)->by_default("")->as_string();
     this->after_probe = THEKERNEL->config->value(leveling_strategy_checksum, cart_grid_leveling_strategy_checksum, after_probe_gcode_checksum)->by_default("")->as_string();
 
+    // for the gcode commands we need to replace _ for space
+    std::replace(before_probe.begin(), before_probe.end(), '_', ' '); // replace _ with space
+    std::replace(after_probe.begin(), after_probe.end(), '_', ' '); // replace _ with space
+
     // allocate in AHB0
     grid = (float *)AHB0.alloc(configured_grid_x_size * configured_grid_y_size * sizeof(float));
 

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -40,7 +40,7 @@ private:
 
     float *grid;
     std::tuple<float, float, float> probe_offsets;
-    std::tuple<float, float, float> m_attach;
+    float *m_attach;
     float x_start,y_start;
     float x_size,y_size;
 

--- a/src/modules/tools/zprobe/CartGridStrategy.h
+++ b/src/modules/tools/zprobe/CartGridStrategy.h
@@ -36,6 +36,7 @@ private:
     float height_limit;
     float dampening_start;
     float damping_interval;
+    std::string before_probe, after_probe;
 
     float *grid;
     std::tuple<float, float, float> probe_offsets;

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -344,7 +344,9 @@ bool DeltaGridStrategy::handleGcode(Gcode *gcode)
                 remove(GRIDFILE);
                 gcode->stream->printf("%s deleted\n", GRIDFILE);
             } else {
+                __disable_irq();
                 save_grid(gcode->stream);
+                __enable_irq();
             }
 
             return true;


### PR DESCRIPTION
1. Allow cart grid to send optional gcodes before and after probing, basically to automatically deploy a bltouch (or any deployable probe).

2. Allow park after homing, this allows going to a predefined position (the park position) after homing instead of going to 0,0. This is useful for when the probe is offset from the head so much that probing cannot go to 0,0 due to the probe offsets.

3. Fix $J to not turn on laser.

4. Fix crashes when saving grids to sdcard.