### PR TITLE
Graphical menu screens

### DIFF
--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -511,16 +511,18 @@ void Panel::enter_menu_mode(bool force)
     encoder_cb_fnc= nullptr;
 }
 
-void Panel::setup_menu(uint16_t rows)
+void Panel::setup_menu(uint16_t rows, bool reset_pos)
 {
-    this->setup_menu(rows, min(rows, this->max_screen_lines()));
+    this->setup_menu(rows, min(rows, this->max_screen_lines()), reset_pos);
 }
 
-void Panel::setup_menu(uint16_t rows, uint16_t lines)
+void Panel::setup_menu(uint16_t rows, uint16_t lines, bool reset_pos)
 {
-    this->menu_selected_line = 0;
-    this->menu_current_line = 0;
-    this->menu_start_line = 0;
+    if (reset_pos) {
+        this->menu_selected_line = 0;
+        this->menu_current_line = 0;
+        this->menu_start_line = 0;
+    }
     this->menu_rows = rows;
     this->panel_lines = lines;
 }

--- a/src/modules/utils/panel/Panel.h
+++ b/src/modules/utils/panel/Panel.h
@@ -52,8 +52,8 @@ class Panel : public Module {
         // Menu
         void enter_nop_mode();
         void enter_menu_mode(bool force= false);
-        void setup_menu(uint16_t rows, uint16_t lines);
-        void setup_menu(uint16_t rows);
+        void setup_menu(uint16_t rows, uint16_t lines, bool reset_pos = true);
+        void setup_menu(uint16_t rows, bool reset_pos = true);
         void menu_update();
         bool menu_change();
         uint16_t max_screen_lines() { return screen_lines; }

--- a/src/modules/utils/panel/PanelScreen.cpp
+++ b/src/modules/utils/panel/PanelScreen.cpp
@@ -143,9 +143,9 @@ void PanelScreen::drawWindow(const char* title)
 }
 
 void PanelScreen::drawScrollBar(int pos, int vis, int max) {
-    int top = 9 + (54 * pos) / max;
-    int len = 54 * vis / max;
-    if (54 * vis % max > 0) len++;
+    int top = 10 + (52 * pos) / max;
+    int len = 52 * vis / max;
+    if (52 * vis % max > 0) len++;
     THEPANEL->lcd->drawVLine(122, 9, 54);
-    THEPANEL->lcd->drawBox(123, top, 4, len);
+    THEPANEL->lcd->drawBox(124, top, 2, len);
 }

--- a/src/modules/utils/panel/PanelScreen.cpp
+++ b/src/modules/utils/panel/PanelScreen.cpp
@@ -30,13 +30,29 @@ void PanelScreen::on_enter() {}
 
 void PanelScreen::refresh_menu(bool clear)
 {
-    if (clear) THEPANEL->lcd->clear();
-    for (uint16_t i = THEPANEL->menu_start_line; i < THEPANEL->menu_start_line + min( THEPANEL->menu_rows, THEPANEL->panel_lines ); i++ ) {
-        THEPANEL->lcd->setCursor(2, i - THEPANEL->menu_start_line );
-        this->display_menu_line(i);
+    if (THEPANEL->lcd->hasFullGraphics() ) {
+        THEPANEL->lcd->clear();
+        this->drawWindow(this->getTitle());
+        for (uint16_t i = THEPANEL->menu_start_line; i < THEPANEL->menu_start_line + min( THEPANEL->menu_rows, THEPANEL->panel_lines ); i++ ) {
+            THEPANEL->lcd->setCursorPX(2, 10 + 9 * (i - THEPANEL->menu_start_line) );
+            this->display_menu_line(i);
+        }
+        // Draw scroll bar
+        if (THEPANEL->menu_rows > THEPANEL->panel_lines) {
+            this->drawScrollBar(THEPANEL->menu_start_line, THEPANEL->panel_lines, THEPANEL->menu_rows);
+            THEPANEL->lcd->drawBox(1, 9 + 9 * (THEPANEL->menu_current_line - THEPANEL->menu_start_line), 121, 9, 2);
+        } else {
+            THEPANEL->lcd->drawBox(1, 9 + 9 * (THEPANEL->menu_current_line - THEPANEL->menu_start_line), 126, 9, 2);
+        }
+    } else {
+        if (clear) THEPANEL->lcd->clear();
+        for (uint16_t i = THEPANEL->menu_start_line; i < THEPANEL->menu_start_line + min( THEPANEL->menu_rows, THEPANEL->panel_lines ); i++ ) {
+            THEPANEL->lcd->setCursor(2, i - THEPANEL->menu_start_line );
+            this->display_menu_line(i);
+        }
+        THEPANEL->lcd->setCursor(0, THEPANEL->menu_current_line - THEPANEL->menu_start_line );
+        THEPANEL->lcd->printf(">");
     }
-    THEPANEL->lcd->setCursor(0, THEPANEL->menu_current_line - THEPANEL->menu_start_line );
-    THEPANEL->lcd->printf(">");
 }
 
 void PanelScreen::refresh_screen(bool clear)
@@ -108,4 +124,28 @@ void PanelScreen::on_main_loop()
             break;
         }
     }
+}
+
+void PanelScreen::drawWindow(const char* title)
+{
+    // Draw borders
+    THEPANEL->lcd->drawBox(0, 0, 128, 9);
+    THEPANEL->lcd->drawVLine(0, 9, 54);
+    THEPANEL->lcd->drawVLine(127, 9, 54);
+    THEPANEL->lcd->drawHLine(1, 63, 126);
+    THEPANEL->lcd->pixel(0, 0, 0);
+    THEPANEL->lcd->pixel(127, 0, 0);
+    // Print title
+    THEPANEL->lcd->setColor(0);
+    THEPANEL->lcd->setCursorPX(2, 1);
+    THEPANEL->lcd->printf(title);
+    THEPANEL->lcd->setColor(1);
+}
+
+void PanelScreen::drawScrollBar(int pos, int vis, int max) {
+    int top = 9 + (54 * pos) / max;
+    int len = 54 * vis / max;
+    if (54 * vis % max > 0) len++;
+    THEPANEL->lcd->drawVLine(122, 9, 54);
+    THEPANEL->lcd->drawBox(123, top, 4, len);
 }

--- a/src/modules/utils/panel/PanelScreen.h
+++ b/src/modules/utils/panel/PanelScreen.h
@@ -28,9 +28,12 @@ public:
     void refresh_screen(bool clear);
     void refresh_menu(bool clear);
     void refresh_menu(void) { refresh_menu(true); };
+    void drawWindow(const char* title);
+    void drawScrollBar(int pos, int vis, int max);
     virtual void display_menu_line(uint16_t line) = 0;
     // default idle timeout for a screen, each screen can override this
     virtual int idle_timeout_secs(){ return 10; }
+    virtual const char* getTitle() { return ""; }
 
     friend class Panel;
 protected:

--- a/src/modules/utils/panel/panels/ST7565.h
+++ b/src/modules/utils/panel/panels/ST7565.h
@@ -29,7 +29,7 @@ public:
     uint8_t readButtons();
     int readEncoderDelta();
     int getEncoderResolution() { return is_viki2 ? 4 : 2; }
-    uint16_t get_screen_lines() { return 8; }
+    uint16_t get_screen_lines() { return 6; }
     bool hasGraphics() { return true; }
     bool hasFullGraphics() { return true; }
 

--- a/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.cpp
@@ -69,6 +69,7 @@ void ExtruderScreen::setupConfigSettings()
 {
     auto mvs= new ModifyValuesScreen(true);  // self delete on exit
     mvs->set_parent(this);
+    mvs->setTitle("E Settings");
 
     mvs->addMenuItem("E steps/mm",
         // gets steps/mm for currently active extruder

--- a/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/ExtruderScreen.h
@@ -18,6 +18,7 @@ class ExtruderScreen : public PanelScreen {
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
         int idle_timeout_secs() { return 60; }
+        const char* getTitle() { return "Extruder"; }
 
     private:
       void setupConfigSettings();

--- a/src/modules/utils/panel/screens/3dprinter/JogScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/JogScreen.h
@@ -19,6 +19,7 @@ class JogScreen : public PanelScreen {
         void on_enter();
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
+        const char* getTitle() { return "Jog"; }
 
     private:
         ControlScreen *control_screen;

--- a/src/modules/utils/panel/screens/3dprinter/MainMenuScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/MainMenuScreen.cpp
@@ -47,6 +47,7 @@ void MainMenuScreen::setupConfigureScreen()
 {
     auto mvs= new ModifyValuesScreen(true); // delete itself on exit
     mvs->set_parent(this);
+    mvs->setTitle("Configure");
 
     // acceleration
     mvs->addMenuItem("def Acceleration", // menu name

--- a/src/modules/utils/panel/screens/3dprinter/MainMenuScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/MainMenuScreen.h
@@ -17,6 +17,7 @@ class MainMenuScreen : public PanelScreen {
         void on_enter();
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
+        const char* getTitle() { return "Menu"; }
 
         friend class Panel;
     private:

--- a/src/modules/utils/panel/screens/3dprinter/PrepareScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/PrepareScreen.h
@@ -20,6 +20,7 @@ public:
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs() { return 60; }
+    const char* getTitle() { return "Prepare"; }
 
 private:
     void preheat();

--- a/src/modules/utils/panel/screens/3dprinter/ProbeScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/ProbeScreen.cpp
@@ -44,18 +44,17 @@ void ProbeScreen::on_enter()
 
 void ProbeScreen::on_refresh()
 {
-    if ( THEPANEL->menu_change() ) {
+    if ( THEPANEL->menu_change() or this->new_result ) {
+        if(this->new_result) {
+            this->new_result = false;
+            int lines = this->result.length() / 20;
+            if (this->result.length() % 20 > 0) lines++;
+            THEPANEL->setup_menu(3+lines,false);
+        }
         this->refresh_menu();
     }
     if ( THEPANEL->click() ) {
         this->clicked_menu_entry(THEPANEL->get_menu_current_line());
-    }
-    if(this->new_result) {
-        this->new_result= false;
-        for ( uint8_t l=0; (l < THEPANEL->get_screen_lines()-3) && (this->result.size() > l*20); l++ ) {
-            THEPANEL->lcd->setCursor(0, l+3);
-            THEPANEL->lcd->printf("%-20s", this->result.substr(l*20,20).c_str());
-        }
     }
 }
 
@@ -65,6 +64,9 @@ void ProbeScreen::display_menu_line(uint16_t line)
         case 0: THEPANEL->lcd->printf("Back");  break;
         case 1: THEPANEL->lcd->printf("Status");  break;
         case 2: THEPANEL->lcd->printf("Z Probe");  break;
+        default:
+            THEPANEL->lcd->printf("%-20s", this->result.substr((line-3)*20,20).c_str());
+            break;
     }
 }
 

--- a/src/modules/utils/panel/screens/3dprinter/ProbeScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/ProbeScreen.h
@@ -22,6 +22,7 @@ class ProbeScreen : public PanelScreen {
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
         int idle_timeout_secs() { return 120; }
+        const char* getTitle() { return "Probe"; }
 
     private:
       int tcnt;

--- a/src/modules/utils/panel/screens/ControlScreen.h
+++ b/src/modules/utils/panel/screens/ControlScreen.h
@@ -20,6 +20,7 @@ public:
     void display_menu_line(uint16_t line);
     void set_jog_increment(float i) { jog_increment = i;}
     int idle_timeout_secs() { return 120; }
+    const char* getTitle() { return "Jog"; }
 
 private:
     void clicked_menu_entry(uint16_t line);

--- a/src/modules/utils/panel/screens/CustomScreen.h
+++ b/src/modules/utils/panel/screens/CustomScreen.h
@@ -23,6 +23,7 @@ public:
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs() { return 60; }
+    const char* getTitle() { return "Custom"; }
 
 private:
     std::vector<std::tuple<const char*,const char*> > menu_items;

--- a/src/modules/utils/panel/screens/DynMenuScreen.h
+++ b/src/modules/utils/panel/screens/DynMenuScreen.h
@@ -27,6 +27,8 @@ public:
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs(){ return timeout; }
     void set_timeout(int n) { timeout= n; }
+    const char* getTitle() { return menuTitle; }
+    void setTitle(const char* title) { menuTitle = title; }
     void addMenuItem(const char *name, std::function<void()> fnc);
     void addMenuItem(const char *name, const char *gcode);
     void on_exit_action(const char *);
@@ -36,6 +38,7 @@ private:
     using MenuItemType = std::tuple<char *, std::function<void()>, char *, bool>;
     void addMenuItem(const MenuItemType& item);
     int timeout{60};
+    const char* menuTitle = "";
 
     // name, function, command, type
     std::vector<MenuItemType> menu_items;

--- a/src/modules/utils/panel/screens/FileScreen.h
+++ b/src/modules/utils/panel/screens/FileScreen.h
@@ -21,6 +21,7 @@ class FileScreen : public PanelScreen {
         void on_main_loop();
         void clicked_line(uint16_t line);
         void display_menu_line(uint16_t line);
+        const char* getTitle() { return "Play"; }
 
     private:
         void enter_folder(const char *folder);

--- a/src/modules/utils/panel/screens/ModifyValuesScreen.h
+++ b/src/modules/utils/panel/screens/ModifyValuesScreen.h
@@ -29,12 +29,16 @@ public:
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs(){ return 60; }
+    const char* getTitle() { return menuTitle; }
+    void setTitle(const char* title) { menuTitle = title; }
 
     typedef std::tuple<char *, std::function<float()>, std::function<void(float)>, float, float, float, bool> MenuItemType;
     void addMenuItem(const char *name, std::function<float()> getter, std::function<void(float)> setter, float inc= 1.0F, float min= NAN, float max= NAN, bool instant= false);
 
 private:
     void addMenuItem(const MenuItemType& item);
+
+    const char* menuTitle = "";
 
     int execute_function;
     float new_value, min_value, max_value;

--- a/src/modules/utils/panel/screens/cnc/JogScreen.h
+++ b/src/modules/utils/panel/screens/cnc/JogScreen.h
@@ -19,6 +19,7 @@ class JogScreen : public PanelScreen {
         void on_enter();
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
+        const char* getTitle() { return "Jog"; }
 
     private:
         void set_feed_rates();

--- a/src/modules/utils/panel/screens/cnc/LaserScreen.cpp
+++ b/src/modules/utils/panel/screens/cnc/LaserScreen.cpp
@@ -76,6 +76,7 @@ void LaserScreen::testFireScreen()
 {
     auto dms= new DynMenuScreen();  // self delete on exit
     dms->set_parent(this->parent); // because this will have been deleted when it exits
+    dms->setTitle("Test Fire");
     dms->set_timeout(10); // 10 seconds and it will turn off
     dms->on_exit_action("fire off");
 
@@ -94,6 +95,7 @@ void LaserScreen::setPowerScreen(int type)
 {
     auto mvs= new ModifyValuesScreen(true);  // self delete on exit
     mvs->set_parent(this->parent); // because this will have been deleted when it exits
+    mvs->setTitle("Power");
 
     if(type == 0) {
         #ifndef NO_TOOLS_LASER

--- a/src/modules/utils/panel/screens/cnc/LaserScreen.h
+++ b/src/modules/utils/panel/screens/cnc/LaserScreen.h
@@ -19,6 +19,7 @@ public:
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs() { return 60; }
+    const char* getTitle() { return "Laser"; }
 
 private:
     void testFireScreen();

--- a/src/modules/utils/panel/screens/cnc/MainMenuScreen.cpp
+++ b/src/modules/utils/panel/screens/cnc/MainMenuScreen.cpp
@@ -48,6 +48,7 @@ void MainMenuScreen::setupConfigureScreen()
 {
     auto mvs= new ModifyValuesScreen(true); // delete itself on exit
     mvs->set_parent(this);
+    mvs->setTitle("Configure");
 
    // acceleration
     mvs->addMenuItem("def Acceleration", // menu name

--- a/src/modules/utils/panel/screens/cnc/MainMenuScreen.h
+++ b/src/modules/utils/panel/screens/cnc/MainMenuScreen.h
@@ -18,6 +18,7 @@ class MainMenuScreen : public PanelScreen {
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
         PanelScreen * get_watch_screen() const { return watch_screen; }
+        const char* getTitle() { return "Menu"; }
         friend class Panel;
 
     private:

--- a/src/modules/utils/panel/screens/cnc/PrepareScreen.h
+++ b/src/modules/utils/panel/screens/cnc/PrepareScreen.h
@@ -20,6 +20,7 @@ public:
     void display_menu_line(uint16_t line);
     void clicked_menu_entry(uint16_t line);
     int idle_timeout_secs() { return 60; }
+    const char* getTitle() { return "Prepare"; }
 };
 
 #endif

--- a/src/modules/utils/panel/screens/cnc/ProbeScreen.h
+++ b/src/modules/utils/panel/screens/cnc/ProbeScreen.h
@@ -22,6 +22,7 @@ class ProbeScreen : public PanelScreen {
         void display_menu_line(uint16_t line);
         void clicked_menu_entry(uint16_t line);
         int idle_timeout_secs() { return 120; }
+        const char* getTitle() { return "Probe"; }
 
     private:
       int tcnt;


### PR DESCRIPTION
![](https://i.imgur.com/Mg7Kd5v.jpg)

## Changes
* Added titles to the menu screens
* Added a scroll bar
* Inverted the color of the selected item.

## Todo
Right now this breaks the Probe > Status display, because it writes directly to the screen instead of using `display_menu_line()`. I intend to fix this by making a new screen to show the endstop status. This will come as a separate PR.