### PR TITLE
protect probe menu screen from exiting if busy

### DIFF
--- a/src/modules/tools/drillingcycles/Drillingcycles.cpp
+++ b/src/modules/tools/drillingcycles/Drillingcycles.cpp
@@ -98,7 +98,7 @@ void Drillingcycles::update_sticky(Gcode *gcode)
     if (gcode->has_letter('R')) this->sticky_r = gcode->get_value('R');
     if (gcode->has_letter('F')) this->sticky_f = gcode->get_value('F');
     if (gcode->has_letter('Q')) this->sticky_q = gcode->get_value('Q');
-    if (gcode->has_letter('P')) this->sticky_p = gcode->get_int('P');
+    if (gcode->has_letter('P')) this->sticky_p = gcode->get_value('P');
 
     // set retract plane
     if (this->retract_type == RETRACT_TO_Z)
@@ -132,7 +132,7 @@ void Drillingcycles::peck_hole()
     // start values
     float depth  = this->sticky_r - this->sticky_z; // travel depth
     float cycles = depth / this->sticky_q;          // cycles count
-    float rest   = fmod(depth, this->sticky_q);     // final pass
+    float rest   = fmodf(depth, this->sticky_q);     // final pass
     float z_pos  = this->sticky_r;                  // current z position
 
     // for each cycle
@@ -181,7 +181,7 @@ void Drillingcycles::make_hole(Gcode *gcode)
             this->send_gcode("G4 S%u", this->sticky_p);
         // dwell exprimed in milliseconds
         else
-            this->send_gcode("G4 P%u", this->sticky_p);
+            this->send_gcode("G4 P%f", this->sticky_p);
     }
 
     // rapids retract at R-Plane (Initial-Z or R)

--- a/src/modules/tools/drillingcycles/Drillingcycles.h
+++ b/src/modules/tools/drillingcycles/Drillingcycles.h
@@ -39,7 +39,7 @@ class Drillingcycles : public Module
         float sticky_f;     // feedrate
 
         float sticky_q;     // depth increment
-        int   sticky_p;     // dwell pause
+        float sticky_p;     // dwell pause
 
         int   dwell_units;  // units for dwell
 };

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -57,7 +57,7 @@
     Display mode of current grid can be changed to human readable mode (table with coordinates) by using
        leveling-strategy.rectangular-grid.human_readable  true
 
-    For probes like the bltouch yo ucan define a before probe a d after probne GCode sequence (to deploy and stow the probe)
+    For probes like the bltouch you can define a before probe and after probe GCode sequence (to deploy and stow the probe)
         leveling-strategy.rectangular-grid.before_probe_gcode M280
         leveling-strategy.rectangular-grid.after_probe_gcode M281
 
@@ -650,7 +650,7 @@ bool CartGridStrategy::doProbe(Gcode *gc)
 
     gc->stream->printf("Probe start ht: %0.3f mm, start MCS x,y: %0.3f,%0.3f, rectangular bed width,height in mm: %0.3f,%0.3f, grid size: %dx%d\n", zprobe->getProbeHeight(), x_start, y_start, x_size, y_size, current_grid_x_size, current_grid_y_size);
 
-    // do first probe for at start point
+    // do first probe at start point
     float mm;
     if(!zprobe->doProbeAt(mm, this->x_start - X_PROBE_OFFSET_FROM_EXTRUDER, this->y_start - Y_PROBE_OFFSET_FROM_EXTRUDER)) return false;
     float z_reference = zprobe->getProbeHeight() - mm; // this should be zero

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -203,6 +203,7 @@ bool ZProbe::run_probe(float& mm, float feedrate, float max_dist, bool reverse)
 
     // wait until finished
     THECONVEYOR->wait_for_idle();
+    if(THEKERNEL->is_halted()) return false;
 
     // now see how far we moved, get delta in z we moved
     // NOTE this works for deltas as well as all three actuators move the same amount in Z

--- a/src/modules/utils/panel/screens/3dprinter/ProbeScreen.cpp
+++ b/src/modules/utils/panel/screens/3dprinter/ProbeScreen.cpp
@@ -25,6 +25,7 @@ ProbeScreen::ProbeScreen()
     this->do_probe= false;
     this->do_status= false;
     this->new_result= false;
+    this->busy= false;
 }
 
 void ProbeScreen::on_exit()
@@ -32,6 +33,7 @@ void ProbeScreen::on_exit()
     this->do_probe= false;
     this->do_status= false;
     this->new_result= false;
+    this->busy= false;
     delete this;
 }
 
@@ -72,7 +74,7 @@ void ProbeScreen::clicked_menu_entry(uint16_t line)
 {
     this->do_status= false;
     switch ( line ) {
-        case 0: THEPANEL->enter_screen(this->parent); return;
+        case 0: if(!this->busy) THEPANEL->enter_screen(this->parent); return;
         case 1: this->do_status= true; this->tcnt= 1; break;
         case 2: this->do_probe= true; break;
     }
@@ -83,19 +85,23 @@ void ProbeScreen::on_main_loop()
 {
     if (this->do_probe) {
         this->do_probe= false;
+        this->busy= true;
         StringStream string_stream;
         Gcode gcode("G30", &string_stream);
         THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
         this->result= string_stream.getOutput();
         this->new_result= true;
+        this->busy= false;
 
     }else if (this->do_status && --this->tcnt == 0) {
         // this will refresh the results every 10 main loop iterations
         this->tcnt= 10; // update every 10 times
+        this->busy= true;
         StringStream string_stream;
         Gcode gcode("M119", &string_stream);
         THEKERNEL->call_event(ON_GCODE_RECEIVED, &gcode);
         this->result= string_stream.getOutput();
         this->new_result= true;
+        this->busy= false;
     }
 }

--- a/src/modules/utils/panel/screens/3dprinter/ProbeScreen.h
+++ b/src/modules/utils/panel/screens/3dprinter/ProbeScreen.h
@@ -30,6 +30,7 @@ class ProbeScreen : public PanelScreen {
         bool do_probe:1;
         bool do_status:1;
         bool new_result:1;
+        bool busy:1;
       };
 };
 


### PR DESCRIPTION
Add hack to protect panel probe screen from exiting if busy fixes issue #1394 
Fix drilling cycle dwell
Allow $J to handle multiple axis