### PR TITLE
refactor max actuator speeds and acceleration using major axis motion

### DIFF
--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -350,7 +350,7 @@ void Block::prepare(float acceleration_in_steps, float deceleration_in_steps)
         this->tick_info[m].deceleration_change= -(int64_t)round(deceleration_per_tick * aratio);
         this->tick_info[m].plateau_rate= (int64_t)round(((this->maximum_rate * aratio) / STEP_TICKER_FREQUENCY) * STEPTICKER_FPSCALE);
 
-        #if 1
+        #if 0
         THEKERNEL->streams->printf("spt: %08lX %08lX, ac: %08lX %08lX, dc: %08lX %08lX, pr: %08lX %08lX\n",
             (uint32_t)(this->tick_info[m].steps_per_tick>>32), // 2.62 fixed point
             (uint32_t)(this->tick_info[m].steps_per_tick&0xFFFFFFFF), // 2.62 fixed point

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -21,6 +21,9 @@
 #include "mri.h"
 #include <inttypes.h>
 
+#define DEBUG_PRINTF THEKERNEL->streams->printf
+//#define DEBUG_PRINTF(...)
+
 using std::string;
 
 #define STEP_TICKER_FREQUENCY THEKERNEL->step_ticker->get_frequency()
@@ -140,7 +143,7 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
     float initial_rate = this->nominal_rate * (entryspeed / this->nominal_speed); // steps/sec
     float final_rate = this->nominal_rate * (exitspeed / this->nominal_speed);
 
-    THEKERNEL->streams->printf("Initial rate: %f, final_rate: %f\n", initial_rate, final_rate);
+    DEBUG_PRINTF("Initial rate: %f, final_rate: %f\n", initial_rate, final_rate);
 
     // How many steps ( can be fractions of steps, we need very precise values ) to accelerate and decelerate
     // This is a simplification to get rid of rate_delta and get the steps/s² accel directly from the mm/s² accel
@@ -148,7 +151,7 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
 
     float maximum_possible_rate = sqrtf( ( this->steps_event_count * acceleration_per_second ) + ( ( powf(initial_rate, 2) + powf(final_rate, 2) ) / 2.0F ) );
 
-    THEKERNEL->streams->printf("acceleration_per_second: %f, maximum_possible_rate: %f steps/sec, %f mm/sec\n", acceleration_per_second, maximum_possible_rate, maximum_possible_rate/100);
+    DEBUG_PRINTF("acceleration_per_second: %f, maximum_possible_rate: %f steps/sec, %f mm/sec\n", acceleration_per_second, maximum_possible_rate, maximum_possible_rate/100);
 
     // Now this is the maximum rate we'll achieve this move, either because
     // it's the higher we can achieve, or because it's the higher we are
@@ -181,7 +184,8 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
 
     // Figure out how long the move takes total ( in seconds )
     float total_move_time = time_to_accelerate + time_to_decelerate + plateau_time;
-    //puts "total move time: #{total_move_time}s time to accelerate: #{time_to_accelerate}, time to decelerate: #{time_to_decelerate}"
+
+    DEBUG_PRINTF("total move time: %f s, time to accelerate: %f, time to decelerate: %f\n", total_move_time, time_to_accelerate, time_to_decelerate);
 
     // We now have the full timing for acceleration, plateau and deceleration,
     // yay \o/ Now this is very important these are in seconds, and we need to
@@ -351,7 +355,7 @@ void Block::prepare(float acceleration_in_steps, float deceleration_in_steps)
         this->tick_info[m].plateau_rate= (int64_t)round(((this->maximum_rate * aratio) / STEP_TICKER_FREQUENCY) * STEPTICKER_FPSCALE);
 
         #if 0
-        THEKERNEL->streams->printf("spt: %08lX %08lX, ac: %08lX %08lX, dc: %08lX %08lX, pr: %08lX %08lX\n",
+        DEBUG_PRINTF("spt: %08lX %08lX, ac: %08lX %08lX, dc: %08lX %08lX, pr: %08lX %08lX\n",
             (uint32_t)(this->tick_info[m].steps_per_tick>>32), // 2.62 fixed point
             (uint32_t)(this->tick_info[m].steps_per_tick&0xFFFFFFFF), // 2.62 fixed point
             (uint32_t)(this->tick_info[m].acceleration_change>>32), // 2.62 fixed point signed

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -139,14 +139,16 @@ void Block::calculate_trapezoid( float entryspeed, float exitspeed )
 
     float initial_rate = this->nominal_rate * (entryspeed / this->nominal_speed); // steps/sec
     float final_rate = this->nominal_rate * (exitspeed / this->nominal_speed);
-    //printf("Initial rate: %f, final_rate: %f\n", initial_rate, final_rate);
+
+    THEKERNEL->streams->printf("Initial rate: %f, final_rate: %f\n", initial_rate, final_rate);
+
     // How many steps ( can be fractions of steps, we need very precise values ) to accelerate and decelerate
     // This is a simplification to get rid of rate_delta and get the steps/s² accel directly from the mm/s² accel
     float acceleration_per_second = (this->acceleration * this->steps_event_count) / this->millimeters;
 
     float maximum_possible_rate = sqrtf( ( this->steps_event_count * acceleration_per_second ) + ( ( powf(initial_rate, 2) + powf(final_rate, 2) ) / 2.0F ) );
 
-    //printf("id %d: acceleration_per_second: %f, maximum_possible_rate: %f steps/sec, %f mm/sec\n", this->id, acceleration_per_second, maximum_possible_rate, maximum_possible_rate/100);
+    THEKERNEL->streams->printf("acceleration_per_second: %f, maximum_possible_rate: %f steps/sec, %f mm/sec\n", acceleration_per_second, maximum_possible_rate, maximum_possible_rate/100);
 
     // Now this is the maximum rate we'll achieve this move, either because
     // it's the higher we can achieve, or because it's the higher we are
@@ -348,7 +350,7 @@ void Block::prepare(float acceleration_in_steps, float deceleration_in_steps)
         this->tick_info[m].deceleration_change= -(int64_t)round(deceleration_per_tick * aratio);
         this->tick_info[m].plateau_rate= (int64_t)round(((this->maximum_rate * aratio) / STEP_TICKER_FREQUENCY) * STEPTICKER_FPSCALE);
 
-        #if 0
+        #if 1
         THEKERNEL->streams->printf("spt: %08lX %08lX, ac: %08lX %08lX, dc: %08lX %08lX, pr: %08lX %08lX\n",
             (uint32_t)(this->tick_info[m].steps_per_tick>>32), // 2.62 fixed point
             (uint32_t)(this->tick_info[m].steps_per_tick&0xFFFFFFFF), // 2.62 fixed point

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -21,8 +21,8 @@
 #include "mri.h"
 #include <inttypes.h>
 
-#define DEBUG_PRINTF THEKERNEL->streams->printf
-//#define DEBUG_PRINTF(...)
+//#define DEBUG_PRINTF THEKERNEL->streams->printf
+#define DEBUG_PRINTF(...)
 
 using std::string;
 

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -104,7 +104,7 @@ void Conveyor::on_idle(void*)
         } else {
             // Cleanly delete block
             Block* block = queue.tail_ref();
-            //block->debug();
+            block->debug();
             block->clear();
             queue.consume_tail();
         }

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -104,7 +104,7 @@ void Conveyor::on_idle(void*)
         } else {
             // Cleanly delete block
             Block* block = queue.tail_ref();
-            block->debug();
+            //block->debug();
             block->clear();
             queue.consume_tail();
         }

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -84,26 +84,13 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
     // use default JD
     float junction_deviation = this->junction_deviation;
 
-    // use either regular junction deviation or z specific and see if a primary axis move
-    block->primary_axis = true;
-    if(block->steps[ALPHA_STEPPER] == 0 && block->steps[BETA_STEPPER] == 0) {
-        if(block->steps[GAMMA_STEPPER] != 0) {
-            // z only move
-            if(!isnan(this->z_junction_deviation)) junction_deviation = this->z_junction_deviation;
+    // record if this is a primary axis move
+    block->primary_axis = (unit_vec != nullptr);
 
-        } else {
-            // is not a primary axis move
-            block->primary_axis= false;
-            #if N_PRIMARY_AXIS > 3
-                for (int i = 3; i < N_PRIMARY_AXIS; ++i) {
-                    if(block->steps[i] != 0){
-                        block->primary_axis= true;
-                        break;
-                    }
-                }
-            #endif
-
-        }
+    // use either regular junction deviation or z specific
+    if(block->steps[ALPHA_STEPPER] == 0 && block->steps[BETA_STEPPER] == 0 && block->steps[GAMMA_STEPPER] != 0) {
+        // z only move
+        if(!isnan(this->z_junction_deviation)) junction_deviation = this->z_junction_deviation;
     }
 
     block->acceleration = acceleration; // save in block

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1323,7 +1323,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     }
     if(auxilliary_move) {
         distance= sqrtf(sos); // distance in mm of the e move
-        if(distance < 0.00001F) return false; // avoid divide by zero furter on
+        if(distance < 0.00001F) return false; // avoid divide by zero further on
     }
 #endif
 
@@ -1340,7 +1340,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         // actual distance moved for this actuator
         // NOTE for a rotary axis this will be degrees turned not distance
         float d = fabsf(actuator_pos[actuator] - actuators[actuator]->get_last_milestone());
-        if(d == 0 || !actuators[actuator]->is_selected()) continue; // no movement for this actuator
+        if(d < 0.00001F || !actuators[actuator]->is_selected()) continue; // no perceptible movement for this actuator
 
         // find approximate min time this axis needs to move its distance
         float actuator_min_time= d / actuators[actuator]->get_max_rate();

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1349,21 +1349,26 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             // so we decrease the overall feed rate so it can complete within the min time for this actuator
             rate_mm_s= distance / actuator_min_time;
             // recalculate time from new rate
-            secs = distance / rate_mm_s;
+            float new_secs = distance / rate_mm_s;
+            // we need to reduce the acceleration by the same ratio
+            acceleration *= secs/new_secs;
+            secs= new_secs;
         }
+
+        THEKERNEL->streams->printf("act: %d, d: %f, min: %f, rate: %f, secs: %f, acc: %f\n", actuator, d, actuator_min_time, rate_mm_s, secs, acceleration);
 
         // we do not bother with extruder acceleration, becuase if we did in a 3d printer we would always
         // be using the extruders acceleration and not the XY acceleration which is usually a lot higher
         // and extruder moves are usually tiny
-        if(!auxilliary_move && actuators[actuator]->is_extruder()) continue;
+        // if(!auxilliary_move && actuators[actuator]->is_extruder()) continue;
 
-        // select the lowest acceleration of the axis in motion
-        float ma = actuators[actuator]->get_acceleration(); // in mm/sec²
-        if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-            if (acceleration > ma) {
-                acceleration= ma;
-            }
-        }
+        // // select the lowest acceleration of the axis in motion
+        // float ma = actuators[actuator]->get_acceleration(); // in mm/sec²
+        // if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
+        //     if (acceleration > ma) {
+        //         acceleration= ma;
+        //     }
+        // }
     }
 
     // if we are in feed hold wait here until it is released, this means that even segmented lines will pause

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1387,7 +1387,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         // adjust acceleration to not exceed the actuators acceleration
         float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
         if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-            float ca = fabsf((d/distance) * acceleration);
+            float ca = (d/distance) * acceleration;
             // if it exceeds the axis acceleration then we reduce the acceleration by the ratio it is over
             if (ca > ma) {
                 acceleration *= ( ma / ca );

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1291,7 +1291,6 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     int major_axis= 0;
     uint32_t max_steps= 0;
     for (int i = 0; i < n_motors; ++i) {
-        if(deltas[i] == 0) continue;
         // collect the number of steps for each actuator and remember the major axis
         uint32_t s= labs(actuators[i]->steps_to_target(actuator_pos[i]));
         DEBUG_PRINTF("acc: %d, delta: %f, steps: %lu\n", i, deltas[i], s);

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1045,7 +1045,8 @@ void Robot::process_move(Gcode *gcode, enum MOTION_MODE_T motion_mode)
         }
     }
 
-    // process ABC axis, this is mutually exclusive to using E for an extruder, so if E is used and A then the results are undefined
+    // process ABC axis, this is mutually exclusive to using E for an extruder, so if E is used and A
+    // then the results are undefined
     for (int i = A_AXIS; i < n_motors; ++i) {
         char letter= 'A'+i-A_AXIS;
         if(gcode->has_letter(letter)) {
@@ -1337,25 +1338,25 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     }
     if(auxilliary_move) {
         distance= sqrtf(sos); // distance in mm of the e move
-<<<<<<< HEAD
         if(distance < 0.00001F) return false; // avoid divide by zero further on
-=======
-        if(distance < 0.00001F) return false;
->>>>>>> upstreamedge
     }
 #endif
 
     // use default acceleration to start with
     float acceleration = default_acceleration;
 
-    float isecs = rate_mm_s / distance;
+    // this is the time it should take to execute this cartesian move, it is approximate
+    // as it does not take into account accel/decel
+    float secs = distance / rate_mm_s;
 
-    // check per-actuator speed limits
+    // check per-actuator speed limits by looking at the minimum time each axis can move its specified amount
+    // this is regardless of whether it is mm/sec or deg/sec for a rotary axis
     for (size_t actuator = 0; actuator < n_motors; actuator++) {
+        // actual distance moved for this actuator
+        // NOTE for a rotary axis this will be degrees turned not distance
         float d = fabsf(actuator_pos[actuator] - actuators[actuator]->get_last_milestone());
         if(d < 0.00001F || !actuators[actuator]->is_selected()) continue; // no perceptible movement for this actuator
 
-<<<<<<< HEAD
         // find approximate min time this axis needs to move its distance
         float actuator_min_time= d / actuators[actuator]->get_max_rate();
         if (secs < actuator_min_time ) {
@@ -1377,28 +1378,11 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             if (ca > ma) {
                 acceleration *= ( ma / ca );
                 THEKERNEL->streams->printf("new acceleration: %f\n", acceleration);
-=======
-        float actuator_rate= d * isecs;
-        if (actuator_rate > actuators[actuator]->get_max_rate()) {
-            rate_mm_s *= (actuators[actuator]->get_max_rate() / actuator_rate);
-            isecs = rate_mm_s / distance;
-        }
-
-        // adjust acceleration to lowest found, for now just primary axis unless it is an auxiliary move
-        // TODO we may need to do all of them, check E won't limit XYZ.. it does on long E moves, but not checking it could exceed the E acceleration.
-        if(auxilliary_move || actuator < N_PRIMARY_AXIS) {
-            float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
-            if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-                float ca = fabsf((d/distance) * acceleration);
-                if (ca > ma) {
-                    acceleration *= ( ma / ca );
-                }
->>>>>>> upstreamedge
             }
         }
     }
 
-    // if we are in feed hold wait here until it is released, this means that even segemnted lines will pause
+    // if we are in feed hold wait here until it is released, this means that even segmented lines will pause
     while(THEKERNEL->get_feed_hold()) {
         THEKERNEL->call_event(ON_IDLE, this);
         // if we also got a HALT then break out of this
@@ -1467,7 +1451,7 @@ bool Robot::append_line(Gcode *gcode, const float target[], float rate_mm_s, flo
 
     /*
         For extruders, we need to do some extra work to limit the volumetric rate if specified...
-        If using volumetric limts we need to be using volumetric extrusion for this to work as Ennn needs to be in mm³ not mm
+        If using volumetric limits we need to be using volumetric extrusion for this to work as Ennn needs to be in mm³ not mm
         We ask Extruder to do all the work but we need to pass in the relevant data.
         NOTE we need to do this before we segment the line (for deltas)
     */

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -100,6 +100,9 @@
 
 #define PI 3.14159265358979323846F // force to be float, do not use M_PI
 
+#define DEBUG_PRINTF THEKERNEL->streams->printf
+//#define DEBUG_PRINTF(...)
+
 // The Robot converts GCodes into actual movements, and then adds them to the Planner, which passes them to the Conveyor so they can be added to the queue
 // It takes care of cutting arcs into segments, same thing for line that are too long
 
@@ -1354,24 +1357,23 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
                 // a certain speed over the surface.
                 actuator_min_time= std::max(actuator_min_time, d/rate_mm_s);
             }
-            if(actuator >= N_PRIMARY_AXIS) {
+            if(!auxilliary_move && actuator >= N_PRIMARY_AXIS) {
                 // if this is a rotary axis we need to increase the distance
                 distance *= actuator_min_time/secs;
                 secs= actuator_min_time;
-                THEKERNEL->streams->printf("new distance: %f\n", distance);
+                DEBUG_PRINTF("new distance: %f - %d\n", distance, actuator);
             }else{
                 // primary axis we just change the feed rate
                 rate_mm_s= distance / actuator_min_time;
-                THEKERNEL->streams->printf("new rate: %f\n", rate_mm_s);
+                DEBUG_PRINTF("new rate: %f - %d\n", rate_mm_s, actuator);
                 // recalculate time from new rate
-                float new_secs = distance / rate_mm_s;
-                secs= new_secs;
+                secs = distance / rate_mm_s;
             }
         }
 
-        THEKERNEL->streams->printf("act: %d, d: %f, distance: %f, min: %f, rate: %f, secs: %f, acc: %f\n", actuator, d, distance, actuator_min_time, rate_mm_s, secs, acceleration);
+        DEBUG_PRINTF("act: %d, d: %f, distance: %f, min: %f, rate: %f, secs: %f, acc: %f\n", actuator, d, distance, actuator_min_time, rate_mm_s, secs, acceleration);
 
-        // adjust acceleration to not exceed the actuators acceleration, based on the ratio above
+        // adjust acceleration to not exceed the actuators acceleration
         float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
         if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
             float ca = fabsf((d/distance) * acceleration);

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1355,7 +1355,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         // we do not bother with extruder acceleration, becuase if we did in a 3d printer we would always
         // be using the extruders acceleration and not the XY acceleration which is usually a lot higher
         // and extruder moves are usually tiny
-        if(actuators[actuator]->is_extruder()) continue;
+        if(!auxilliary_move && actuators[actuator]->is_extruder()) continue;
 
         // select the lowest acceleration of the axis in motion
         float ma = actuators[actuator]->get_acceleration(); // in mm/sec²

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1348,6 +1348,12 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         if (secs < actuator_min_time ) {
             // this move at the default rate will move too quickly for this actuator
             // so we decrease the overall feed rate so it can complete within the min time for this actuator
+            if(actuator >= N_PRIMARY_AXIS && !actuators[actuator]->is_extruder()) {
+                // if this is a rotary axis we check what the time would be if the given feedrate was
+                // for a solo move in degrees/sec so we do not go faster than that
+                // this is for rotary engraving
+                actuator_min_time= std::max(actuator_min_time, d/rate_mm_s);
+            }
             rate_mm_s= distance / actuator_min_time;
             // recalculate time from new rate
             float new_secs = distance / rate_mm_s;
@@ -1368,6 +1374,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
                 // if it exceeds the axis acceleration then we reduce the acceleration by the ratio it is over
                 if (ca > ma) {
                     acceleration *= ( ma / ca );
+                    THEKERNEL->streams->printf("new acceleration: %f\n", acceleration);
                 }
             } else {
                 // for rotary axis we just select the lowest acceleration as we can't compare the distances

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1352,6 +1352,11 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             secs = distance / rate_mm_s;
         }
 
+        // we do not bother with extruder acceleration, becuase if we did in a 3d printer we would always
+        // be using the extruders acceleration and not the XY acceleration which is usually a lot higher
+        // and extruder moves are usually tiny
+        if(actuators[actuator]->is_extruder()) continue;
+
         // select the lowest acceleration of the axis in motion
         float ma = actuators[actuator]->get_acceleration(); // in mm/sec²
         if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1264,7 +1264,6 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     // do this by finding the major axis based on steps moved not distance
     // if we find a non primary axis (other than E) is moving more than the primary axis
     // we treat it as an auxilliary move
-    bool auxilliary_move= false;
     int major_axis= 0;
     uint32_t max_steps= 0;
     for (int i = 0; i < n_motors; ++i) {
@@ -1280,7 +1279,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
 
     // find the major axis which is the one with the most steps, if
     // this is a non extruder but non primary axis then treat this as an auxilliary move
-    auxilliary_move = (major_axis >= N_PRIMARY_AXIS);
+    bool auxilliary_move = (major_axis >= N_PRIMARY_AXIS);
 
     // total movement, use XYZ if a primary axis otherwise we calculate distance for E after scaling to mm
     float distance= auxilliary_move ? 0 : sqrtf(sos);

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -100,8 +100,8 @@
 
 #define PI 3.14159265358979323846F // force to be float, do not use M_PI
 
-#define DEBUG_PRINTF THEKERNEL->streams->printf
-//#define DEBUG_PRINTF(...)
+//#define DEBUG_PRINTF THEKERNEL->streams->printf
+#define DEBUG_PRINTF(...)
 
 // The Robot converts GCodes into actual movements, and then adds them to the Planner, which passes them to the Conveyor so they can be added to the queue
 // It takes care of cutting arcs into segments, same thing for line that are too long

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1352,19 +1352,11 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             secs = distance / rate_mm_s;
         }
 
-        // we cannot handle acceleration for non linear (ie rotary) actuators the same way
-        // if limiting acceleration for a rotary axis is needed then issue it as a solo move
-        if(actuator >= N_PRIMARY_AXIS && !(auxilliary_move || actuators[actuator]->is_extruder())) continue;
-
-        // adjust acceleration to not exceed the actuators acceleration, based on the ratio it
-        // presents for the overall move (NOTE this may be incorrect)
-        float ma =  actuators[actuator]->get_acceleration(); // in mm/sec²
+        // select the lowest acceleration of the axis in motion
+        float ma = actuators[actuator]->get_acceleration(); // in mm/sec²
         if(!isnan(ma)) {  // if axis does not have acceleration set then it uses the default_acceleration
-            // this is the proportion of the total move scaling the acceleration
-            float ca = fabsf((d/distance) * acceleration);
-            // if it exceeds the axis acceleration then we reduce the acceleration by the ratio it is over
-            if (ca > ma) {
-                acceleration *= ( ma / ca );
+            if (acceleration > ma) {
+                acceleration= ma;
             }
         }
     }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -100,8 +100,8 @@
 
 #define PI 3.14159265358979323846F // force to be float, do not use M_PI
 
-#define DEBUG_PRINTF THEKERNEL->streams->printf
-//#define DEBUG_PRINTF(...)
+//#define DEBUG_PRINTF THEKERNEL->streams->printf
+#define DEBUG_PRINTF(...)
 
 // The Robot converts GCodes into actual movements, and then adds them to the Planner, which passes them to the Conveyor so they can be added to the queue
 // It takes care of cutting arcs into segments, same thing for line that are too long
@@ -1392,7 +1392,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
             // if it exceeds the axis acceleration then we reduce the acceleration by the ratio it is over
             if (ca > ma) {
                 acceleration *= ( ma / ca );
-                THEKERNEL->streams->printf("new acceleration: %f\n", acceleration);
+                DEBUG_PRINTF("new acceleration: %f\n", acceleration);
             }
         }
     }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1301,8 +1301,6 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         }
     }
 
-    DEBUG_PRINTF("major axis is : %d, sos: %f\n", major_axis, sos);
-
     // find the major axis which is the one with the most steps, if
     // this is an extruder solo move or an ABC move then treat this as an auxilliary move
     // if it is an extruder move but ther eis any XYZ move it is not treated as an auxillairy
@@ -1319,6 +1317,8 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
         // ABC axis is major axis or a solo extruder move then it is an auxilliary move
         auxilliary_move= true;
     }
+
+    DEBUG_PRINTF("major axis is : %d, sos: %f, aux_move: %d\n", major_axis, sos, auxilliary_move);
 
     // total movement, use XYZ if a primary axis otherwise we calculate distance for E after scaling to mm
     // or ABC

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1308,6 +1308,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
 
     // total movement, use XYZ if a primary axis otherwise we calculate distance for E after scaling to mm
     // or ABC
+    // TODO optimize this to avoid doing both sqrts and taking sqrt of 0
     float p_distance= sqrtf(xyz_sos);
     float a_distance= sqrtf(abc_sos);
     float distance;
@@ -1328,7 +1329,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
 
     }else if(xyz_sos >= 0.25F) { // this is about 0.5mm
         // it is a ABC axis move but there is a significant XYZ move so not an auxilliary move
-        // but we use the ABC movement as distance
+        // but we use the ABC movement as distance (as A is the major axis)
         auxilliary_move= false;
         distance= a_distance;
 


### PR DESCRIPTION
A correct fix to the rotary actuator acceleration issue, for instance ```G1 X0.001 A360```.

It turned out this was actually a planner issue, where step generation uses a major axis (the one with the most steps) for all its calculations, but it expects the distance to be related to that major axis.
Now we calculate and pass the distance for the major axis, keeping that contract in place. This means that we decide if this is a primary axis move or auxiliary moved based on the major axis.