### PR TITLE
Feature: Add option to skip suspend gcode when head is above specific height

### DIFF
--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -44,6 +44,8 @@ class Player : public Module {
         string after_suspend_gcode;
         string before_resume_gcode;
         string on_boot_gcode;
+        uint16_t block_susp_gcode_height;
+
         StreamOutput* current_stream;
         StreamOutput* reply_stream;
 


### PR DESCRIPTION
Hello,

This is a reimplementation of a feature present in bundled firmware of 3dQuality Delta printer  (that firmware is based on Smoothieware, but I do not have source code for).

**Description:**
It is common for suspend gcode to include head lifting while moving away from the model.
On a Delta printer, when the print head is homed (top most position) and the suspend code is run, it can force the carriages out of bounds.

This problem is specific to Detla printers.

This PR adds a config option `block_susp_gcode_height`. 
If set, the suspend gcode will not run, if the printhead is above `block_susp_gcode_height` at the time.

By default, the height is set sufficiently high (65meters) as to disable this feature and make run gcode as usual.

Tested on Re-Arm board Delta printer. 