### PR TITLE
Feature/Endstop Release Before Homing

### DIFF
--- a/ConfigSamples/Snippets/abc-endstop.config
+++ b/ConfigSamples/Snippets/abc-endstop.config
@@ -9,6 +9,7 @@ endstop.minx.max_travel                      500              # the maximum trav
 endstop.minx.fast_rate                       50               # fast homing rate in mm/sec
 endstop.minx.slow_rate                       25               # slow homing rate in mm/sec
 endstop.minx.retract                         5                # bounce off endstop in mm
+endstop.minx.release_first                   false            # first move away from endstop until released
 
 # uncomment for homing to max and comment the minx above
 #endstop.maxx.enable                          true             # enable an endstop
@@ -20,6 +21,7 @@ endstop.minx.retract                         5                # bounce off endst
 #endstop.maxx.fast_rate                       50               # fast homing rate in mm/sec
 #endstop.maxx.slow_rate                       25               # slow homing rate in mm/sec
 #endstop.maxx.retract                         5                # bounce off endstop in mm
+#endstop.maxx.release_first                   false            # first move away from endstop until released
 
 endstop.miny.enable                          true             # enable an endstop
 endstop.miny.pin                             1.26             # pin
@@ -30,6 +32,7 @@ endstop.miny.max_travel                      500              # the maximum trav
 endstop.miny.fast_rate                       50               # fast homing rate in mm/sec
 endstop.miny.slow_rate                       25               # slow homing rate in mm/sec
 endstop.miny.retract                         5                # bounce off endstop in mm
+endstop.miny.release_first                   false            # first move away from endstop until released
 
 # uncomment for homing to max and comment the min above
 #endstop.maxy.enable                          true             # enable an endstop
@@ -41,6 +44,7 @@ endstop.miny.retract                         5                # bounce off endst
 #endstop.maxy.fast_rate                       50               # fast homing rate in mm/sec
 #endstop.maxy.slow_rate                       25               # slow homing rate in mm/sec
 #endstop.maxy.retract                         5                # bounce off endstop in mm
+#endstop.maxy.release_first                   false            # first move away from endstop until released
 
 endstop.minz.enable                          true             # enable an endstop
 endstop.minz.pin                             1.28             # pin
@@ -51,6 +55,7 @@ endstop.minz.max_travel                      100              # the maximum trav
 endstop.minz.fast_rate                       10               # fast homing rate in mm/sec
 endstop.minz.slow_rate                       2                # slow homing rate in mm/sec
 endstop.minz.retract                         5                # bounce off endstop in mm
+endstop.minz.release_first                   false            # first move away from endstop until released
 
 # uncomment for homing to max and comment the min above
 #endstop.maxz.enable                          true             # enable an endstop
@@ -62,6 +67,7 @@ endstop.minz.retract                         5                # bounce off endst
 #endstop.maxz.fast_rate                       10               # fast homing rate in mm/sec
 #endstop.maxz.slow_rate                       2                # slow homing rate in mm/sec
 #endstop.maxz.retract                         5                # bounce off endstop in mm
+#endstop.maxz.release_first                   false            # first move away from endstop until released
 
 # optional enable limit switches, actions will stop if any enabled limit switch is triggered
 #endstop.minx.limit_enable                   false            # set to true to enable the limit on this endstop
@@ -84,6 +90,7 @@ endstop.minz.retract                         5                # bounce off endst
 #endstop.mina.fast_rate                       10               # fast homing rate in mm/sec
 #endstop.mina.slow_rate                       2                # slow homing rate in mm/sec
 #endstop.mina.retract                         5                # bounce off endstop in mm
+#endstop.mina.release_first                   false            # first move away from endstop until released
 
 # type of machine
 #corexy_homing                               false            # set to true if homing on a hbot or corexy

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -657,6 +657,7 @@ void Endstops::home(axis_bitmap_t a)
 
     this->axis_to_home= a;
 
+    // Check if any of the axes have  "release_first" enabled and prepare to move these
     float delta[homing_axis.size()];
     for (size_t i = 0; i < homing_axis.size(); ++i) delta[i] = 0;
     
@@ -673,7 +674,7 @@ void Endstops::home(axis_bitmap_t a)
     }
 
     if (do_release) {
-      // If "release_first" is enabled, start moving the axes away from the endstops until the switches are released
+      // If "release_first" was enabled for any one axis, start moving these axes away from the endstops until the switches are released
       this->status = MOVING_FROM_ENDSTOP_FAST;
 
       THEROBOT->disable_segmentation = true; // we must disable segmentation as this won't work with it enabled

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -589,7 +589,7 @@ uint32_t Endstops::read_endstops(uint32_t dummy)
 
         if(STEPPER[m]->is_moving()) {
             // if it is moving then we check the associated endstop, and debounce it
-            if(pin_logic_state == (e.pin_info->pin.get() != 0)) {
+            if(pin_logic_state == e.pin_info->pin.get()) {
                 if(e.pin_info->debounce < debounce_ms) {
                     e.pin_info->debounce++;
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -657,11 +657,6 @@ void Endstops::home(axis_bitmap_t a)
 
     this->axis_to_home= a;
 
-    THEROBOT->disable_segmentation = true; // we must disable segmentation as this won't work with it enabled
-
-    // If "release_first" is enabled, start moving the axes away from the endstops until the switches are released
-    this->status = MOVING_FROM_ENDSTOP_FAST;
-    
     float delta[homing_axis.size()];
     for (size_t i = 0; i < homing_axis.size(); ++i) delta[i] = 0;
     
@@ -678,6 +673,11 @@ void Endstops::home(axis_bitmap_t a)
     }
 
     if (do_retract) {
+      // If "release_first" is enabled, start moving the axes away from the endstops until the switches are released
+      this->status = MOVING_FROM_ENDSTOP_FAST;
+
+      THEROBOT->disable_segmentation = true; // we must disable segmentation as this won't work with it enabled
+
       THEROBOT->delta_move(delta, feed_rate, homing_axis.size());
       // wait until finished
       THECONVEYOR->wait_for_idle();
@@ -697,6 +697,8 @@ void Endstops::home(axis_bitmap_t a)
 
     // Start moving the axes to the origin
     this->status = MOVING_TO_ENDSTOP_FAST;
+
+    THEROBOT->disable_segmentation= true; // we must disable segmentation as this won't work with it enabled
 
     if(!home_z_first) home_xy();
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -661,18 +661,18 @@ void Endstops::home(axis_bitmap_t a)
     for (size_t i = 0; i < homing_axis.size(); ++i) delta[i] = 0;
     
     float feed_rate = homing_axis[X_AXIS].fast_rate;
-    bool do_retract = false;
+    bool do_release = false;
     for (auto& i : homing_axis) {
       int c = i.axis_index;
       if (axis_to_home[c] && i.release_first_enable) {
         delta[c] = i.max_travel; // we go the max
         if (!i.home_direction) delta[c] = -delta[c];
         feed_rate = std::min(i.fast_rate, feed_rate);
-        do_retract = true;
+        do_release = true;
       }
     }
 
-    if (do_retract) {
+    if (do_release) {
       // If "release_first" is enabled, start moving the axes away from the endstops until the switches are released
       this->status = MOVING_FROM_ENDSTOP_FAST;
 
@@ -692,6 +692,12 @@ void Endstops::home(axis_bitmap_t a)
           THEROBOT->disable_segmentation = false;
           return;
         }
+      }
+
+      // after this, again reset debounce counts for all endstops
+      for (auto& e : endstops) {
+        e->debounce = 0;
+        e->triggered = false;
       }
     }
 

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -76,6 +76,7 @@ class Endstops : public Module{
                 uint8_t axis_index:3;
                 bool home_direction:1; // true min or false max
                 bool homed:1;
+                bool release_first_enable:1;
             };
         };
 


### PR DESCRIPTION
### Description

In some machines the homing switch is not mounted at the end of the working range, but in the middle. i.e. for half the working range, the switch is engaged. The actual use case is a dual nozzle Pick and Place machine, where [one physical actuator is shared to create the two nozzles' "virtual" Z axes in a counterweight, seesaw or rocker configuration](https://github.com/openpnp/openpnp/wiki/GcodeDriver:-Axis-Mapping#axis-transforms) (when one is moving up, the other is moving down). 

When homing the machine, the state of the homing switch might therefore already be active. The retract distance might not be enough to move the axis out of the switch active range or conversely, we cannot just increase the retract distance because this might cause a collision (e.g. ramming one of the nozzles into an obstacle) if the initial position was already close to the switch or over. 

Therefore, a new config option is created to first move the axis in the opposite direction until the switch is released. Only then is the actual homing cycle commenced. 

The following video shows the result. The switch is pressed as long as the (shiny black) coding bar is present i.e. as long as the right nozzle is down. The nozzle is first moved up until the end of the coding bar is reached. Only then the actual homing takes place.

![endstop_first_release](https://user-images.githubusercontent.com/9963310/63649877-77e8ea00-c743-11e9-9f84-32a87d20a042.gif)
(footage credits: Mike Menci)

The new option is only available for [the modern 6axis endstop syntax](http://smoothieware.org/6axis) and defaults to false. It follows the following syntax pattern. In order to enable it, change it to true. 

`endstop.minx.release_first                   false            # first move away from endstop until released`

### Justification and Credits

A [similar change](https://groups.google.com/d/msg/openpnp/QpSp-ONilcM/LIX1WXWJBgAJ) was made by Jason, founder of OpenPNP. As the underlying code was rewritten soon after that, dual nozzle users (a majority I guess) were stuck with Jason's July 2016 version and can't benefit from any of Smoothieware's improvements. This PR aims to change that. 

### Implementation

The implementation follows the existing code and style closely and strives to be minimal. 

The config snippet is updated to include the new option. 

### Testing 

Initial testing was done on an actual machine (see Video) but it is ongoing, and we will document progress in the conversation below (if welcome).

See also:
https://groups.google.com/d/msg/openpnp/2zbqS_uHGAg/76zeHIfXDwAJ
