### PR TITLE
take care of kill button pressed when setting halted to false

### DIFF
--- a/src/modules/utils/killbutton/KillButton.h
+++ b/src/modules/utils/killbutton/KillButton.h
@@ -8,6 +8,8 @@ class KillButton : public Module {
 
         void on_module_loaded();
         void on_idle(void *argument);
+        void on_get_public_data(void* argument);
+        
         uint32_t button_tick(uint32_t dummy);
 
     private:

--- a/src/modules/utils/killbutton/KillButtonPublicAccess.h
+++ b/src/modules/utils/killbutton/KillButtonPublicAccess.h
@@ -1,0 +1,8 @@
+#ifndef __KILLBUTTONPUBLICACCESS_H_
+#define __KILLBUTTONPUBLICACCESS_H_
+
+// addresses used for public data access
+#define killbutton_checksum               CHECKSUM("killbutton")
+#define killbutton_is_pressed_checksum    CHECKSUM("killbutton_pressed")
+
+#endif


### PR DESCRIPTION
Proposed patch for the issue in Bugreport  #1424

Issue: 
Press the killswitch and hold it down.
Now homing via $H clears the halted flag even if the killswitch is still pressed.

From my point of view clearing the halted flag while the source that caused the flag to be set is still active is not correct. 
Before clearing it should be checked if the cause is still active.

Another possible fix would be that KillSwitch subscribes to ON_HALT and sets the flag again if the button is still pressed. But thats ugly, too ;)