### PR TITLE
respect pushed kill button when trying to leave halted state

### DIFF
--- a/src/modules/utils/killbutton/KillButton.cpp
+++ b/src/modules/utils/killbutton/KillButton.cpp
@@ -89,7 +89,13 @@ uint32_t KillButton::button_tick(uint32_t dummy)
                 if(killed) state= KILLED_BUTTON_DOWN;
                 break;
             case KILLED_BUTTON_DOWN:
-                if(this->kill_button.get()) state= KILLED_BUTTON_UP;
+                if (this->kill_button.get()) {
+                    state= KILLED_BUTTON_UP;
+                } else if ((toggle_enable) && (!killed)) {
+                    // button is still pressed but the halted state was left
+                    // re-trigger the halted state
+                    state= KILL_BUTTON_DOWN;
+                }                    
                 break;
             case KILLED_BUTTON_UP:
                 if(!killed) state= IDLE;


### PR DESCRIPTION
Proposed patch for the issue in Bugreport #1424

Issue:
Press the killswitch and hold it down.
Now homing via $H clears the halted flag even if the killswitch is still pressed.

From my point of view clearing the halted flag while the source that caused the flag to be set is still active is not correct.
Before clearing it should be checked if the cause is still active.

This patch fixes that, when homing while the kill button is pressed and the button is configured with toggle the system will enter the halted state again.