### PR TITLE
initial attempt to handle the step rounding error accumulation.

### DIFF
--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -71,14 +71,12 @@ void StepperMotor::change_steps_per_mm(float new_steps)
     steps_per_mm = new_steps;
     mm_per_step = 1.0F / steps_per_mm;
     // we need to adjust the last_milestone_steps to be the same position it currently is in mm
-    last_milestone_steps = lroundf(apos * steps_per_mm);
-    current_position_steps = last_milestone_steps;
+    change_last_milestone(apos);
 }
 
 void StepperMotor::change_last_milestone(float new_milestone)
 {
-    last_milestone_steps = lroundf(new_milestone * steps_per_mm);
-    current_position_steps = last_milestone_steps;
+    set_last_milestones(lroundf(new_milestone * steps_per_mm));
 }
 
 void StepperMotor::set_last_milestones(int32_t steps)

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -39,11 +39,11 @@ class StepperMotor  : public Module {
         float get_steps_per_mm()  const { return steps_per_mm; }
         void change_steps_per_mm(float);
         void change_last_milestone(float);
-        void set_last_milestones(float, int32_t);
-        void update_last_milestones(float mm, int32_t steps);
-        float get_last_milestone(void) const { return last_milestone_mm; }
+        void set_last_milestones(int32_t);
+        void update_last_milestones(int32_t steps);
+        float get_last_milestone(void) const { return last_milestone_steps * mm_per_step; }
         int32_t get_last_milestone_steps(void) const { return last_milestone_steps; }
-        float get_current_position(void) const { return (float)current_position_steps/steps_per_mm; }
+        float get_current_position(void) const { return (float)current_position_steps * mm_per_step; }
         uint32_t get_current_step(void) const { return current_position_steps; }
         float get_max_rate(void) const { return max_rate; }
         void set_max_rate(float mr) { max_rate= mr; }
@@ -67,12 +67,12 @@ class StepperMotor  : public Module {
 
         float steps_per_second;
         float steps_per_mm;
+        float mm_per_step;
         float max_rate; // this is not really rate it is in mm/sec, misnamed used in Robot and Extruder
         float acceleration;
 
         volatile int32_t current_position_steps;
         int32_t last_milestone_steps;
-        float   last_milestone_mm;
 
         volatile struct {
             uint8_t motor_id:8;

--- a/src/modules/robot/Planner.cpp
+++ b/src/modules/robot/Planner.cpp
@@ -60,7 +60,7 @@ bool Planner::append_block( ActuatorCoordinates &actuator_pos, uint8_t n_motors,
         int32_t steps = THEROBOT->actuators[i]->steps_to_target(actuator_pos[i]);
         // Update current position
         if(steps != 0) {
-            THEROBOT->actuators[i]->update_last_milestones(actuator_pos[i], steps);
+            THEROBOT->actuators[i]->update_last_milestones(steps);
             has_steps = true;
         }
 

--- a/src/modules/tools/extruder/Extruder.cpp
+++ b/src/modules/tools/extruder/Extruder.cpp
@@ -201,7 +201,7 @@ void Extruder::save_position()
 void Extruder::restore_position()
 {
     THEROBOT->reset_axis_position(std::get<0>(this->saved_position), motor_id);
-    stepper_motor->set_last_milestones(std::get<1>(this->saved_position), std::get<2>(this->saved_position));
+    stepper_motor->set_last_milestones(std::get<2>(this->saved_position));
 }
 
 // check against maximum speeds and return the rate modifier


### PR DESCRIPTION
This takes into account the actual actuator position based on the integral number of steps, and uses that to figure out the delta move for the target position, and converts that delta to steps.

This should mitigate the rare issue where rounding up (or down) a move into steps will accumulate an error over time if the same move is done hundreds of times.