### PR TITLE
Slave motors AND endstops

### DIFF
--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -43,7 +43,7 @@ StepperMotor::~StepperMotor()
     THEKERNEL->unregister_for_event(ON_HALT, this);
     THEKERNEL->unregister_for_event(ON_ENABLE, this);
 
-    if(has_slave) {
+    if(has_slave()) {
         slave->~StepperMotor();
     }
 }
@@ -74,7 +74,7 @@ void StepperMotor::change_steps_per_mm(float new_steps)
     steps_per_mm = new_steps;
     last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
-    if (has_slave) {
+    if (has_slave()) {
         slave->change_steps_per_mm(new_steps);
     }
 }
@@ -84,7 +84,7 @@ void StepperMotor::change_last_milestone(float new_milestone)
     last_milestone_mm = new_milestone;
     last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
-    if (has_slave) {
+    if (has_slave()) {
         slave->change_last_milestone(new_milestone);
     }
 }
@@ -94,7 +94,7 @@ void StepperMotor::set_last_milestones(float mm, int32_t steps)
     last_milestone_mm= mm;
     last_milestone_steps= steps;
     current_position_steps= last_milestone_steps;
-    if (has_slave) {
+    if (has_slave()) {
         slave->set_last_milestones(mm, steps);
     }
 }
@@ -103,7 +103,7 @@ void StepperMotor::update_last_milestones(float mm, int32_t steps)
 {
     last_milestone_steps += steps;
     last_milestone_mm = mm;
-    if (has_slave) {
+    if (has_slave()) {
         slave->update_last_milestones(mm, steps);
     }
 }
@@ -137,7 +137,7 @@ void StepperMotor::manual_step(bool dir)
     // keep track of actuators actual position in steps
     this->current_position_steps += (dir ? -1 : 1);
 
-    if (has_slave) {
+    if (has_slave()) {
         slave->manual_step(dir);
     }
 }

--- a/src/libs/StepperMotor.cpp
+++ b/src/libs/StepperMotor.cpp
@@ -42,6 +42,10 @@ StepperMotor::~StepperMotor()
 {
     THEKERNEL->unregister_for_event(ON_HALT, this);
     THEKERNEL->unregister_for_event(ON_ENABLE, this);
+
+    if(has_slave) {
+        slave->~StepperMotor();
+    }
 }
 
 void StepperMotor::on_halt(void *argument)
@@ -70,6 +74,9 @@ void StepperMotor::change_steps_per_mm(float new_steps)
     steps_per_mm = new_steps;
     last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
+    if (has_slave) {
+        slave->change_steps_per_mm(new_steps);
+    }
 }
 
 void StepperMotor::change_last_milestone(float new_milestone)
@@ -77,6 +84,9 @@ void StepperMotor::change_last_milestone(float new_milestone)
     last_milestone_mm = new_milestone;
     last_milestone_steps = lroundf(last_milestone_mm * steps_per_mm);
     current_position_steps = last_milestone_steps;
+    if (has_slave) {
+        slave->change_last_milestone(new_milestone);
+    }
 }
 
 void StepperMotor::set_last_milestones(float mm, int32_t steps)
@@ -84,12 +94,18 @@ void StepperMotor::set_last_milestones(float mm, int32_t steps)
     last_milestone_mm= mm;
     last_milestone_steps= steps;
     current_position_steps= last_milestone_steps;
+    if (has_slave) {
+        slave->set_last_milestones(mm, steps);
+    }
 }
 
 void StepperMotor::update_last_milestones(float mm, int32_t steps)
 {
     last_milestone_steps += steps;
     last_milestone_mm = mm;
+    if (has_slave) {
+        slave->update_last_milestones(mm, steps);
+    }
 }
 
 int32_t StepperMotor::steps_to_target(float target)
@@ -120,4 +136,8 @@ void StepperMotor::manual_step(bool dir)
 
     // keep track of actuators actual position in steps
     this->current_position_steps += (dir ? -1 : 1);
+
+    if (has_slave) {
+        slave->manual_step(dir);
+    }
 }

--- a/src/libs/StepperMotor.h
+++ b/src/libs/StepperMotor.h
@@ -23,13 +23,13 @@ class StepperMotor  : public Module {
         void set_slave(StepperMotor* s) { slave = s; }
 
         // called from step ticker ISR
-        inline bool step() { step_pin.set(1); if (has_slave) slave->step(); current_position_steps += (direction?-1:1); return moving; }
+        inline bool step() { step_pin.set(1); if (has_slave()) slave->step(); current_position_steps += (direction?-1:1); return moving; }
         // called from unstep ISR
-        inline void unstep() { step_pin.set(0); if (has_slave) slave->unstep(); }
+        inline void unstep() { step_pin.set(0); if (has_slave()) slave->unstep(); }
         // called from step ticker ISR
-        inline void set_direction(bool f) { dir_pin.set(f); if (has_slave) slave->set_direction(f); direction= f; }
+        inline void set_direction(bool f) { dir_pin.set(f); if (has_slave()) slave->set_direction(f); direction= f; }
 
-        void enable(bool state) { en_pin.set(!state); if (has_slave) slave->enable(state); };
+        void enable(bool state) { en_pin.set(!state); if (has_slave()) slave->enable(state); };
         bool is_enabled() const { return !en_pin.get(); };
         bool is_moving() const { return moving; };
         void start_moving() { moving= true; }

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -142,10 +142,10 @@ void Robot::on_module_loaded()
     CHECKSUM(X "_en_pin"),          \
     CHECKSUM(X "_steps_per_mm"),    \
     CHECKSUM(X "_max_rate"),        \
-    CHECKSUM(X "_acceleration")     \
+    CHECKSUM(X "_acceleration"),     \
     CHECKSUM(X "_slave_step_pin"),  \
     CHECKSUM(X "_slave_dir_pin"),   \
-    CHECKSUM(X "_slave_en_pin"),    \
+    CHECKSUM(X "_slave_en_pin")    \
 }
 
 void Robot::load_config()
@@ -212,7 +212,7 @@ void Robot::load_config()
     this->s_value             = THEKERNEL->config->value(laser_module_default_power_checksum)->by_default(0.8F)->as_number();
 
      // Make our Primary XYZ StepperMotors, and potentially A B C
-    uint16_t const motor_checksums[][6] = {
+    uint16_t const motor_checksums[][9] = {
         ACTUATOR_CHECKSUMS("alpha"), // X
         ACTUATOR_CHECKSUMS("beta"),  // Y
         ACTUATOR_CHECKSUMS("gamma"), // Z
@@ -250,8 +250,8 @@ void Robot::load_config()
 
         // does this motor have a slave?
         Pin slave_pins[3]; //step, dir, enable
-        for (size_t i = 6; i < 9; i++) {
-            slave_pins[i].from_string(THEKERNEL->config->value(motor_checksums[a][i])->by_default("nc")->as_string())->as_output();
+        for (size_t i = 0; i < 3; i++) {
+            slave_pins[i].from_string(THEKERNEL->config->value(motor_checksums[a][i+6])->by_default("nc")->as_string())->as_output();
         }
 
         if(slave_pins[0].connected() && slave_pins[1].connected()) { // step and dir must be defined, but enable is optional

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -60,6 +60,8 @@ class Endstops : public Module{
                 char axis:8; // one of XYZABC
                 uint8_t axis_index:3;
                 bool limit_enable:1;
+                bool master_triggered:1;
+                bool slave_triggered:1;
                 bool triggered:1;
             };
         };

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -53,8 +53,10 @@ class Endstops : public Module{
         // per endstop settings
         using endstop_info_t = struct {
             Pin pin;
+            Pin slavePin;
             struct {
                 uint16_t debounce:16;
+                uint16_t slaveDebounce:16;
                 char axis:8; // one of XYZABC
                 uint8_t axis_index:3;
                 bool limit_enable:1;


### PR DESCRIPTION
I'll keep this short and sweet. I don't full expect this to be merged upstream, but just want everyone to know it's here if they need it.

I'm building a CNC using smoothie and have 2 motors for both my Y and Z axis. I wanted to add the ability to use endstops to square the gantry. Marlin has this functionality. 

This change allows each stepper to define a slave, and each endstop may define a slave that controls the slave stepper. The slave endstops only trigger on homing actions, the master switch may still be used as a hard limit. This type of configuration only makes sense on cartesian frames and is completely optional. To use the slave stepper, simply define the slave step, direction, and enable pins:
```
alpha_slave_step_pin
alpha_slave_dir_pin
alpha_slave_en_pin
```
Using slave endstops requires using the new syntax. This would technically work with A,B,C axis if you had a board with that many outputs. I'm using external drivers, so any output pins will work. All that is needed is:
`endstop.minx.slave_pin`

That's pretty much all there is to it. You can slave the motor without using a slaved endstop, but in that case there really is no point. I would love to turn this into a self contained module, but I don't think that is possible.