### PR TITLE
Add support OLED sh1106

### DIFF
--- a/src/modules/utils/panel/Panel.cpp
+++ b/src/modules/utils/panel/Panel.cpp
@@ -49,6 +49,7 @@
 #define viki2_checksum             CHECKSUM("viki2")
 #define mini_viki2_checksum        CHECKSUM("mini_viki2")
 #define universal_adapter_checksum CHECKSUM("universal_adapter")
+#define sh1106_oled_checksum      CHECKSUM("sh1106_oled")
 
 #define menu_offset_checksum        CHECKSUM("menu_offset")
 #define encoder_resolution_checksum CHECKSUM("encoder_resolution")
@@ -128,6 +129,8 @@ void Panel::on_module_loaded()
         this->lcd = new ST7565(3); // variant 3
     } else if (lcd_cksm == universal_adapter_checksum) {
         this->lcd = new UniversalAdapter();
+    } else if (lcd_cksm == sh1106_oled_checksum) {
+        this->lcd = new ST7565(4); // variant 4
     } else {
         // no known lcd type defined
         delete this;

--- a/src/modules/utils/panel/panels/ST7565.h
+++ b/src/modules/utils/panel/panels/ST7565.h
@@ -89,6 +89,7 @@ private:
         bool is_viki2:1;
         bool is_mini_viki2:1;
         bool is_ssd1306:1;
+        bool is_sh1106:1;
         bool use_pause:1;
         bool use_back:1;
         bool text_background:1;


### PR DESCRIPTION
Add support OLED sh1106, based on rejected #1142  and current code.
For use need set
```
panel.lcd                                   sh1106_oled     
panel.spi_channel                           0                 
panel.spi_cs_pin      0.16                     
panel.a0_pin                                1.23  #or other
panel.rst_pin                               2.11   #or other
```