### PR TITLE
Add PT100 with a simple ADC to Temp conversion

### DIFF
--- a/ConfigSamples/Snippets/pt100.config
+++ b/ConfigSamples/Snippets/pt100.config
@@ -1,0 +1,6 @@
+temperature_control.hotend.enable               true
+temperature_control.hotend.sensor               pt100
+temperature_control.hotend.amplifier_pin        0.23
+temperature_control.hotend.baseline_temp        100           # where the ADC reading was taken, 100C is recommended
+temperature_control.hotend.baseline_adc_value   4500          # LM358 gets 4500 at 100C, E3D amplifier with INA826 amp gets 4900
+temperature_control.hotend.adc_delta_per_degree 41            # LM358 gets 41/deg, E3D amplifier with INA826 amp gets 13/deg

--- a/src/modules/tools/temperaturecontrol/PT100.cpp
+++ b/src/modules/tools/temperaturecontrol/PT100.cpp
@@ -1,0 +1,69 @@
+#include "PT100.h"
+#include "libs/Kernel.h"
+#include "libs/Pin.h"
+#include "Config.h"
+#include "checksumm.h"
+#include "Adc.h"
+#include "ConfigValue.h"
+#include "StreamOutputPool.h"
+
+#include <fastmath.h>
+
+#define UNDEFINED -1
+
+#define amplifier_pin_checksum CHECKSUM("amplifier_pin")      //adc pin
+#define baseline_temp_checksum CHECKSUM("baseline_temp")      // baseline temperature
+#define baselineadc_checksum CHECKSUM("baseline_adc_value")   // adc output at baseline temperature
+#define adcdeltadeg_checksum CHECKSUM("adc_delta_per_degree") // adc delta per degree
+
+PT100::PT100()
+{
+    this->min_temp = 400;
+    this->max_temp = 0;
+}
+PT100::~PT100()
+{
+}
+void PT100::UpdateConfig(uint16_t module_checksum, uint16_t name_checksum)
+{
+    this->amplifier_pin.from_string(THEKERNEL->config->value(module_checksum, name_checksum, amplifier_pin_checksum)->required()->as_string());
+    this->baseline_temp = THEKERNEL->config->value(module_checksum, name_checksum, baseline_temp_checksum)->by_default(100)->as_number();
+    this->baseline_adc_value = THEKERNEL->config->value(module_checksum, name_checksum, baselineadc_checksum)->by_default(4500)->as_number();
+    this->adc_delta_deg = THEKERNEL->config->value(module_checksum, name_checksum, adcdeltadeg_checksum)->by_default(41)->as_number();
+
+    THEKERNEL->adc->enable_pin(&amplifier_pin);
+}
+
+float PT100::get_temperature()
+{
+    float t = adc_value_to_temperature(get_adc_reading());
+    // keep track of min/max for M305
+    if (t > max_temp)
+        max_temp = t;
+    if (t < min_temp)
+        min_temp = t;
+    return t;
+}
+
+void PT100::get_raw()
+{
+    int adc_value = get_adc_reading();
+    float t = adc_value_to_temperature(adc_value);
+    THEKERNEL->streams->printf("PT100: adc= %d, baseTemp= %f, delta/deg=%d, baseAdc=%d, temp= %f\n", 
+                                adc_value,this->baseline_temp,this->adc_delta_deg,this->baseline_adc_value, t);
+    // reset the min/max
+    min_temp = max_temp = t;
+}
+
+int PT100::get_adc_reading()
+{
+    return THEKERNEL->adc->read(&amplifier_pin);
+}
+
+float PT100::adc_value_to_temperature(uint32_t adc_value)
+{
+    //PT100 indicates it has 100Ω resistance at 0C. It is supposed to have a very linear resistnace curve.
+    //ADC in Smoothie board is pretty linear with 10bit precision.
+    //the formula below uses that facto, and calculates temperature given baseline temp, adc reading and per degree adc slope
+    return ((adc_value - this->baseline_adc_value * 1.0) / this->adc_delta_deg) + this->baseline_temp;
+}

--- a/src/modules/tools/temperaturecontrol/PT100.h
+++ b/src/modules/tools/temperaturecontrol/PT100.h
@@ -1,0 +1,31 @@
+#ifndef PT100_H
+#define PT100_H
+
+#include "TempSensor.h"
+#include "Pin.h"
+
+#define QUEUE_LEN 32
+
+class StreamOutput;
+
+class PT100 : public TempSensor
+{
+public:
+    PT100();
+    ~PT100();
+
+    // TempSensor interface.
+    void UpdateConfig(uint16_t module_checksum, uint16_t name_checksum);
+    float get_temperature();
+    void get_raw(); //called from M305
+
+private:
+    int get_adc_reading();
+    float adc_value_to_temperature(uint32_t adc_value);
+    Pin amplifier_pin;
+    float min_temp, max_temp;
+    float baseline_temp;
+    int baseline_adc_value;
+    int adc_delta_deg;
+};
+#endif

--- a/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
+++ b/src/modules/tools/temperaturecontrol/TemperatureControl.cpp
@@ -31,7 +31,7 @@
 #include "max31855.h"
 #include "AD8495.h"
 #include "PT100_E3D.h"
-
+#include "PT100.h"
 #include "MRI_Hooks.h"
 
 #define UNDEFINED -1
@@ -188,6 +188,8 @@ void TemperatureControl::load_config()
         sensor = new AD8495();
     } else if(sensor_type.compare("pt100_e3d") == 0) {
         sensor = new PT100_E3D();
+    } else if(sensor_type.compare("pt100") == 0) {
+        sensor = new PT100();
     } else {
         sensor = new TempSensor(); // A dummy implementation
     }


### PR DESCRIPTION
This is a more generic implementation of PT100. PT100 is a PTC which had to be used with an amplifier. Existing Smoothie supports PT100 from E3D, but not other opamps. This will support any amp as long as user can provide a baseline ADC measurements.

The basic assumption of the code is 
1. PT100 has a very linear resistance to temperature relationship (usually  α = 0.003925 for pure platinum based sensors).
2. ADC in Smoothieboard (or LPC1768) provides a linear conversions i.e. the chnage in ADC value is linear with respect to temperature. 
3. The opamp used are linear between the range we would be using (150-350C)

Thus given a baseline temperature and ADC delta/degree we should be able to calculate the temperature. 

Tn = (ADCn - ADCb) / ADCd + Tb, where  Tn is new temperature,  ADCn is ADC value measured at Tn, ADCb is baseline ADC value at Tb, and ADCd is the change in ADC value per Degree - configured

The sample config given has values for LM358 opamp or INA826 used by E3D product. Any other new opamp implementations would need to provide ADCb, Tb and ADCd values. 


Tests:
1. Have verified using a PT100 on a tiertime printer using Tinyfab board (LPC1768 CPU, LM358 OpAmp), with a DMM thermocouple inserted inside the nozzle. 
2. Tried to match the volt and temps publised by E3D for their PT100 board, with a 3.3V rail to rail opamp.

Note: Previous attempt for adding LM358 opamp based PT100 board (#1086) was not successful given the complex nature of code and not being compatible with E3D. This is independent attempt.