### PR TITLE
Various changes affecting rotary delta and rotary delta calibration.

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1225,7 +1225,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
 
                 //} else if(soft_endstop_truncate) {
                     // TODO VERY hard to do need to go back and change the target, and calculate intercept with the edge
-                    // and store all preceding vectors that have on eor more points ourtside of bounds so we can create a propper clip against the boundaries
+                    // and store all preceding vectors that have one or more points outside of bounds so we can create a proper clip against the boundaries
 
                 } else {
                     // ignore it
@@ -1298,6 +1298,8 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     ActuatorCoordinates actuator_pos;
     if(!disable_arm_solution) {
         arm_solution->cartesian_to_actuator( transformed_target, actuator_pos );
+        // some arm solutions can indicate a halt if the calcs go bad
+        if(THEKERNEL->is_halted()) return false;
 
     }else{
         // basically the same as cartesian, would be used for special homing situations like for scara

--- a/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
@@ -54,7 +54,7 @@ RotaryDeltaSolution::RotaryDeltaSolution(Config *config)
     tool_offset = config->value(tool_offset_checksum)->by_default(30.500F)->as_number();
 
     // mirror the XY axis
-    mirror_xy= config->value(delta_mirror_xy_checksum)->by_default(true)->as_bool();
+    mirror_xy= config->value(delta_mirror_xy_checksum)->by_default(false)->as_bool();
 
     debug_flag= false;
     init();

--- a/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
+++ b/src/modules/robot/arm_solutions/RotaryDeltaSolution.cpp
@@ -20,6 +20,7 @@
 #define tool_offset_checksum            CHECKSUM("delta_tool_offset")
 
 #define delta_mirror_xy_checksum        CHECKSUM("delta_mirror_xy")
+#define delta_halt_on_error_checksum    CHECKSUM("delta_halt_on_error")
 
 const static float pi     = 3.14159265358979323846;    // PI
 const static float two_pi = 2 * pi;
@@ -55,6 +56,8 @@ RotaryDeltaSolution::RotaryDeltaSolution(Config *config)
 
     // mirror the XY axis
     mirror_xy= config->value(delta_mirror_xy_checksum)->by_default(false)->as_bool();
+
+    halt_on_error= config->value(delta_halt_on_error_checksum)->by_default(true)->as_bool();
 
     debug_flag= false;
     init();
@@ -178,6 +181,12 @@ void RotaryDeltaSolution::cartesian_to_actuator(const float cartesian_mm[], Actu
             THEKERNEL->streams->printf("// CalcZ= %f\n", z_calc_offset);
             THEKERNEL->streams->printf("// Offz= %f\n", z_with_offset);
         }
+
+        if(halt_on_error) {
+            THEKERNEL->streams->printf("error: RotaryDelta illegal move. reset or $X or M999 required\n");
+            THEKERNEL->call_event(ON_HALT, nullptr);
+        }
+
     } else {
         actuator_mm[ALPHA_STEPPER] = alpha_theta;
         actuator_mm[BETA_STEPPER ] = beta_theta;

--- a/src/modules/robot/arm_solutions/RotaryDeltaSolution.h
+++ b/src/modules/robot/arm_solutions/RotaryDeltaSolution.h
@@ -33,5 +33,6 @@ class RotaryDeltaSolution : public BaseSolution {
         struct {
             bool debug_flag:1;
             bool mirror_xy:1;
+            bool halt_on_error:1;
         };
 };

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -1139,18 +1139,16 @@ void Endstops::on_gcode_received(void *argument)
 
             case 500: // save settings
             case 503: // print settings
-                if(!is_rdelta) {
-                    gcode->stream->printf(";Home offset (mm):\nM206 ");
-                    for (auto &p : homing_axis) {
-                        if(p.pin_info == nullptr) continue; // ignore if not a homing endstop
-                        gcode->stream->printf("%c%1.2f ", p.axis, p.home_offset);
-                    }
-                    gcode->stream->printf("\n");
-
+                if(is_rdelta) {
+                    gcode->stream->printf(";Theta offset (degrees):\nM206 ");
                 }else{
-                    gcode->stream->printf(";Theta offset (degrees):\nM206 A%1.5f B%1.5f C%1.5f\n",
-                        homing_axis[X_AXIS].home_offset, homing_axis[Y_AXIS].home_offset, homing_axis[Z_AXIS].home_offset);
+                    gcode->stream->printf(";Home offset (mm):\nM206 ");
                 }
+                for (auto &p : homing_axis) {
+                    if(p.pin_info == nullptr) continue; // ignore if not a homing endstop
+                    gcode->stream->printf("%c%1.5f ", p.axis, p.home_offset);
+                }
+                gcode->stream->printf("\n");
 
                 if (this->is_delta || this->is_scara) {
                     gcode->stream->printf(";Trim (mm):\nM666 X%1.3f Y%1.3f Z%1.3f\n", trim_mm[0], trim_mm[1], trim_mm[2]);

--- a/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
+++ b/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
@@ -64,7 +64,7 @@ void RotaryDeltaCalibration::on_gcode_received(void *argument)
                 // between what it thinks is the current angle and what the current angle actually is specified by X (ditto for Y and Z)
 
                 ActuatorCoordinates current_angle;
-                // get the current angle for each actuator
+                // get the current angle for each actuator, relies on being left where probe triggered (G30.1)
                 // NOTE we only deal with XYZ so if there are more than 3 actuators this will probably go wonky
                 for (size_t i = 0; i < 3; i++) {
                     current_angle[i]= THEROBOT->actuators[i]->get_current_position();

--- a/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
+++ b/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
@@ -93,19 +93,19 @@ void RotaryDeltaCalibration::on_gcode_received(void *argument)
                 //figure out what home_offset needs to be to correct the homing_position
                 if (gcode->has_letter('X')) {
                     float a = gcode->get_value('X'); // what actual angle is
-                    theta_offset[0] -= (current_angle[0] - a);
+                    theta_offset[0] += (a - current_angle[0]);
                     current_angle[0]= a;
                     cnt++;
                 }
                 if (gcode->has_letter('Y')) {
                     float b = gcode->get_value('Y');
-                    theta_offset[1] -= (current_angle[1] - b);
+                    theta_offset[1] += (b - current_angle[1]);
                     current_angle[1]= b;
                     cnt++;
                 }
                 if (gcode->has_letter('Z')) {
                     float c = gcode->get_value('Z');
-                    theta_offset[2] -= (current_angle[2] - c);
+                    theta_offset[2] += (c - current_angle[2]);
                     current_angle[2]= c;
                     cnt++;
                 }

--- a/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
+++ b/src/modules/tools/rotarydeltacalibration/RotaryDeltaCalibration.cpp
@@ -47,37 +47,39 @@ void RotaryDeltaCalibration::on_gcode_received(void *argument)
                 }
 
                 // set theta offset
-                if (gcode->has_letter('A')) theta_offset[0] = gcode->get_value('A');
-                if (gcode->has_letter('B')) theta_offset[1] = gcode->get_value('B');
-                if (gcode->has_letter('C')) theta_offset[2] = gcode->get_value('C');
+                if (gcode->has_letter('X')) theta_offset[0] = gcode->get_value('X');
+                if (gcode->has_letter('Y')) theta_offset[1] = gcode->get_value('Y');
+                if (gcode->has_letter('Z')) theta_offset[2] = gcode->get_value('Z');
 
                 PublicData::set_value( endstops_checksum, home_offset_checksum, theta_offset );
 
-                gcode->stream->printf("Theta offset set: A %8.5f B %8.5f C %8.5f\n", theta_offset[0], theta_offset[1], theta_offset[2]);
+                gcode->stream->printf("Theta offset set: X %8.5f Y %8.5f Z %8.5f\n", theta_offset[0], theta_offset[1], theta_offset[2]);
 
                 break;
             }
 
             case 306: {
                 // for a rotary delta M306 calibrates the homing angle
-                // by doing M306 A-56.17 it will calculate the M206 A value (the theta offset for actuator A) based on the difference
-                // between what it thinks is the current angle and what the current angle actually is specified by A (ditto for B and C)
+                // by doing M306 X-56.17 it will calculate the M206 X value (the theta offset for actuator X) based on the difference
+                // between what it thinks is the current angle and what the current angle actually is specified by X (ditto for Y and Z)
 
                 ActuatorCoordinates current_angle;
-                // get the current angle for each actuator, NOTE we only deal with  ABC so if there are more than 3 actuators this will probably go wonky
+                // get the current angle for each actuator, NOTE we only deal with XYZ so if there are more than 3 actuators this will probably go wonky
                 for (size_t i = 0; i < 3; i++) {
                     current_angle[i]= THEROBOT->actuators[i]->get_current_position();
                 }
 
                 if (gcode->has_letter('L') && gcode->get_value('L') != 0) {
-                    // specifying L1 it will take the last probe position (set by G30 or G38.x ) and set the home offset based on that
-                    // this allows the use of G30 to find the angle tool
+                    // specifying L1 it will take the last probe position (set by G30) and set the home offset based on that
+                    // this allows the use of G30 to find the angle tool and M306 X0 to set X
                     uint8_t ok;
                     std::tie(current_angle[0], current_angle[1], current_angle[2], ok) = THEROBOT->get_last_probe_position();
                     if(ok == 0) {
                         gcode->stream->printf("error:Nothing set as probe failed or not run\n");
                         return;
                     }
+                    // only Z is set by G30, but all will be the same amount moved
+                    current_angle[0]= current_angle[1]= current_angle[2];
                 }
 
                 float theta_offset[3];
@@ -89,20 +91,20 @@ void RotaryDeltaCalibration::on_gcode_received(void *argument)
                 int cnt= 0;
 
                 //figure out what home_offset needs to be to correct the homing_position
-                if (gcode->has_letter('A')) {
-                    float a = gcode->get_value('A'); // what actual angle is
+                if (gcode->has_letter('X')) {
+                    float a = gcode->get_value('X'); // what actual angle is
                     theta_offset[0] -= (current_angle[0] - a);
                     current_angle[0]= a;
                     cnt++;
                 }
-                if (gcode->has_letter('B')) {
-                    float b = gcode->get_value('B');
+                if (gcode->has_letter('Y')) {
+                    float b = gcode->get_value('Y');
                     theta_offset[1] -= (current_angle[1] - b);
                     current_angle[1]= b;
                     cnt++;
                 }
-                if (gcode->has_letter('C')) {
-                    float c = gcode->get_value('C');
+                if (gcode->has_letter('Z')) {
+                    float c = gcode->get_value('Z');
                     theta_offset[2] -= (current_angle[2] - c);
                     current_angle[2]= c;
                     cnt++;
@@ -119,7 +121,7 @@ void RotaryDeltaCalibration::on_gcode_received(void *argument)
                     gcode->stream->printf("NOTE: actuator position NOT reset\n");
                 }
 
-                gcode->stream->printf("Theta Offset: A %8.5f B %8.5f C %8.5f\n", theta_offset[0], theta_offset[1], theta_offset[2]);
+                gcode->stream->printf("Theta Offset: X %8.5f Y %8.5f Z %8.5f\n", theta_offset[0], theta_offset[1], theta_offset[2]);
             }
         }
     }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -281,8 +281,8 @@ void ZProbe::on_gcode_received(void *argument)
             float rate= gcode->has_letter('F') ? gcode->get_value('F') / 60 : this->slow_feedrate;
             float mm;
 
-            // if not setting Z then return probe to where it started, otherwise leave it where it is
-            probe_result = (set_z ? run_probe(mm, rate, -1, reverse) : run_probe_return(mm, rate, -1, reverse));
+            // if not setting Z ( and not subcode 1) then return probe to where it started, otherwise leave it where it is
+            probe_result = ((set_z || gcode->subcode == 1) ? run_probe(mm, rate, -1, reverse) : run_probe_return(mm, rate, -1, reverse));
 
             if(probe_result) {
                 // the result is in actuator coordinates moved

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -210,6 +210,7 @@ bool ZProbe::run_probe(float& mm, float feedrate, float max_dist, bool reverse)
     mm= z_start_pos - THEROBOT->actuators[2]->get_current_position();
 
     // set the last probe position to the actuator units moved during this home
+    // TODO maybe we should store current actuator position rather than the delta?
     THEROBOT->set_last_probe_position(std::make_tuple(0, 0, mm, probe_detected?1:0));
 
     probing= false;

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1148,8 +1148,8 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
          }
         stream->printf("done\n");
 
-    }else if (what == "raw") {
-        // issues raw steps to the specified axis usage: axis steps steps/sec
+    }else if (what == "raw" || what == "acc") {
+        // issues raw steps (or acctuator units) to the specified axis usage: axis steps steps/sec
         string axis = shift_parameter( parameters );
         string stepstr = shift_parameter( parameters );
         string stepspersec = shift_parameter( parameters );
@@ -1175,6 +1175,13 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
         }
 
         uint32_t sps= strtol(stepspersec.c_str(), NULL, 10);
+
+        if(what == "acc") {
+            // convert actuator units to steps
+            steps= THEROBOT->actuators[a]->get_steps_per_mm() * steps;
+            // convert steps per unit to steps/sec
+            sps= THEROBOT->actuators[a]->get_steps_per_mm() * sps;
+        }
         sps= std::max(sps, 1UL);
 
         uint32_t delayus= 1000000.0F / sps;
@@ -1191,7 +1198,7 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
         //stream->printf("done\n");
 
     }else if (what == "pulse") {
-        // issues a step pulse then wqiats then unsteps, for testing when stepper moves
+        // issues a step pulse then waits then unsteps, for testing when stepper moves
         string axis = shift_parameter( parameters );
         string reps = shift_parameter( parameters );
         if(axis.empty()) {
@@ -1239,6 +1246,7 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
         stream->printf(" test square size iterations [feedrate]\n");
         stream->printf(" test circle radius iterations [feedrate]\n");
         stream->printf(" test raw axis steps steps/sec\n");
+        stream->printf(" test acc axis units units/sec\n");
         stream->printf(" test pulse axis iterations\n");
     }
 }

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1149,7 +1149,7 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
         stream->printf("done\n");
 
     }else if (what == "raw" || what == "acc") {
-        // issues raw steps (or acctuator units) to the specified axis usage: axis steps steps/sec
+        // issues raw steps (or actuator units) to the specified axis usage: axis steps steps/sec
         string axis = shift_parameter( parameters );
         string stepstr = shift_parameter( parameters );
         string stepspersec = shift_parameter( parameters );
@@ -1178,9 +1178,9 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
 
         if(what == "acc") {
             // convert actuator units to steps
-            steps= THEROBOT->actuators[a]->get_steps_per_mm() * steps;
+            steps= lroundf(THEROBOT->actuators[a]->get_steps_per_mm() * steps);
             // convert steps per unit to steps/sec
-            sps= THEROBOT->actuators[a]->get_steps_per_mm() * sps;
+            sps= lroundf(THEROBOT->actuators[a]->get_steps_per_mm() * sps);
         }
         sps= std::max(sps, 1UL);
 

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -1161,7 +1161,7 @@ void SimpleShell::test_command( string parameters, StreamOutput *stream)
         char ax= toupper(axis[0]);
         uint8_t a= ax >= 'X' ? ax - 'X' : ax - 'A' + 3;
         int steps= strtol(stepstr.c_str(), NULL, 10);
-        bool dir= steps >= 0;
+        bool dir= steps <= 0;
         steps= std::abs(steps);
 
         if(a > C_AXIS) {


### PR DESCRIPTION
Other than adding G30.1 (which leaves Z where probe triggered), and `test acc`,  none of these should affect any other arm solution other than rotary delta (which is very rarely used).
I found these changes helped getting rotary delta calibrated, and in some cases fixed errors in the rotary delta calibration.
NOTE for M206 and M306 for rotary delta changed parameters to the usual  XYZ instead of ABC which made no sense with the 6 axis addition.