### PR TITLE
Fix hard limits (issue #1463)

### DIFF
--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -318,6 +318,7 @@ void Kernel::register_for_event(_EVENT_ENUM id_event, Module *mod)
 
 // This will stop the que and stop further commands, and stop motors
 // Optionally used before on_halt() is sent to do a quick stop
+// May be called from an ISR
 void Kernel::immediate_halt()
 {
     this->halted = true;

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -316,6 +316,15 @@ void Kernel::register_for_event(_EVENT_ENUM id_event, Module *mod)
     this->hooks[id_event].push_back(mod);
 }
 
+// This will stop the que and stop further commands, and stop motors
+// Optionally used before on_halt() is sent to do a quick stop
+void Kernel::immediate_halt()
+{
+    this->halted = true;
+    conveyor->flush_queue(); // make sure no queued up codes get through
+    for(auto &a : robot->actuators) a->stop_moving();
+}
+
 // Call a specific event with an argument
 void Kernel::call_event(_EVENT_ENUM id_event, void * argument)
 {

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -56,6 +56,7 @@ class Kernel {
         bool is_feed_hold_enabled() const { return enable_feed_hold; }
         void set_bad_mcu(bool b) { bad_mcu= b; }
         bool is_bad_mcu() const { return bad_mcu; }
+        void immediate_halt();
 
         std::string get_query_string();
 

--- a/src/modules/robot/Conveyor.cpp
+++ b/src/modules/robot/Conveyor.cpp
@@ -87,6 +87,7 @@ void Conveyor::start(uint8_t n)
 void Conveyor::on_halt(void* argument)
 {
     if(argument == nullptr) {
+        // marks queue to be flushed next time get_next_block() is called
         flush_queue();
     }
 }
@@ -199,6 +200,7 @@ bool Conveyor::get_next_block(Block **block)
         while (queue.isr_tail_i != queue.head_i) {
             queue.isr_tail_i = queue.next(queue.isr_tail_i);
         }
+        flush = false;
     }
 
     // default the feerate to zero if there is no block available
@@ -244,11 +246,6 @@ void Conveyor::flush_queue()
     flush= true;
 
     // TODO force deceleration of last block
-
-    // now wait until the block queue has been flushed
-    wait_for_idle(false);
-
-    flush= false;
 }
 
 // Debug function

--- a/src/modules/robot/Conveyor.h
+++ b/src/modules/robot/Conveyor.h
@@ -49,10 +49,10 @@ private:
     size_t queue_size;
     float current_feedrate{0}; // actual nominal feedrate that current block is running at in mm/sec
 
-    struct {
+    volatile struct {
         volatile bool running:1;
         volatile bool allow_fetch:1;
-        bool flush:1;
+        volatile bool flush:1;
     };
 
 };

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -570,10 +570,10 @@ void Endstops::check_limits()
     // check if any limit switches were hit
     for(auto& i : endstops) {
         if(!i->limit_enable) continue;
-        int m= i->axis_index;
+        uint8_t m= i->axis_index;
         bool moving= false;
-        if(is_corexy) {
-            // corexy either stepper moving can result in movement towards a limit
+        if(is_corexy && m < 2) {
+            // corexy either X or Y stepper moving can result in movement towards a limit
             moving=  STEPPER[0]->is_moving() || STEPPER[1]->is_moving();
         } else {
             moving= STEPPER[m]->is_moving();
@@ -589,8 +589,8 @@ void Endstops::check_limits()
                 THEKERNEL->immediate_halt();
                 trigger_halt= true;
                 // remember what axis triggered it (first one wins)
-                // NOTE gives incorrect result on corexy
-                triggered_axis[0]= is_corexy ? '?' : STEPPER[m]->which_direction() ? '-' : '+';
+                // NOTE gives incorrect result on corexy need to use fk to figure it out
+                triggered_axis[0]= (is_corexy && m < 2) ? '?' : STEPPER[m]->which_direction() ? '-' : '+';
                 triggered_axis[1]= i->axis;
                 triggered_axis[2]= '\0';
                 return;

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -433,7 +433,7 @@ void Endstops::on_idle(void*)
 
     } else if(this->limits_activated) {
         this->limits_activated= false;
-        THEKERNEL->streams->printf("// NOTICE hard limits are now active\n");
+        THEKERNEL->streams->printf("// NOTICE hard limits are now enabled\n");
     }
 }
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -108,6 +108,7 @@ Endstops::Endstops()
 {
     this->status = NOT_HOMING;
     this->trigger_halt= false;
+    this->limits_activated= false;
 }
 
 void Endstops::on_module_loaded()
@@ -429,6 +430,10 @@ void Endstops::on_idle(void*)
 
         // disables heaters and motors
         THEKERNEL->call_event(ON_HALT, nullptr);
+
+    } else if(this->limits_activated) {
+        this->limits_activated= false;
+        THEKERNEL->streams->printf("// NOTICE hard limits are now active\n");
     }
 }
 
@@ -553,6 +558,7 @@ void Endstops::check_limits()
         if(all_clear) {
             // clear the state
             this->status = NOT_HOMING;
+            this->limits_activated= true;
         }
         return;
 

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -593,7 +593,7 @@ void Endstops::check_limits()
                 // remember what axis triggered it (first one wins)
                 // TODO gives incorrect result on corexy need to use fk to figure it out
                 triggered_direction= STEPPER[m]->which_direction();
-                triggered_axis= i->axis>='X' ? i->axis-'X' : i->axis-'A' + 3;
+                triggered_axis= m;
                 return;
             }
         }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -569,8 +569,9 @@ void Endstops::check_limits()
                 this->status = LIMIT_TRIGGERED;
                 i->debounce= 0;
 
-                // we cannot call on_halt here but must defer it to on_idle, however we can stop all the motors here
-                for(auto &a : THEROBOT->actuators) a->stop_moving();
+                // we cannot call on_halt here but must defer it to on_idle,
+                // however we can stop incoming commands and stop all the motors here
+                THEKERNEL->immediate_halt();
                 trigger_halt= true;
                 // remember what axis triggered it (first one wins)
                 triggered_axis[0]= STEPPER[i->axis_index]->which_direction() ? '-' : '+';

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -591,7 +591,7 @@ void Endstops::check_limits()
                 THEKERNEL->immediate_halt();
                 trigger_halt= true;
                 // remember what axis triggered it (first one wins)
-                // NOTE gives incorrect result on corexy need to use fk to figure it out
+                // TODO gives incorrect result on corexy need to use fk to figure it out
                 triggered_direction= STEPPER[m]->which_direction();
                 triggered_axis= i->axis>='X' ? i->axis-'X' : i->axis-'A' + 3;
                 return;

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -421,10 +421,12 @@ void Endstops::on_idle(void*)
 {
     if(trigger_halt) {
         trigger_halt= false;
+        char d= triggered_direction ? '-' : '+';
+        char a= triggered_axis < 3 ? 'X' + triggered_axis : 'A' + triggered_axis-3;
         if(!THEKERNEL->is_grbl_mode()) {
-            THEKERNEL->streams->printf("Limit switch %s was hit\n", triggered_axis);
+            THEKERNEL->streams->printf("Limit switch %c%c was hit\n", d, a);
         }else{
-            THEKERNEL->streams->printf("ALARM: Hard limit %s\n", triggered_axis);
+            THEKERNEL->streams->printf("ALARM: Hard limit %c%c\n", d, a);
         }
         THEKERNEL->streams->printf("// NOTICE limits are disabled until all have been cleared\n");
 
@@ -590,9 +592,8 @@ void Endstops::check_limits()
                 trigger_halt= true;
                 // remember what axis triggered it (first one wins)
                 // NOTE gives incorrect result on corexy need to use fk to figure it out
-                triggered_axis[0]= (is_corexy && m < 2) ? '?' : STEPPER[m]->which_direction() ? '-' : '+';
-                triggered_axis[1]= i->axis;
-                triggered_axis[2]= '\0';
+                triggered_direction= STEPPER[m]->which_direction();
+                triggered_axis= i->axis>='X' ? i->axis-'X' : i->axis-'A' + 3;
                 return;
             }
         }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -535,7 +535,7 @@ void Endstops::move_to_origin(axis_bitmap_t axis)
     this->status = NOT_HOMING;
 }
 
-// called in ISR context
+// called in ISR contexte
 void Endstops::check_limits()
 {
     if(this->status == LIMIT_TRIGGERED) {
@@ -611,7 +611,9 @@ uint32_t Endstops::read_endstops(uint32_t dummy)
         if(e.pin_info == nullptr) continue; // ignore if not a homing endstop
         int m= e.axis_index;
 
-        // for corexy homing in X or Y we must only check the associated endstop, works as we only home one axis at a time for corexy
+        // for corexy homing in X or Y we must only check the associated endstop,
+        // this works as we only home one axis at a time for corexy
+        // and a straight move means both actuators move
         if(is_corexy && (m == X_AXIS || m == Y_AXIS) && !axis_to_home[m]) continue;
 
         if(STEPPER[m]->is_moving()) {

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -421,12 +421,13 @@ void Endstops::on_idle(void*)
     if(trigger_halt) {
         trigger_halt= false;
         if(!THEKERNEL->is_grbl_mode()) {
-            THEKERNEL->streams->printf("Limit switch %s was hit - reset or M999 required\n", triggered_axis);
+            THEKERNEL->streams->printf("Limit switch %s was hit", triggered_axis);
         }else{
-            THEKERNEL->streams->printf("ALARM: Hard limit %s\n", triggered_axis);
+            THEKERNEL->streams->printf("ALARM: Hard limit %s", triggered_axis);
         }
+        THEKERNEL->streams->printf(". WARNING limits are disabled until all have been cleared\n");
 
-        // disables heaters and motors, ignores incoming GCode and flushes block queue
+        // disables heaters and motors
         THEKERNEL->call_event(ON_HALT, nullptr);
     }
 }

--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -422,11 +422,11 @@ void Endstops::on_idle(void*)
     if(trigger_halt) {
         trigger_halt= false;
         if(!THEKERNEL->is_grbl_mode()) {
-            THEKERNEL->streams->printf("Limit switch %s was hit", triggered_axis);
+            THEKERNEL->streams->printf("Limit switch %s was hit\n", triggered_axis);
         }else{
-            THEKERNEL->streams->printf("ALARM: Hard limit %s", triggered_axis);
+            THEKERNEL->streams->printf("ALARM: Hard limit %s\n", triggered_axis);
         }
-        THEKERNEL->streams->printf(". WARNING limits are disabled until all have been cleared\n");
+        THEKERNEL->streams->printf("// NOTICE limits are disabled until all have been cleared\n");
 
         // disables heaters and motors
         THEKERNEL->call_event(ON_HALT, nullptr);

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -100,5 +100,6 @@ class Endstops : public Module{
             bool park_after_home:1;
             bool limit_enabled:1;
             volatile bool trigger_halt:1;
+            volatile bool limits_activated:1;
         };
 };

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -41,6 +41,7 @@ class Endstops : public Module{
         void set_homing_offset(Gcode* gcode);
         uint32_t read_endstops(uint32_t dummy);
         void handle_park();
+        void on_idle(void*);
 
         // global settings
         float saved_position[3]{0}; // save G28 (in grbl mode)
@@ -49,6 +50,7 @@ class Endstops : public Module{
         axis_bitmap_t axis_to_home;
 
         float trim_mm[3];
+        char triggered_axis[3]{0};
 
         // per endstop settings
         using endstop_info_t = struct {
@@ -97,5 +99,6 @@ class Endstops : public Module{
             bool move_to_origin_after_home:1;
             bool park_after_home:1;
             bool limit_enabled:1;
+            volatile bool trigger_halt:1;
         };
 };

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -35,7 +35,7 @@ class Endstops : public Module{
         void move_to_origin(axis_bitmap_t axis);
         void on_get_public_data(void* argument);
         void on_set_public_data(void* argument);
-        void on_idle(void *argument);
+        void check_limits();
         bool debounced_get(Pin *pin);
         void process_home_command(Gcode* gcode);
         void set_homing_offset(Gcode* gcode);
@@ -96,5 +96,6 @@ class Endstops : public Module{
             bool home_z_first:1;
             bool move_to_origin_after_home:1;
             bool park_after_home:1;
+            bool limit_enabled:1;
         };
 };

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -100,7 +100,7 @@ class Endstops : public Module{
             bool limit_enabled:1;
             volatile bool trigger_halt:1;
             volatile bool limits_activated:1;
-            char triggered_axis:3;
-            char triggered_direction:1;
+            uint8_t triggered_axis:3;
+            bool triggered_direction:1;
         };
 };

--- a/src/modules/tools/endstops/Endstops.h
+++ b/src/modules/tools/endstops/Endstops.h
@@ -50,7 +50,6 @@ class Endstops : public Module{
         axis_bitmap_t axis_to_home;
 
         float trim_mm[3];
-        char triggered_axis[3]{0};
 
         // per endstop settings
         using endstop_info_t = struct {
@@ -101,5 +100,7 @@ class Endstops : public Module{
             bool limit_enabled:1;
             volatile bool trigger_halt:1;
             volatile bool limits_activated:1;
+            char triggered_axis:3;
+            char triggered_direction:1;
         };
 };

--- a/src/modules/tools/spindle/HuanyangSpindleControl.cpp
+++ b/src/modules/tools/spindle/HuanyangSpindleControl.cpp
@@ -5,7 +5,7 @@
       You should have received a copy of the GNU General Public License along with Smoothie. If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* 
+/*
     Hunayang RS485 communication protocol
 
     originally found on cnczone.nl, posted by Rikkepic:
@@ -20,7 +20,7 @@
     PD164   1   RS485 Baud rate: 9600
     PD165   3   RS485 Mode: RTU, 8N1
 
-    == Function Read == 
+    == Function Read ==
 
     ADDR    CMD     LEN     PAR     DATA        CRC
     0x01    0x01    0x03    0xA5    0x00 0x00   0x2C 0x6D       Read PD165 (165=0xA5)
@@ -76,7 +76,7 @@
 #include "gpio.h"
 #include "Modbus.h"
 
-void HuanyangSpindleControl::turn_on() 
+void HuanyangSpindleControl::turn_on()
 {
     // prepare data for the spindle off command
     char turn_on_msg[6] = { 0x01, 0x03, 0x01, 0x01, 0x00, 0x00 };
@@ -90,7 +90,7 @@ void HuanyangSpindleControl::turn_on()
     modbus->delay(1);
     // send the actual message
     modbus->serial->write(turn_on_msg, sizeof(turn_on_msg));
-    // wait a calculated time for the data to be sent 
+    // wait a calculated time for the data to be sent
     modbus->delay((int) ceil(sizeof(turn_on_msg) * modbus->delay_time));
     // disable transmitter
     modbus->dir_output->clear();
@@ -100,7 +100,8 @@ void HuanyangSpindleControl::turn_on()
 
 }
 
-void HuanyangSpindleControl::turn_off() 
+// FIXME this cannot call delay() as it calls on_idle and this can be called from on_idle so recursion
+void HuanyangSpindleControl::turn_off()
 {
     // prepare data for the spindle off command
     char turn_off_msg[6] = { 0x01, 0x03, 0x01, 0x08, 0x00, 0x00 };
@@ -114,7 +115,7 @@ void HuanyangSpindleControl::turn_off()
     modbus->delay(1);
     // send the actual message
     modbus->serial->write(turn_off_msg, sizeof(turn_off_msg));
-    // wait a calculated time for the data to be sent 
+    // wait a calculated time for the data to be sent
     modbus->delay((int) ceil(sizeof(turn_off_msg) * modbus->delay_time));
     // disable transmitter
     modbus->dir_output->clear();
@@ -124,13 +125,13 @@ void HuanyangSpindleControl::turn_off()
 
 }
 
-void HuanyangSpindleControl::set_speed(int target_rpm) 
+void HuanyangSpindleControl::set_speed(int target_rpm)
 {
 
     // prepare data for the set speed command
     char set_speed_msg[7] = { 0x01, 0x05, 0x02, 0x00, 0x00, 0x00, 0x00 };
     // convert RPM into Hz
-    unsigned int hz = target_rpm / 60 * 100; 
+    unsigned int hz = target_rpm / 60 * 100;
     set_speed_msg[3] = (hz >> 8);
     set_speed_msg[4] = hz & 0xFF;
     // calculate CRC16 checksum
@@ -143,7 +144,7 @@ void HuanyangSpindleControl::set_speed(int target_rpm)
     modbus->delay(1);
     // send the actual message
     modbus->serial->write(set_speed_msg, sizeof(set_speed_msg));
-    // wait a calculated time for the data to be sent 
+    // wait a calculated time for the data to be sent
     modbus->delay((int) ceil(sizeof(set_speed_msg) * modbus->delay_time));
     // disable transmitter
     modbus->dir_output->clear();
@@ -152,7 +153,7 @@ void HuanyangSpindleControl::set_speed(int target_rpm)
 
 }
 
-void HuanyangSpindleControl::report_speed() 
+void HuanyangSpindleControl::report_speed()
 {
     // clear RX buffer before start
     while(modbus->serial->readable()){
@@ -171,7 +172,7 @@ void HuanyangSpindleControl::report_speed()
     modbus->delay(1);
     // send the actual message
     modbus->serial->write(get_speed_msg, sizeof(get_speed_msg));
-    // wait a calculated time for the data to be sent 
+    // wait a calculated time for the data to be sent
     modbus->delay((int) ceil(sizeof(get_speed_msg) * modbus->delay_time));
     // disable transmitter
     modbus->dir_output->clear();
@@ -182,7 +183,7 @@ void HuanyangSpindleControl::report_speed()
     modbus->delay((int) ceil(8 * modbus->delay_time));
     // prepare an array for the answer
     char speed[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-   
+
     // read the answer into the buffer
     for(int i=0; i<8; i++) {
         speed[i] = modbus->serial->getc();

--- a/src/modules/tools/spindle/SpindleControl.cpp
+++ b/src/modules/tools/spindle/SpindleControl.cpp
@@ -11,11 +11,11 @@
 #include "Conveyor.h"
 #include "SpindleControl.h"
 
-void SpindleControl::on_gcode_received(void *argument) 
+void SpindleControl::on_gcode_received(void *argument)
 {
-    
+
     Gcode *gcode = static_cast<Gcode *>(argument);
-        
+
     if (gcode->has_m)
     {
         if (gcode->m == 957)
@@ -35,16 +35,16 @@ void SpindleControl::on_gcode_received(void *argument)
                 set_d_term( gcode->get_value('D') );
             // report PID settings
             report_settings();
-          
+
         }
-        else if (gcode->m == 3) 
+        else if (gcode->m == 3)
         {
             THECONVEYOR->wait_for_idle();
             // M3: Spindle on
             if(!spindle_on) {
                 turn_on();
             }
-            
+
             // M3 with S value provided: set speed
             if (gcode->has_letter('S'))
             {
@@ -67,6 +67,7 @@ void SpindleControl::on_halt(void *argument)
 {
     if (argument == nullptr) {
         if(spindle_on) {
+            // This is dangerous as turn_off calls on_delay in some instances
             turn_off();
         }
     }

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -386,6 +386,7 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
             if(!before_probe.empty()) {
                 Gcode gc(before_probe, &(StreamOutput::NullStream));
                 THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
+                THEKERNEL->conveyor->wait_for_idle();
             }
 
             THEROBOT->disable_segmentation= true;

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -393,7 +393,12 @@ bool CartGridStrategy::handleGcode(Gcode *gcode)
             if(!doProbe(gcode)) {
                 gcode->stream->printf("Probe failed to complete, check the initial probe height and/or initial_height settings\n");
             } else {
-                gcode->stream->printf("Probe completed. Enter M374 to save this grid\n");
+                gcode->stream->printf("Probe completed.");
+                if(!only_by_two_corners) {
+                    gcode->stream->printf(" Enter M374 to save this grid\n");
+                }else{
+                    gcode->stream->printf("\n");
+                }
             }
             THEROBOT->disable_segmentation= false;
 

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -528,7 +528,6 @@ void ZProbe::coordinated_move(float x, float y, float z, float feedrate, bool re
     THEKERNEL->call_event(ON_CONSOLE_LINE_RECEIVED, &message );
     THEKERNEL->conveyor->wait_for_idle();
     THEROBOT->pop_state();
-
 }
 
 // issue home command
@@ -536,5 +535,4 @@ void ZProbe::home()
 {
     Gcode gc(THEKERNEL->is_grbl_mode() ? "G28.2" : "G28", &(StreamOutput::NullStream));
     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
-    THEKERNEL->conveyor->wait_for_idle();
 }

--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -536,4 +536,5 @@ void ZProbe::home()
 {
     Gcode gc(THEKERNEL->is_grbl_mode() ? "G28.2" : "G28", &(StreamOutput::NullStream));
     THEKERNEL->call_event(ON_GCODE_RECEIVED, &gc);
+    THEKERNEL->conveyor->wait_for_idle();
 }

--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.cpp
@@ -223,7 +223,7 @@ void MotorDriverControl::on_idle(void *argument)
 void MotorDriverControl::on_halt(void *argument)
 {
     if(argument == nullptr) {
-        // we are being safe here and makign sure this gets called in on_idle not when on_halt is called
+        // we are being safe here and making sure this gets called in on_idle not when on_halt is called
         on_enable(nullptr);
     }
 }

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -383,7 +383,10 @@ void Player::abort_command( string parameters, StreamOutput *stream )
     if(parameters.empty()) {
         // clear out the block queue, will wait until queue is empty
         // MUST be called in on_main_loop to make sure there are no blocked main loops waiting to put something on the queue
-        THEKERNEL->conveyor->flush_queue();
+        THECONVEYOR->flush_queue();
+
+        // now wait until the block queue has been flushed and motors have stopped
+        THECONVEYOR->wait_for_idle(true);
 
         // now the position will think it is at the last received pos, so we need to do FK to get the actuator position and reset the current position
         THEROBOT->reset_position_from_current_actuator_position();

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -402,6 +402,7 @@ void Player::on_main_loop(void *argument)
     if(abort_flag) {
         abort_flag= false;
         abort_command("1", &(StreamOutput::NullStream));
+        return;
     }
 
     if(suspended && suspend_loops > 0) {

--- a/src/modules/utils/player/Player.h
+++ b/src/modules/utils/player/Player.h
@@ -61,6 +61,7 @@ class Player : public Module {
             bool was_playing_file:1;
             bool leave_heaters_on:1;
             bool override_leave_heaters_on:1;
+            bool abort_flag:1;
             uint8_t suspend_loops:4;
         };
 };


### PR DESCRIPTION
issue #1463 identified several bugs in both the way hard limits were detected and in recursive calls to on_idle caused by on_halt calls from on_idle.

This PR attempts to fix these issues.
1. Hard limits are now checked in the same timer as endstops for homing.
2. on_halt is flagged in the timer ISR and executed in the on_idle loop.
3. limits are not released now until all limits show clear.
4. fixed Player module which was calling abort in on_idle, now defers to main_loop.
5. cleaned up the way flush is handled in Conveyor so it does not wait.

Flagged errors in Spindle module that will need to be fixed as it calls a delay() that is ultimately called from on_halt().

The first issue though is not an issue but is by design, that is if you release HALT state with $X (or M999) the hard limits are disabled until they are all released. The reason for this is to allow the operator to jog off the hard limit (with care). 
At the moment I see no easy way to only allow movement away from a hard stop (which would be the preferred solution). However I think this can be emulated by also enabling Soft endstops, and setting them to ignor emoves that would violate the softendstop limit.