### PR TITLE
player should not send a line with \n in it

### DIFF
--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -427,7 +427,11 @@ void Player::on_main_loop(void *argument)
                     continue;
                 }
                 if(len == 1) continue; // empty line
-
+                if(buf[len - 2] == '\r') {
+                    // \r\n terminated ignore \r
+                    len -=1;
+                    if(len == 1) continue; // empty line
+                }
                 if(this->current_stream != nullptr) {
                     this->current_stream->printf("%s", buf);
                 }

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -433,7 +433,7 @@ void Player::on_main_loop(void *argument)
                 }
 
                 struct SerialMessage message;
-                message.message = buf;
+                message.message.assign(buf, len-1); // we do not want to include the \n
                 message.stream = this->current_stream == nullptr ? &(StreamOutput::NullStream) : this->current_stream;
 
                 // waits for the queue to have enough room


### PR DESCRIPTION
Currently the \n is sent at the end of the line to modules, this may only be an issue if there are lowercase console commands in the file.
Also handle files with \r\n line termination.