### PR TITLE
Proper G92 offset for ABC axes. M114.x reports all axes. Allows setti…

### DIFF
--- a/src/modules/robot/Robot.h
+++ b/src/modules/robot/Robot.h
@@ -120,7 +120,7 @@ class Robot : public Module {
 
         std::array<wcs_t, MAX_WCS> wcs_offsets; // these are persistent once saved with M500
         uint8_t current_wcs{0}; // 0 means G54 is enabled this is persistent once saved with M500
-        wcs_t g92_offset;
+        float g92_offset[k_max_actuators];
         wcs_t tool_offset; // used for multiple extruders, sets the tool offset for the current extruder applied first
         std::tuple<float, float, float, uint8_t> last_probe_position{0,0,0,0};
 


### PR DESCRIPTION
# Description

The G92 offset is stored for all axes, i.e. also for ABC. 

Based on this, M114.x can now report all axes i.e. including ABC. 

Allows setting the G92 offset, while a move is still pending. 

# Justification

G92 offsets are currently only stored for the XYZ axes. G92 on ABC are implemented by resetting the `machine_position` along with the actuator position `current_position_steps`. This is not correct, if a move is still pending, as the actuator `current_position_steps` is still being updated. 

Some M114 commands only report XYZ axes. For true 6-axis operation, we need the ABC axes reported too. Trying to implement this, the shortcoming of missing G92 offsets for ABC was revealed. If G92 is issued during a pending move, M114.1 cannot report ABC coordinates correctly. 

# Use Case

In OpenPnP we have a rotating nozzle. For optimization purposes, the nozzle will always rotate the shorter way around to a target angle. Example: if it is currently at 350° and we  want it to go to 30°, it will _not_ rotate the long way around by -320° but the short way by +40° to 390° which is the same as 30°. 

In order to avoid winding up the angle to unreadable values, we reset the angle to a modulo 360° range using G92 (more specifically to the -180° ... 180° range).

The G92 command is issued immediately after the optimized move has been commanded, e.g. after G1 C390, there will be a G92 C30. For best performance, no M400 still-stand is acceptable to do this. 

At the same time, OpenPnP needs M114.1 real-time coordinate reporting. Currently, only XYZ are reported. In order to report all axes, i.e. including ABC, we need proper G92 offsets. The current implementation of just resetting  `current_position_steps` to the G92 axis reset value is incorrect, because the move may still be pending i.e. it has not reached the milestone coordinate yet, therefore `current_position_steps` will be changed after the G92 and incur an offset. Subsequent M114.1 reports will be wrong. 

# Testing

The changes have been tested on a controller both by hand coding G-code and by using OpenPnP with the described features.
