### PR TITLE
Software SPI support

### DIFF
--- a/ConfigSamples/Snippets/motor_driver_control.config
+++ b/ConfigSamples/Snippets/motor_driver_control.config
@@ -1,0 +1,10 @@
+## Motor Driver Control SPI
+motor_driver_control.alpha.enable	               true		      # Whether to activate the SPI motor driver module.
+motor_driver_control.alpha.axis		               X			  # Motor driver axis designation [XYZABC]
+motor_driver_control.alpha.chip                    TMC2660		  # Motor driver chip name.
+motor_driver_control.alpha.spi_channel		       0			  # SPI bus 0 or 1 for hardware SPI. Use -1 for Software SPI and specify mosi, miso, and sclk pins
+motor_driver_control.alpha.spi_cs_pin	           1.10		      # SPI SSEL pin.
+motor_driver_control.alpha.spi_frequency           500000		  # SPI SCLK frequency.
+#motor_driver_control.alpha.spi_mosi_pin            1.17           # SPI MOSI pin.
+#motor_driver_control.alpha.spi_miso_pin            0.5            # SPI MISO pin.
+#motor_driver_control.alpha.spi_sclk_pin            0.4            # SPI SCLK pin.

--- a/mbed/src/cpp/SWSPI.cpp
+++ b/mbed/src/cpp/SWSPI.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
  
-#include <mbed.h>
+#include "mbed.h"
 #include "SWSPI.h"
  
 SWSPI::SWSPI(PinName mosi_pin, PinName miso_pin, PinName sclk_pin)

--- a/mbed/src/cpp/SWSPI.cpp
+++ b/mbed/src/cpp/SWSPI.cpp
@@ -1,0 +1,85 @@
+/* SWSPI, Software SPI library
+ * Copyright (c) 2012-2014, David R. Van Wagner, http://techwithdave.blogspot.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+ 
+#include <mbed.h>
+#include "SWSPI.h"
+ 
+SWSPI::SWSPI(PinName mosi_pin, PinName miso_pin, PinName sclk_pin)
+{
+    mosi = new DigitalOut(mosi_pin);
+    miso = new DigitalIn(miso_pin);
+    sclk = new DigitalOut(sclk_pin);
+    format(8);
+    frequency();
+}
+ 
+SWSPI::~SWSPI()
+{
+    delete mosi;
+    delete miso;
+    delete sclk;
+}
+ 
+void SWSPI::format(int bits, int mode)
+{
+    this->bits = bits;
+    this->mode = mode;
+    polarity = (mode >> 1) & 1;
+    phase = mode & 1;
+    sclk->write(polarity);
+}
+ 
+void SWSPI::frequency(int hz)
+{
+    this->freq = hz;
+}
+ 
+int SWSPI::write(int value)
+{
+    int read = 0;
+    for (int bit = bits-1; bit >= 0; --bit)
+    {
+        mosi->write(((value >> bit) & 0x01) != 0);
+ 
+        if (phase == 0)
+        {
+            if (miso->read())
+                read |= (1 << bit);
+        }
+ 
+        sclk->write(!polarity);
+ 
+        wait(1.0/freq/2);
+ 
+        if (phase == 1)
+        {
+            if (miso->read())
+                read |= (1 << bit);
+        }
+ 
+        sclk->write(polarity);
+ 
+        wait(1.0/freq/2);
+    }
+    
+    return read;
+}

--- a/mbed/src/cpp/SWSPI.h
+++ b/mbed/src/cpp/SWSPI.h
@@ -1,0 +1,95 @@
+/* SWSPI, Software SPI library
+ * Copyright (c) 2012-2014, David R. Van Wagner, http://techwithdave.blogspot.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+ 
+#ifndef SWSPI_H
+#define SWSPI_H
+ 
+/** A software implemented SPI that can use any digital pins
+ *
+ * Useful when don't want to share a single SPI hardware among attached devices
+ * or when pinout doesn't match exactly to the target's SPI pins
+ *
+ * @code
+ * #include "mbed.h"
+ * #include "SWSPI.h"
+ * 
+ * SWSPI spi(p5, p6, p7); // mosi, miso, sclk
+ * 
+ * int main() 
+ * {
+ *     DigitalOut cs(p8);
+ *     spi.format(8, 0);
+ *     spi.frequency(10000000);
+ *     cs.write(0);
+ *     spi.write(0x9f);
+ *     int jedecid = (spi.write(0) << 16) | (spi.write(0) << 8) | spi.write(0);
+ *     cs.write(1);
+ * }
+ * @endcode
+ */
+class SWSPI
+{
+private:
+    DigitalOut* mosi;
+    DigitalIn* miso;
+    DigitalOut* sclk;
+    int port;
+    int bits;
+    int mode;
+    int polarity; // idle clock value
+    int phase; // 0=sample on leading (first) clock edge, 1=trailing (second)
+    int freq;
+    
+public:
+    /** Create SWSPI object
+     *
+     *  @param mosi_pin
+     *  @param miso_pin
+     *  @param sclk_pin
+     */
+    SWSPI(PinName mosi_pin, PinName miso_pin, PinName sclk_pin);
+    
+    /** Destructor */
+    ~SWSPI();
+    
+    /** Specify SPI format
+     *
+     *  @param bits  8 or 16 are typical values
+     *  @param mode  0, 1, 2, or 3 phase (bit1) and idle clock (bit0)
+     */
+    void format(int bits, int mode = 0);
+    
+    /** Specify SPI clock frequency
+     *
+     *  @param hz  frequency (optional, defaults to 10000000)
+     */
+    void frequency(int hz = 10000000);
+    
+    /** Write data and read result
+     *
+     *  @param value  data to write (see format for bit size)
+     *  returns value read from device
+     */
+    int write(int value);
+};
+ 
+#endif // SWSPI_H

--- a/src/modules/utils/motordrivercontrol/MotorDriverControl.h
+++ b/src/modules/utils/motordrivercontrol/MotorDriverControl.h
@@ -13,6 +13,7 @@ class DRV8711DRV;
 class TMC26X;
 class StreamOutput;
 class Gcode;
+class SWSPI;
 
 class MotorDriverControl : public Module {
     public:
@@ -40,7 +41,11 @@ class MotorDriverControl : public Module {
         int sendSPI(uint8_t *b, int cnt, uint8_t *r);
 
         Pin spi_cs_pin;
-        mbed::SPI *spi;
+        union {
+            mbed::SPI *spi;
+            SWSPI *swspi;
+        };
+        int spi_channel;
 
         enum CHIP_TYPE {
             DRV8711,


### PR DESCRIPTION
Pulling in the de facto software SPI implementation for mbed by David Van Wagner. This allows spi based communication for boards without proper hardware SPI breakout, as well as general functionality improvement for boards that have hardware SPI breakout. Software SPI support is specifically added to the MotorDriverControl module in this pr. The SWSPI pointer is unioned with the existing SPI pointer and the spi_channel is used to indicate the usage of either hardware of software implementations. In this case -1 is used to indicate software spi since it correlates with no hardware spi bank. To use software spi, mosi miso and sclk pins must be specified, and will be ignored in the case of hardware spi.
No changes to the existing hardware spi functionality. Config snippet included for convenience, example pins based off of the SKR v1.4 pro implementation.

I've been using software spi without any issue for the last year or so on both a SKR v1.3 and later a SKR v1.4 pro. Both loaded with 5 tmc stepper drivers. Reads and writes have shown no issues.