### PR TITLE
Trigger tcp data send after handling command from command queue

### DIFF
--- a/src/libs/Network/uip/Network.h
+++ b/src/libs/Network/uip/Network.h
@@ -46,6 +46,7 @@ private:
     uint8_t ipaddr[4];
     uint8_t ipmask[4];
     uint8_t ipgw[4];
+    bool flush_network_data;
 };
 
 #endif


### PR DESCRIPTION
Quick and (semi) dirty fix to avoid 500 ms delay when waiting for response from telnet server. In my case this greatly improves moving in small steps, when feedback (`M400`) is used. The 500 ms issue has been noted before #1341

Tested out on my setup. Also watched traffic on wireshark