### PR TITLE
Add SWSPI support  for RRDGLCD on SKR 1.3/1.4

### DIFF
--- a/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.h
+++ b/src/modules/utils/panel/panels/rrdglcd/RrdGlcd.h
@@ -14,9 +14,12 @@
  */
 
 #include <mbed.h>
+#include "SWSPI.h"
 #include "libs/Kernel.h"
 #include "libs/utils.h"
 #include <libs/Pin.h>
+
+class SWSPI;
 
 
 class RrdGlcd {
@@ -54,8 +57,12 @@ public:
     // void setCursorPX(int x, int y);
 
 private:
+    bool sw_spi;
     Pin cs;
-    mbed::SPI* spi;
+    union {
+        mbed::SPI *spi;
+        SWSPI *swspi;
+    };
     void renderChar(uint8_t *fb, char c, int ox, int oy);
     void displayChar(int row, int column,char inpChr);
 

--- a/src/modules/utils/panel/panels/rrdglcd/SWSPI.cpp
+++ b/src/modules/utils/panel/panels/rrdglcd/SWSPI.cpp
@@ -1,0 +1,85 @@
+/* SWSPI, Software SPI library
+ * Copyright (c) 2012-2014, David R. Van Wagner, http://techwithdave.blogspot.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "mbed.h"
+#include "SWSPI.h"
+
+SWSPI::SWSPI(PinName mosi_pin, PinName miso_pin, PinName sclk_pin)
+    : mosi(mosi_pin),
+      miso(NULL),
+      sclk(sclk_pin)
+{
+    if (miso_pin!= NC)
+        miso = new DigitalIn(miso_pin);
+    format(8);
+    frequency();
+}
+
+SWSPI::~SWSPI()
+{
+    delete miso;
+}
+
+void SWSPI::format(int bits, int mode)
+{
+    this->bits = bits;
+    polarity = (mode >> 1) & 1;
+    phase = mode & 1;
+    sclk.write(polarity);
+}
+
+void SWSPI::frequency(int hz)
+{
+    // TODO: need wait_ns taking int
+    this->delay_us = 500000/hz;
+}
+
+int SWSPI::write(int value)
+{
+    int read = 0;
+    for (unsigned bit = 1 << (bits-1); bit; bit >>= 1)
+    {
+        mosi.write((value & bit) != 0);
+
+        if (phase == 0)
+        {
+            if (miso && miso->read())
+                read |= bit;
+        }
+
+        sclk.write(!polarity);
+
+        if (delay_us) wait_us(delay_us);
+
+        if (phase == 1)
+        {
+            if (miso && miso->read())
+                read |= bit;
+        }
+
+        sclk.write(polarity);
+
+        if (delay_us) wait_us(delay_us);
+    }
+    
+    return read;
+}

--- a/src/modules/utils/panel/panels/rrdglcd/SWSPI.h
+++ b/src/modules/utils/panel/panels/rrdglcd/SWSPI.h
@@ -1,0 +1,93 @@
+/* SWSPI, Software SPI library
+ * Copyright (c) 2012-2014, David R. Van Wagner, http://techwithdave.blogspot.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef SWSPI_H
+#define SWSPI_H
+
+/** A software implemented SPI that can use any digital pins
+ *
+ * Useful when don't want to share a single SPI hardware among attached devices
+ * or when pinout doesn't match exactly to the target's SPI pins
+ *
+ * @code
+ * #include "mbed.h"
+ * #include "SWSPI.h"
+ * 
+ * SWSPI spi(p5, p6, p7); // mosi, miso, sclk
+ * 
+ * int main() 
+ * {
+ *     DigitalOut cs(p8);
+ *     spi.format(8, 0);
+ *     spi.frequency(10000000);
+ *     cs.write(0);
+ *     spi.write(0x9f);
+ *     int jedecid = (spi.write(0) << 16) | (spi.write(0) << 8) | spi.write(0);
+ *     cs.write(1);
+ * }
+ * @endcode
+ */
+class SWSPI
+{
+private:
+    DigitalOut mosi;
+    DigitalIn* miso;
+    DigitalOut sclk;
+    int8_t bits;
+    int8_t polarity; // idle clock value
+    int8_t phase; // 0=sample on leading (first) clock edge, 1=trailing (second)
+    unsigned delay_us;
+    
+public:
+    /** Create SWSPI object
+     *
+     *  @param mosi_pin
+     *  @param miso_pin can be NC
+     *  @param sclk_pin
+     */
+    SWSPI(PinName mosi_pin, PinName miso_pin, PinName sclk_pin);
+    
+    /** Destructor */
+    ~SWSPI();
+    
+    /** Specify SPI format
+     *
+     *  @param bits  8 or 16 are typical values
+     *  @param mode  0, 1, 2, or 3 phase (bit1) and idle clock (bit0)
+     */
+    void format(int bits, int mode = 0);
+    
+    /** Specify SPI clock frequency
+     *
+     *  @param hz  frequency (optional, defaults to 10000000)
+     */
+    void frequency(int hz = 10000000);
+    
+    /** Write data and read result
+     *
+     *  @param value  data to write (see format for bit size)
+     *  returns value read from device
+     */
+    int write(int value);
+};
+
+#endif // SWSPI_H


### PR DESCRIPTION
This pull request is to add a software spi support for boards where LCD is wired to general IO pins. 

Heavily tested on BTT SKR 1.3/1.4 with Reprap Discount Graphic LCD controler. Pinout reviewed with provided schematics : https://github.com/bigtreetech/BIGTREETECH-SKR-V1.3/blob/master/BTT%20SKR%20V1.4/Hardware/BTT%20SKR%20V1.4-SCH.pdf

SWSPI library is based on "SWSPI.cpp/h" ,  Ella Robotics fork  ( https://os.mbed.com/teams/ELLA-Robotics-Inc/code/SWSPI/ ) of Dave Van Wagner job ( https://os.mbed.com/users/davervw/code/SWSPI/ ).

For software Spi, just set channel to -1 :
```
############################################
# For Software SPI 
panel.spi_channel                    -1      # Software spi mosi = P1_18; miso = P1_21; sclk = P1_20;
panel.spi_cs_pin                   1.19      # CS on SKR 1.3/1.4
panel.spi_frequency              200000      # Needs to reduce spi frequency for emulated rrdglcd
                                             # default : 1 000 000 Hz

panel.encoder_a_pin                3.25!^    # Encoder pin         ; GLCD EXP2 Pin 3
panel.encoder_b_pin                3.26!^    # Encoder pin         ; GLCD EXP2 Pin 5
panel.click_button_pin             0.28!^    # Click button        ; GLCD EXP1 Pin 2
panel.buzz_pin                     1.30      # Pin for buzzer      ; GLCD EXP1 Pin 1
#panel.back_button_pin             0.28!^    # Back button         ; GLCD EXP2 Pin 8
panel.encoder_resolution              4
panel.external_sd                  true      # set to true if there is an extrernal sdcard on the panel
panel.external_sd.spi_channel         0      # On SKR 1.4, wired to spi0 (free).
panel.external_sd.spi_cs_pin       0.16      # set spi chip select for the sdcard (or any spare pin)
panel.external_sd.sdcd_pin         1.31!^    # sd detect signal (set to nc if no sdcard detect) (or any spare pin)
panel.menu_offset                     1      # Some panels will need 1 here
panel.alpha_jog_feedrate           6000      # X jogging feedrate in mm/min
panel.beta_jog_feedrate            6000      # Y jogging feedrate in mm/min
panel.gamma_jog_feedrate           3000      # Z jogging feedrate in mm/min
panel.hotend_temperature            185      # Temp to set hotend when preheat is selected
panel.bed_temperature                60      # Temp to set bed when preheat is selected
```

This is my first contribution on Smoothieware. I apologize for mistakes.
