### PR TITLE
Enhance ThreePointStrategy to correct skew from non-perpendicular axes

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -280,6 +280,7 @@ zprobe.probe_height                          5               # How much above be
 #leveling-strategy.three-point-leveling.tolerance      0.03        # the probe tolerance in mm, anything less that this will be ignored, default is 0.03mm
 #leveling-strategy.three-point-leveling.probe_offsets  0,0,0       # the probe offsets from nozzle, must be x,y,z, default is no offset
 #leveling-strategy.three-point-leveling.save_plane     false       # set to true to allow the bed plane to be saved with M500 default is false
+#leveling-strategy.three-point-leveling.correct_skew   false       # set to true to correct skew caused by unlevel bed, rather than only correcting z offset
 
 ## Panel
 # See http://smoothieware.org/panel

--- a/src/modules/tools/zprobe/Plane3D.cpp
+++ b/src/modules/tools/zprobe/Plane3D.cpp
@@ -1,5 +1,7 @@
 #include "Plane3D.h"
 
+#include "math.h"
+
 Plane3D::Plane3D(const Vector3 &v1, const Vector3 &v2, const Vector3 &v3)
 {
     // get the normal of the plane
@@ -45,3 +47,32 @@ Vector3 Plane3D::getNormal() const
 {
     return normal;
 }
+
+Vector3 Plane3D::getUpwardsNormal() const
+{
+    if (normal.data()[2] >=0) {
+        return normal;
+    }
+    return normal.mul(-1);
+}
+
+float Plane3D::findRayIntersection(Vector3 rayOrigin, Vector3 rayDirection)
+{
+    // ray equation: P = O + tD (starting at origin O and travelling in direction D)
+    // plane equation: (P - P0).N = 0  (passing through P0 and with normal N)
+    // => (O + tD - P0).N = 0
+    // => t = (N.(P0 - O)) / (N.D)
+
+    float denomenator = this->normal.dot(rayDirection.unit());
+    if (denomenator == 0) {
+        return NAN; // No intersection.
+    }
+
+    Vector3 arbitraryPointOnPlane = Vector3(0, 0, this->getz(0, 0));
+    float numerator = this->normal.dot(arbitraryPointOnPlane.sub(rayOrigin));
+    float distance = numerator / denomenator;
+    return distance;
+}
+
+
+

--- a/src/modules/tools/zprobe/Plane3D.cpp
+++ b/src/modules/tools/zprobe/Plane3D.cpp
@@ -50,7 +50,7 @@ Vector3 Plane3D::getNormal() const
 
 Vector3 Plane3D::getUpwardsNormal() const
 {
-    if (normal.data()[2] >=0) {
+    if (normal.data()[2] >= 0) {
         return normal;
     }
     return normal.mul(-1);

--- a/src/modules/tools/zprobe/Plane3D.h
+++ b/src/modules/tools/zprobe/Plane3D.h
@@ -18,6 +18,17 @@ public:
     float getz(float x, float y);
     Vector3 getNormal() const;
     void encode(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d);
+
+    // Like getNormal(), but guaranteed to return a normal pointing in the direction of positive Z, i.e. upwards
+    Vector3 getUpwardsNormal() const;
+
+    /**
+     * Checks for intersection of a ray with the plane.
+     * @param rayOrigin Starting point of the ray
+     * @param rayDirection Direction vector in which to cast the ray
+     * @return The distance along the ray at which the intersection was found, or NAN if the ray does not intersect the plane.
+     */
+    float findRayIntersection(Vector3 rayOrigin, Vector3 rayDirection);
 };
 
 #endif

--- a/src/modules/tools/zprobe/ThreePointStrategy.cpp
+++ b/src/modules/tools/zprobe/ThreePointStrategy.cpp
@@ -366,9 +366,9 @@ void ThreePointStrategy::setAdjustFunction(bool on)
         THEROBOT->compensationTransform= [this](float *target, bool inverse) {
             Vector3 result;
             if (inverse) {
-                result = this->correctPoint(target[0], target[1], target[2]);
-            } else {
                 result = this->uncorrectPoint(target[0], target[1], target[2]);
+            } else {
+                result = this->correctPoint(target[0], target[1], target[2]);
             }
             target[0] = result.data()[0];
             target[1] = result.data()[1];
@@ -409,9 +409,6 @@ Vector3 ThreePointStrategy::uncorrectPoint(float x, float y, float z)
     Vector3 intersectionPoint = rayDirection.mul(intersectionDistance).add(rayOrigin);
     return Vector3(intersectionPoint.data()[0], intersectionPoint.data()[1], intersectionDistance);
 }
-
-
-
 
 // parse a "X,Y" string return x,y
 std::tuple<float, float> ThreePointStrategy::parseXY(const char *str)

--- a/src/modules/tools/zprobe/ThreePointStrategy.h
+++ b/src/modules/tools/zprobe/ThreePointStrategy.h
@@ -36,11 +36,12 @@ private:
     struct {
         bool home:1;
         bool save:1;
+        bool correct_skew:1;
     };
     float tolerance;
 
-    Vector3 correctPoint(float x, float y, float z);
-    Vector3 uncorrectPoint(float x, float y, float z);
+    void legacyCompensationTransform(float *target, bool inverse);
+    void skewCorrectingCompensationTransform(float *target, bool inverse);
 };
 
 #endif

--- a/src/modules/tools/zprobe/ThreePointStrategy.h
+++ b/src/modules/tools/zprobe/ThreePointStrategy.h
@@ -3,8 +3,10 @@
 
 #include "LevelingStrategy.h"
 
+#include "Vector3.h"
 #include <string.h>
 #include <tuple>
+
 
 #define three_point_leveling_strategy_checksum CHECKSUM("three-point-leveling")
 
@@ -36,6 +38,9 @@ private:
         bool save:1;
     };
     float tolerance;
+
+    Vector3 correctPoint(float x, float y, float z);
+    Vector3 uncorrectPoint(float x, float y, float z);
 };
 
 #endif


### PR DESCRIPTION
I ran into an issue with some 3d-printed gears being skewed because the print bed on my machine isn't quite level. Although I used the 3-point leveling already, this did not address the skew at all.

The existing implementation of 3-point leveling only shifts the Z coordinate to maintain correct spacing to the bed. If the bed is not perfectly horizontal, then a cuboid printed with 3-point levelling will become a rhomboid.

To address this, I have modified the 3 point strategy to effectively tilt the entire object such that the base is parallel with the bed plane. This is done by:
1. Taking the input point, saving the supplied Z coordinate (height) for later
2. Projecting this point onto the bed plane vertically (i.e. taking the x and y coordinates of the input point and finding the z value on the plane)
3. Using this projected point as the origin for casting a ray up out of the bed, in the direction of the bed plane's normal vector, and taking the point at a distance along this ray equal to the input height saved in step 1. This point is the corrected coordinate.

Here is a quick video clip showing the impact of this change on the gear I was printing: https://www.youtube.com/watch?v=f3tT3_7rRfM&feature=youtu.be