### PR TITLE
Update one of the steps per millimeter examples to include floating p…

### DIFF
--- a/ConfigSamples/Smoothieboard/config
+++ b/ConfigSamples/Smoothieboard/config
@@ -14,7 +14,7 @@ mm_max_arc_error                             0.01             # The maximum erro
 # Arm solution configuration : Cartesian robot. Translates mm positions into stepper positions
 # See http://smoothieware.org/stepper-motors
 alpha_steps_per_mm                           80               # Steps per mm for alpha ( X ) stepper
-beta_steps_per_mm                            80               # Steps per mm for beta ( Y ) stepper
+beta_steps_per_mm                            333.3333         # Steps per mm for beta ( Y ) stepper
 gamma_steps_per_mm                           1600             # Steps per mm for gamma ( Z ) stepper
 
 # Planner module configuration : Look-ahead and acceleration configuration


### PR DESCRIPTION
A user asked in the forums if the numbers were allowed to have floating points/digits like this.
I think adding this to the example configuration file would be a convenient/easy way to make it obvious that it is ok to do this.
Other values in the config do have floating points, so I expect their question is specifically about the steps per millimeters, not configuration options in general.
I don't think there is any downsides to changing this value this way, but comments/ideas/objections are welcome.

I'm using Github's "edit in place" web interface feature for this PR, so I'm not seeing the normal template for PRs, which is a bit odd, I'd expect/would like even edits made this way to display the template, maybe something to look into... [Edit: I'm at the next steps, and I see the template now, so there is no issue here]
