### PR TITLE
Update PT1000.cpp

### DIFF
--- a/src/modules/tools/temperaturecontrol/PT1000.cpp
+++ b/src/modules/tools/temperaturecontrol/PT1000.cpp
@@ -57,8 +57,8 @@ float PT1000::adc_value_to_temperature(uint32_t adc_value)
         return infinityf();
 
     // polynomial approximation for PT1000, using 4.7kOhm and 1kOhm (PT1000) 3.3V.
-
-    float x = (adc_value) / ((float)max_adc_value);
+    
+    float x = (adc_value / (float)max_adc_value);
     float x2 = (x * x);
     float x3 = (x2 * x);
     float x4 = (x3 * x);


### PR DESCRIPTION
# FIX: PT1000 Sensor Reads -1 for all temperatures.

Tested new PT1000 module from Pull Request #1503  in Smoothie Edge (thanks lukrow80) running: 
#=============== FW ============================
Version:	edge-fdb15bb
Date:		16/02/2021
#===============================================

Temperature readout was -1 for all temperatures and allowed the heater cartridge to heat infinitely if not checked by the user. Correct Config was checked, and hardware confirmed working with NTC100K and relevant config.

Changes to the PT1000.cpp implementation (brackets in formula) were made and then the module was tested and confirmed working. Temperature validated (using external k-type thermocouple).
