### PR TITLE
Add A,B, and C to G92.4

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -632,7 +632,7 @@ void Robot::on_gcode_received(void *argument)
                 }
 
                 #if MAX_ROBOT_ACTUATORS > 3
-                if(gcode->subcode == 0  && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
+                if(gcode->subcode == 0 && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
                     // reset the E position, legacy for 3d Printers to be reprap compatible
                     // find the selected extruder
                     int selected_extruder= get_active_extruder();

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -632,7 +632,7 @@ void Robot::on_gcode_received(void *argument)
                 }
 
                 #if MAX_ROBOT_ACTUATORS > 3
-                if(gcode->subcode == 0 && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
+                if((gcode->subcode == 0 || gcode->subcode == 4) && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
                     // reset the E position, legacy for 3d Printers to be reprap compatible
                     // find the selected extruder
                     int selected_extruder= get_active_extruder();
@@ -642,7 +642,7 @@ void Robot::on_gcode_received(void *argument)
                         actuators[selected_extruder]->change_last_milestone(get_e_scale_fnc ? e*get_e_scale_fnc() : e);
                     }
                 }
-                if(gcode->subcode == 0 && gcode->get_num_args() > 0) {
+                if((gcode->subcode == 0 || gcode->subcode == 4) && gcode->get_num_args() > 0) {
                     for (int i = A_AXIS; i < n_motors; i++) {
                         // ABC just need to set machine_position and compensated_machine_position if specified
                         char axis= 'A'+i-3;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -632,7 +632,7 @@ void Robot::on_gcode_received(void *argument)
                 }
 
                 #if MAX_ROBOT_ACTUATORS > 3
-                if((gcode->subcode == 0 || gcode->subcode == 4) && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
+                if(gcode->subcode == 0  && (gcode->has_letter('E') || gcode->get_num_args() == 0)){
                     // reset the E position, legacy for 3d Printers to be reprap compatible
                     // find the selected extruder
                     int selected_extruder= get_active_extruder();


### PR DESCRIPTION
My thinking behind this, is if I have a machine without limit switches that included rotary axis, and I wanted to manually home everything, it would be convenient to do G92.4 X5 Y6 Z2 A90 and do manually homing on all axis including the rotary in one command.

Since A,B, and C don't have WCS anyway, doing a G92 with one of them is really doing something more like a G92.4, but having them included in the G92.4 command would be helpful for those realizing that what they need to do with rotary axis is a manual home, and would think they would need G92.4 for this.