### PR TITLE
Fix Probe when in G20 mode to use coordinates specified in inches.

### DIFF
--- a/src/modules/tools/zprobe/ZProbe.cpp
+++ b/src/modules/tools/zprobe/ZProbe.cpp
@@ -226,7 +226,7 @@ bool ZProbe::run_probe(float& mm, float feedrate, float max_dist, bool reverse)
 // do probe then return to start position
 bool ZProbe::run_probe_return(float& mm, float feedrate, float max_dist, bool reverse)
 {
-    float save_z_pos= THEROBOT->from_millimeters(THEROBOT->get_axis_position(Z_AXIS));
+    float save_z_pos= THEROBOT->get_axis_position(Z_AXIS);
 
     bool ok= run_probe(mm, feedrate, max_dist, reverse);
 
@@ -523,6 +523,7 @@ void ZProbe::coordinated_move(float x, float y, float z, float feedrate, bool re
 
     // send as a command line as may have multiple G codes in it
     THEROBOT->push_state();
+    THEROBOT->inch_mode = false; //turn off inch_mode.  No need to restore it as the pop_state will do that
     struct SerialMessage message;
     message.message = cmd;
     delete [] cmd;


### PR DESCRIPTION
G38.2 - G28.5 used to properly use G20 mode, but when I tried to use the current edge, I found that they now were not in inches anymore when in G20. 

G30 was half in inches, half in millimeters.  G30 F  was using the feedrate in mm, but the coordinates were in inches.  G30 Z would set the new value of Z in inches, however the return was trying to go to the mm return value... but in inch mode.  so what should have been a return to machine coordinate Z-1 would return to Z-25.4  (yea, it crashed my probe) 

This has all been fixed and tested in both G20 and G21

G30 with return is working properly, but for some odd reason, there is a double move on the return.  It returns part of the way, stops, then all the way.  It did this before, and both in G20 and G21.  I can't see where the first retract move is coming from, but it does get to the correct end position.  It's just in 2 moves.